### PR TITLE
Support new `torch-nos==0.1.0` API with support for default kwargs

### DIFF
--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -43,7 +43,7 @@ class Env:
         self._db_name: Optional[str] = None
         self._db_port: Optional[int] = None
         self._store_container: Optional[docker.models.containers.Container] = None
-        self._nos_client: Optional[nos.client.InferenceClient] = None
+        self._nos_client: Optional[nos.client.Client] = None
 
         # logging-related state
         self._logger = logging.getLogger('pixeltable')
@@ -204,7 +204,7 @@ class Env:
 
         self._logger.info('connecting to NOS')
         nos.init(logging_level=logging.DEBUG)
-        self._nos_client = nos.client.InferenceClient()
+        self._nos_client = nos.client.Client()
         self._logger.info('waiting for NOS')
         self._nos_client.WaitForServer()
 
@@ -280,6 +280,6 @@ class Env:
         return self._sa_engine
 
     @property
-    def nos_client(self) -> nos.client.InferenceClient:
+    def nos_client(self) -> nos.client.Client:
         assert self._nos_client is not None
         return self._nos_client

--- a/pixeltable/exec.py
+++ b/pixeltable/exec.py
@@ -661,7 +661,7 @@ class ExprEvalNode(ExecNode):
                             f'Running NOS task {cohort.model_info.task}: '
                             f'batch_size={num_nos_batch_rows} target_res={target_res}')
                         result = Env.get().nos_client.Run(
-                            task=cohort.model_info.task, model_name=cohort.model_info.name, **kwargs)
+                            task=cohort.model_info.task, model_name=cohort.model_info.name, inputs=kwargs)
                         self.ctx.profile.eval_time[fn_call.slot_idx] += time.perf_counter() - start_ts
                         self.ctx.profile.eval_count[fn_call.slot_idx] += num_nos_batch_rows
 

--- a/pixeltable/exec.py
+++ b/pixeltable/exec.py
@@ -436,12 +436,12 @@ class ExprEvalNode(ExecNode):
             nos_calls = [e for e in self.exprs if isinstance(e, exprs.FunctionCall) and e.is_nos_call()]
             assert len(nos_calls) <= 1
             nos_call = nos_calls[0] if len(nos_calls) > 0 else None
-            self.nos_param_names = self.model_info.signature.get_inputs_spec().keys()
+            self.nos_param_names = self.model_info.signature[self.model_info.default_method].get_inputs_spec().keys()
             self.scalar_nos_param_names = []
 
             # try to determine batch_size and img_size
             batch_size = sys.maxsize
-            for pos, (param_name, type_info) in enumerate(self.model_info.signature.get_inputs_spec().items()):
+            for pos, (param_name, type_info) in enumerate(self.model_info.signature[self.model_info.default_method].get_inputs_spec().items()):
                 if isinstance(type_info, list):
                     assert isinstance(type_info[0].base_spec(), nos.common.ImageSpec)
                     # this is a multi-resolution image model
@@ -660,8 +660,7 @@ class ExprEvalNode(ExecNode):
                         _logger.debug(
                             f'Running NOS task {cohort.model_info.task}: '
                             f'batch_size={num_nos_batch_rows} target_res={target_res}')
-                        result = Env.get().nos_client.Run(
-                            task=cohort.model_info.task, model_name=cohort.model_info.name, inputs=kwargs)
+                        result = Env.get().nos_client.Run(cohort.model_info.name, inputs=kwargs, method=cohort.model_info.default_method, shm=True)
                         self.ctx.profile.eval_time[fn_call.slot_idx] += time.perf_counter() - start_ts
                         self.ctx.profile.eval_count[fn_call.slot_idx] += num_nos_batch_rows
 

--- a/pixeltable/exec.py
+++ b/pixeltable/exec.py
@@ -677,7 +677,9 @@ class ExprEvalNode(ExecNode):
                                 result_bboxes.append(bboxes)
                             result['bboxes'] = result_bboxes
 
-                        if len(result) == 1:
+                        if isinstance(result, (list, set, tuple)):
+                            row_results = list(result)
+                        elif isinstance(result, dict) and len(result) == 1:
                             key = list(result.keys())[0]
                             row_results = result[key]
                         else:

--- a/pixeltable/tests/test_nos.py
+++ b/pixeltable/tests/test_nos.py
@@ -52,9 +52,11 @@ class TestNOS:
     @pytest.mark.skip(reason='too slow')
     def test_sd(self, test_client: pt.Client) -> None:
         """Test model that mixes batched with scalar parameters"""
