### PR TITLE
Fix many instances of dot-completion by adding missing imports

### DIFF
--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -9,7 +9,6 @@ import json
 
 import pandas as pd
 import sqlalchemy as sql
-import torch
 
 from .schema_object import SchemaObject
 from .column import Column
@@ -183,6 +182,8 @@ class Table(SchemaObject):
         cat = catalog.Catalog.get()
         del cat.tbls[self._id]
 
+    # TODO Factor this out into a separate module.
+    # The return type is unresolvable, but torch can't be imported since it's an optional dependency.
     def to_pytorch_dataset(self, image_format : str = 'pt') -> 'torch.utils.data.IterableDataset':
         """Return a PyTorch Dataset for this table.
             See DataFrame.to_pytorch_dataset()

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -9,6 +9,7 @@ import json
 
 import pandas as pd
 import sqlalchemy as sql
+import torch
 
 from .schema_object import SchemaObject
 from .column import Column
@@ -16,6 +17,7 @@ from .table_version_path import TableVersionPath
 from .table_version import TableVersion
 from .globals import is_valid_identifier, is_system_column_name
 from pixeltable import exceptions as exc
+import pixeltable
 import pixeltable.type_system as ts
 import pixeltable.catalog as catalog
 import pixeltable.env as env

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -13,6 +13,7 @@ import sqlalchemy.orm as orm
 
 from .globals import UpdateStatus, POS_COLUMN_NAME, is_valid_identifier
 from .column import Column
+import pixeltable
 from pixeltable import exceptions as exc
 from pixeltable.env import Env
 import pixeltable.func as func

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -15,6 +15,7 @@ import sqlalchemy.orm as orm
 from .globals import UpdateStatus, POS_COLUMN_NAME, is_valid_identifier
 from .column import Column
 from .table_version import TableVersion
+import pixeltable
 from pixeltable import exceptions as exc
 from pixeltable.env import Env
 import pixeltable.func as func

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -14,7 +14,6 @@ import hashlib
 import importlib.util
 import logging
 import mimetypes
-import torch
 
 import pixeltable.type_system as ts
 import pixeltable.catalog as catalog
@@ -580,6 +579,8 @@ class DataFrame:
         else:
             return write_coco_dataset(self, dest_path)
 
+    # TODO Factor this out into a separate module.
+    # The return type is unresolvable, but torch can't be imported since it's an optional dependency.
     def to_pytorch_dataset(self, image_format: str = 'pt') -> 'torch.utils.data.IterableDataset':
         """
         Convert the dataframe to a pytorch IterableDataset suitable for parallel loading

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -14,6 +14,7 @@ import hashlib
 import importlib.util
 import logging
 import mimetypes
+import torch
 
 import pixeltable.type_system as ts
 import pixeltable.catalog as catalog

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -12,6 +12,7 @@ import sqlalchemy as sql
 
 from .globals import ComparisonOperator, LogicalOperator, LiteralPythonTypes, ArithmeticOperator
 from .data_row import DataRow
+import pixeltable
 import pixeltable.exceptions as excs
 import pixeltable.catalog as catalog
 import pixeltable.type_system as ts
@@ -396,7 +397,7 @@ class Expr(abc.ABC):
             return ArraySlice(self, index)
         raise excs.Error(f'Type {self.col_type} is not subscriptable')
 
-    def __getattr__(self, name: str) -> Union['ImageMemberAccess', 'JsonPath']:
+    def __getattr__(self, name: str) -> Union['pixeltable.exprs.ImageMemberAccess', 'pixeltable.exprs.JsonPath']:
         """
         ex.: <img col>.rotate(60)
         """
@@ -412,32 +413,32 @@ class Expr(abc.ABC):
         raise TypeError(
             'Pixeltable expressions cannot be used in conjunction with Python boolean operators (and/or/not)')
 
-    def __lt__(self, other: object) -> 'Comparison':
+    def __lt__(self, other: object) -> 'pixeltable.exprs.Comparison':
         return self._make_comparison(ComparisonOperator.LT, other)
 
-    def __le__(self, other: object) -> 'Comparison':
+    def __le__(self, other: object) -> 'pixeltable.exprs.Comparison':
         return self._make_comparison(ComparisonOperator.LE, other)
 
-    def __eq__(self, other: object) -> 'Comparison':
+    def __eq__(self, other: object) -> 'pixeltable.exprs.Comparison':
         if other is None:
             from .is_null import IsNull
             return IsNull(self)
         return self._make_comparison(ComparisonOperator.EQ, other)
 
-    def __ne__(self, other: object) -> 'Comparison':
+    def __ne__(self, other: object) -> 'pixeltable.exprs.Comparison':
         if other is None:
             from .compound_predicate import CompoundPredicate
             from .is_null import IsNull
             return CompoundPredicate(LogicalOperator.NOT, [IsNull(self)])
         return self._make_comparison(ComparisonOperator.NE, other)
 
