### PR TITLE
Shorthand notation for `ArrayType` instances with wildcard dimensions

### DIFF
--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -587,9 +587,12 @@ class JsonType(ColumnType):
 
 class ArrayType(ColumnType):
     def __init__(
-            self, shape: Tuple[Union[int, None], ...], dtype: ColumnType, nullable: bool = False):
+            self, shape: Union[int, Tuple[Union[int, None], ...]], dtype: ColumnType, nullable: bool = False):
         super().__init__(self.Type.ARRAY, nullable=nullable)
-        self.shape = shape
+        if isinstance(shape, int):
+            self.shape = tuple(None for i in range(0, shape))
+        else:
+            self.shape = shape
         assert dtype.is_int_type() or dtype.is_float_type() or dtype.is_bool_type() or dtype.is_string_type()
         self.dtype = dtype._type
 
@@ -608,7 +611,12 @@ class ArrayType(ColumnType):
         return result
 
     def __str__(self) -> str:
-        return f'{self._type.name.lower()}({self.shape}, dtype={self.dtype.name})'
+        if all(self.shape[n] is None for n in range(0, len(self.shape))):
+            # Display shorthand if all dimensions are unspecified
+            shape_repr = len(self.shape)
+        else:
+            shape_repr = self.shape
+        return f'{self._type.name.lower()}({shape_repr}, dtype={self.dtype.name})'
 
     @classmethod
     def _from_dict(cls, d: Dict) -> ColumnType:


### PR DESCRIPTION
Introduces a new shorthand notation for `ArrayType` instances where every dimension is a wildcard (`None`).

`ArrayType(3, dtype=FloatType())`

is equivalent to

`ArrayType((None, None, None), dtype=FloatType())`

and so forth.

This makes `ArrayType`s easier to define and read, in the very common case where all the dimensions are wildcards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pixeltable/pixeltable/101)
<!-- Reviewable:end -->