-        t = test_client.create_table('sd_test', [pt.Column('prompt', pt.StringType())])
-        t.insert([['cat on a sofa']])
+        t = test_client.create_table('sd_test', [pt.Column('prompt', pt.StringType()), pt.Column('neg_prompt', pt.StringType())])
+        t.insert([['cat on a sofa', 'low quality']])
         from pixeltable.functions.image_generation import stabilityai_stable_diffusion_2 as sd2
-        t.add_column(pt.Column('img', computed_with=sd2(t.prompt, 1, 512, 512), stored=True))
+        num_images, num_inference_steps, guidance_scale, seed = 1, 50, 7.5, 1
+        height, width = 512, 512
+        t.add_column(pt.Column('img', computed_with=sd2(t.prompt, t.neg_prompt, num_images, num_inference_steps, height, width, seed), stored=True))
         img = t[t.img].show(1)[0, 0]
         assert img.size == (512, 512)

--- a/pixeltable/utils/clip.py
+++ b/pixeltable/utils/clip.py
@@ -14,7 +14,7 @@ def embed_image(img: PIL.Image.Image) -> np.ndarray:
 
 def embed_text(text: str) -> np.ndarray:
     from pixeltable.functions.text_embedding import openai_clip
-    model_info, method = FunctionRegistry.get().get_nos_info(openai_clip)
+    model_info = FunctionRegistry.get().get_nos_info(openai_clip)
     assert model_info.default_method == "encode_text"
     result = Env.get().nos_client.Run(model_info.name, inputs={"texts": [text]}, method=model_info.default_method, shm=True)
     return result['embedding'].squeeze(0)

--- a/pixeltable/utils/clip.py
+++ b/pixeltable/utils/clip.py
@@ -8,11 +8,11 @@ from pixeltable.env import Env
 def embed_image(img: PIL.Image.Image) -> np.ndarray:
     from pixeltable.functions.image_embedding import openai_clip
     model_info = FunctionRegistry.get().get_nos_info(openai_clip)
-    result = Env.get().nos_client.Run(task=model_info.task, model_name=model_info.name, images=[img.resize((224, 224))])
+    result = Env.get().nos_client.Run(task=model_info.task, model_name=model_info.name, inputs={"images": [img.resize((224, 224))]})
     return result['embedding'].squeeze(0)
 
 def embed_text(text: str) -> np.ndarray:
     from pixeltable.functions.text_embedding import openai_clip
     model_info = FunctionRegistry.get().get_nos_info(openai_clip)
-    result = Env.get().nos_client.Run(task=model_info.task, model_name=model_info.name, texts=[text])
+    result = Env.get().nos_client.Run(task=model_info.task, model_name=model_info.name, inputs={"texts": [text]})
     return result['embedding'].squeeze(0)

--- a/pixeltable/utils/clip.py
+++ b/pixeltable/utils/clip.py
@@ -8,11 +8,13 @@ from pixeltable.env import Env
 def embed_image(img: PIL.Image.Image) -> np.ndarray:
     from pixeltable.functions.image_embedding import openai_clip
     model_info = FunctionRegistry.get().get_nos_info(openai_clip)
-    result = Env.get().nos_client.Run(task=model_info.task, model_name=model_info.name, inputs={"images": [img.resize((224, 224))]})
+    assert model_info.default_method == "encode_image"
+    result = Env.get().nos_client.Run(model_info.name, inputs={"images": [img.resize((224, 224))]}, method=model_info.default_method, shm=True)
     return result['embedding'].squeeze(0)
 
 def embed_text(text: str) -> np.ndarray:
     from pixeltable.functions.text_embedding import openai_clip
-    model_info = FunctionRegistry.get().get_nos_info(openai_clip)
-    result = Env.get().nos_client.Run(task=model_info.task, model_name=model_info.name, inputs={"texts": [text]})
+    model_info, method = FunctionRegistry.get().get_nos_info(openai_clip)
+    assert model_info.default_method == "encode_text"
+    result = Env.get().nos_client.Run(model_info.name, inputs={"texts": [text]}, method=model_info.default_method, shm=True)
     return result['embedding'].squeeze(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ docker = "^6.0.1"
 psutil = "^5.9.5"
 sqlalchemy = "^2.0.17"
 sqlalchemy-utils = "^0.41.1"
-autonomi-nos = "^0.0.9"
+torch-nos = "^0.1.0rc1"
 pgvector = "^0.2.1"
 boto3 = {version = "^1.17", optional = true}
 


### PR DESCRIPTION
This PR updates `client.Run()` with the new nos `torch-nos==0.1.0` API
that removes the need for specifying task types. Additionally,
we also introduce an explicit `shm=True` kwarg to `client.Run()` to
enable shared memory. The nos tests have been updated to reflect the
new API as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pixeltable/pixeltable/30)
<!-- Reviewable:end -->