-    def __gt__(self, other: object) -> 'Comparison':
+    def __gt__(self, other: object) -> 'pixeltable.exprs.Comparison':
         return self._make_comparison(ComparisonOperator.GT, other)
 
-    def __ge__(self, other: object) -> 'Comparison':
+    def __ge__(self, other: object) -> 'pixeltable.exprs.Comparison':
         return self._make_comparison(ComparisonOperator.GE, other)
 
-    def _make_comparison(self, op: ComparisonOperator, other: object) -> 'Comparison':
+    def _make_comparison(self, op: ComparisonOperator, other: object) -> 'pixeltable.exprs.Comparison':
         """
         other: Union[Expr, LiteralPythonTypes]
         """
@@ -450,22 +451,22 @@ class Expr(abc.ABC):
             return Comparison(op, self, Literal(other))  # type: ignore[arg-type]
         raise TypeError(f'Other must be Expr or literal: {type(other)}')
 
-    def __add__(self, other: object) -> 'ArithmeticExpr':
+    def __add__(self, other: object) -> 'pixeltable.exprs.ArithmeticExpr':
         return self._make_arithmetic_expr(ArithmeticOperator.ADD, other)
 
-    def __sub__(self, other: object) -> 'ArithmeticExpr':
+    def __sub__(self, other: object) -> 'pixeltable.exprs.ArithmeticExpr':
         return self._make_arithmetic_expr(ArithmeticOperator.SUB, other)
 
-    def __mul__(self, other: object) -> 'ArithmeticExpr':
+    def __mul__(self, other: object) -> 'pixeltable.exprs.ArithmeticExpr':
         return self._make_arithmetic_expr(ArithmeticOperator.MUL, other)
 
-    def __truediv__(self, other: object) -> 'ArithmeticExpr':
+    def __truediv__(self, other: object) -> 'pixeltable.exprs.ArithmeticExpr':
         return self._make_arithmetic_expr(ArithmeticOperator.DIV, other)
 
-    def __mod__(self, other: object) -> 'ArithmeticExpr':
+    def __mod__(self, other: object) -> 'pixeltable.exprs.ArithmeticExpr':
         return self._make_arithmetic_expr(ArithmeticOperator.MOD, other)
 
-    def _make_arithmetic_expr(self, op: ArithmeticOperator, other: object) -> 'ArithmeticExpr':
+    def _make_arithmetic_expr(self, op: ArithmeticOperator, other: object) -> 'pixeltable.exprs.ArithmeticExpr':
         """
         other: Union[Expr, LiteralPythonTypes]
         """

--- a/pixeltable/exprs/predicate.py
+++ b/pixeltable/exprs/predicate.py
@@ -3,6 +3,7 @@ from typing import Optional, List, Tuple, Callable
 
 from .expr import Expr
 from .globals import LogicalOperator
+import pixeltable
 import pixeltable.type_system as ts
 
 
@@ -21,7 +22,7 @@ class Predicate(Expr):
         else:
             return [], self
 
-    def __and__(self, other: object) -> 'CompoundPredicate':
+    def __and__(self, other: object) -> 'pixeltable.exprs.CompoundPredicate':
         if not isinstance(other, Expr):
             raise TypeError(f'Other needs to be an expression: {type(other)}')
         if not other.col_type.is_bool_type():
@@ -29,7 +30,7 @@ class Predicate(Expr):
         from .compound_predicate import CompoundPredicate
         return CompoundPredicate(LogicalOperator.AND, [self, other])
 
-    def __or__(self, other: object) -> 'CompoundPredicate':
+    def __or__(self, other: object) -> 'pixeltable.exprs.CompoundPredicate':
         if not isinstance(other, Expr):
             raise TypeError(f'Other needs to be an expression: {type(other)}')
         if not other.col_type.is_bool_type():
@@ -37,7 +38,7 @@ class Predicate(Expr):
         from .compound_predicate import CompoundPredicate
         return CompoundPredicate(LogicalOperator.OR, [self, other])
 
-    def __invert__(self) -> 'CompoundPredicate':
+    def __invert__(self) -> 'pixeltable.exprs.CompoundPredicate':
         from .compound_predicate import CompoundPredicate
         return CompoundPredicate(LogicalOperator.NOT, [self])
 

--- a/pixeltable/func/function.py
+++ b/pixeltable/func/function.py
@@ -7,6 +7,7 @@ import importlib
 
 from .function_md import FunctionMd
 from .globals import resolve_symbol
+import pixeltable
 import pixeltable.exceptions as excs
 
 class Function:

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -11,6 +11,7 @@ import urllib.parse
 import av
 import numpy as np
 import PIL.Image
+import pyarrow
 import sqlalchemy as sql
 
 from pixeltable import exceptions as exc

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -11,7 +11,6 @@ import urllib.parse
 import av
 import numpy as np
 import PIL.Image
-import pyarrow
 import sqlalchemy as sql
 
 from pixeltable import exceptions as exc


### PR DESCRIPTION
Fix many instances of dot-completion by adding missing imports (and in some cases, fully qualifying types where a direct import would introduce a circular type reference).