### PR TITLE
Some repo cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and to ensure reproducibility.
 
     On MacOS: follow [these](https://docs.docker.com/desktop/install/mac-install/) instructions.
 
-2. `pip install git+https://github.com/mkornacker/pixeltable`
+2. `pip install git+https://github.com/pixeltable/pixeltable`
 
 
 ## First Steps

--- a/docs/tutorials/comparing_object_detection_models_for_video.ipynb
+++ b/docs/tutorials/comparing_object_detection_models_for_video.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "import urllib.request\n",
     "\n",
-    "download_url = 'https://raw.github.com/mkornacker/pixeltable/master/docs/source/data/bangkok.mp4'\n",
+    "download_url = 'https://raw.github.com/pixeltable/pixeltable/master/docs/source/data/bangkok.mp4'\n",
     "filename, _ = urllib.request.urlretrieve(download_url)"
    ]
   },

--- a/docs/tutorials/object_detection_in_videos.ipynb
+++ b/docs/tutorials/object_detection_in_videos.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "import urllib.request\n",
     "\n",
-    "download_url = 'https://raw.github.com/mkornacker/pixeltable/master/docs/source/data/bangkok.mp4'\n",
+    "download_url = 'https://raw.github.com/pixeltable/pixeltable/master/docs/source/data/bangkok.mp4'\n",
     "filename, _ = urllib.request.urlretrieve(download_url)"
    ]
   },

--- a/docs/tutorials/pixeltable_basics.ipynb
+++ b/docs/tutorials/pixeltable_basics.ipynb
@@ -36,7 +36,7 @@
     "import tempfile\n",
     "import tqdm\n",
     "\n",
-    "download_prefix = 'https://raw.github.com/mkornacker/pixeltable/master/docs/source/data'\n",
+    "download_prefix = 'https://raw.github.com/pixeltable/pixeltable/master/docs/source/data'\n",
     "json_data_url = f'{download_prefix}/coco-records.json'\n",
     "\n",
     "records = json.loads(urllib.request.urlopen(json_data_url).read().decode('utf-8'))\n",

--- a/pixeltable/catalog/column.py
+++ b/pixeltable/catalog/column.py
@@ -6,11 +6,10 @@ from typing import Optional, Union, Callable, Set
 import sqlalchemy as sql
 from pgvector.sqlalchemy import Vector
 
-from pixeltable import exceptions as exc
+from pixeltable import exceptions as excs
 from pixeltable.metadata import schema
 from pixeltable.type_system import ColumnType, StringType
 from .globals import is_valid_identifier
-
 
 _logger = logging.getLogger('pixeltable')
 
@@ -59,10 +58,10 @@ class Column:
         indexed: only valid for image columns; if true, maintains an NN index for this column
         """
         if not is_valid_identifier(name):
-            raise exc.Error(f"Invalid column name: '{name}'")
+            raise excs.Error(f"Invalid column name: '{name}'")
         self.name = name
         if col_type is None and computed_with is None:
-            raise exc.Error(f'Column {name}: col_type is required if computed_with is not specified')
+            raise excs.Error(f'Column {name}: col_type is required if computed_with is not specified')
 
         self.value_expr: Optional['Expr'] = None
         self.compute_func: Optional[Callable] = None
@@ -72,11 +71,11 @@ class Column:
             if value_expr is None:
                 # computed_with needs to be a Callable
                 if not isinstance(computed_with, Callable):
-                    raise exc.Error(
+                    raise excs.Error(
                         f'Column {name}: computed_with needs to be either a Pixeltable expression or a Callable, '
                         f'but it is a {type(computed_with)}')
                 if col_type is None:
-                    raise exc.Error(f'Column {name}: col_type is required if computed_with is a Callable')
+                    raise excs.Error(f'Column {name}: col_type is required if computed_with is a Callable')
                 # we need to turn the computed_with function into an Expr, but this requires resolving
                 # column name references and for that we need to wait until we're assigned to a Table
                 self.compute_func = computed_with
@@ -105,7 +104,7 @@ class Column:
         self.tbl: Optional[TableVersion] = None  # set by owning TableVersion
 
         if indexed and not self.col_type.is_image_type():
-            raise exc.Error(f'Column {name}: indexed=True requires ImageType')
+            raise excs.Error(f'Column {name}: indexed=True requires ImageType')
         self.is_indexed = indexed
 
     @classmethod
@@ -127,7 +126,7 @@ class Column:
     def check_value_expr(self) -> None:
         assert self.value_expr is not None
         if self.stored == False and self.is_computed and self.has_window_fn_call():
-            raise exc.Error(
+            raise excs.Error(
                 f'Column {self.name}: stored={self.stored} not supported for columns computed with window functions:'
                 f'\n{self.value_expr}')
 

--- a/pixeltable/catalog/path.py
+++ b/pixeltable/catalog/path.py
@@ -2,16 +2,15 @@ from __future__ import annotations
 
 import logging
 
-from pixeltable import exceptions as exc
+from pixeltable import exceptions as excs
 from .globals import is_valid_path
-
 
 _logger = logging.getLogger('pixeltable')
 
 class Path:
     def __init__(self, path: str, empty_is_valid: bool = False):
         if not is_valid_path(path, empty_is_valid):
-            raise exc.Error(f"Invalid path format: '{path}'")
+            raise excs.Error(f"Invalid path format: '{path}'")
         self.components = path.split('.')
 
     @property

--- a/pixeltable/catalog/path_dict.py
+++ b/pixeltable/catalog/path_dict.py
@@ -7,13 +7,12 @@ from uuid import UUID
 
 import sqlalchemy.orm as orm
 
-from .schema_object import SchemaObject
-from .dir import Dir
-from .path import Path
-from pixeltable import exceptions as exc
+from pixeltable import exceptions as excs
 from pixeltable.env import Env
 from pixeltable.metadata import schema
-
+from .dir import Dir
+from .path import Path
+from .schema_object import SchemaObject
 
 _logger = logging.getLogger('pixeltable')
 
@@ -55,11 +54,11 @@ class PathDict:
         dir = self.root_dir
         for i, component in enumerate(path.components):
             if component not in self.dir_contents[dir._id]:
-                raise exc.Error(f'No such path: {".".join(path.components[:i+1])}')
+                raise excs.Error(f'No such path: {".".join(path.components[:i + 1])}')
             schema_obj = self.dir_contents[dir._id][component]
             if i < len(path.components) - 1:
                 if not isinstance(schema_obj, Dir):
-                    raise exc.Error(f'Not a directory: {".".join(path.components[:i+1])}')
+                    raise excs.Error(f'Not a directory: {".".join(path.components[:i + 1])}')
                 dir = schema_obj
         return schema_obj
 
@@ -114,21 +113,21 @@ class PathDict:
         if expected is not None:
             schema_obj = self._resolve_path(path)
             if not isinstance(schema_obj, expected):
-                raise exc.Error(
+                raise excs.Error(
                     f'{str(path)} needs to be a {expected.display_name()} but is a {type(schema_obj).display_name()}')
         if expected is None:
             parent_obj = self._resolve_path(path.parent)
             if not isinstance(parent_obj, Dir):
-                raise exc.Error(
+                raise excs.Error(
                     f'{str(path.parent)} is a {type(parent_obj).display_name()}, not a {Dir.display_name()}')
             if path.name in self.dir_contents[parent_obj._id]:
                 obj = self.dir_contents[parent_obj._id][path.name]
-                raise exc.Error(f"{type(obj).display_name()} '{str(path)}' already exists")
+                raise excs.Error(f"{type(obj).display_name()} '{str(path)}' already exists")
 
     def get_children(self, parent: Path, child_type: Optional[Type[SchemaObject]], recursive: bool) -> List[Path]:
         dir = self._resolve_path(parent)
         if not isinstance(dir, Dir):
-            raise exc.Error(f'{str(parent)} is a {type(dir).display_name()}, not a directory')
+            raise excs.Error(f'{str(parent)} is a {type(dir).display_name()}, not a directory')
         matches = [
             obj for obj in self.dir_contents[dir._id].values() if child_type is None or isinstance(obj, child_type)
         ]

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -1,29 +1,27 @@
 from __future__ import annotations
 
-import logging
-from typing import Union, Any, List, Dict, Optional, Callable, Set, Tuple
-from uuid import UUID
-from pathlib import Path
 import dataclasses
 import json
+import logging
+from pathlib import Path
+from typing import Union, Any, List, Dict, Optional, Callable, Set, Tuple
+from uuid import UUID
 
 import pandas as pd
 import sqlalchemy as sql
 
-from .schema_object import SchemaObject
-from .column import Column
-from .table_version_path import TableVersionPath
-from .table_version import TableVersion
-from .globals import is_valid_identifier, is_system_column_name
-from pixeltable import exceptions as exc
 import pixeltable
-import pixeltable.type_system as ts
 import pixeltable.catalog as catalog
 import pixeltable.env as env
-import pixeltable.metadata.schema as schema
-import pixeltable.exprs as exprs
 import pixeltable.exceptions as excs
-
+import pixeltable.exprs as exprs
+import pixeltable.metadata.schema as schema
+import pixeltable.type_system as ts
+from .column import Column
+from .globals import is_valid_identifier, is_system_column_name
+from .schema_object import SchemaObject
+from .table_version import TableVersion
+from .table_version_path import TableVersionPath
 
 _logger = logging.getLogger('pixeltable')
 
@@ -67,7 +65,7 @@ class Table(SchemaObject):
 
     def _check_is_dropped(self) -> None:
         if self.is_dropped:
-            raise exc.Error(f'{self.display_name()} {self.name} has been dropped')
+            raise excs.Error(f'{self.display_name()} {self.name} has been dropped')
 
     def __getattr__(self, col_name: str) -> 'pixeltable.exprs.ColumnRef':
         """Return a ColumnRef for the given column name.

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -1,27 +1,26 @@
 from __future__ import annotations
 
 import dataclasses
+import importlib
 import inspect
 import logging
-from typing import Optional, List, Dict, Any, Union, Tuple, Type, Set
-from uuid import UUID
 import time
-import importlib
+from typing import Optional, List, Dict, Any, Tuple, Type, Set
+from uuid import UUID
 
 import sqlalchemy as sql
 import sqlalchemy.orm as orm
 
-from .globals import UpdateStatus, POS_COLUMN_NAME, is_valid_identifier
-from .column import Column
 import pixeltable
-from pixeltable import exceptions as exc
-from pixeltable.env import Env
 import pixeltable.func as func
-from pixeltable.metadata import schema
-from pixeltable.utils.media_store import MediaStore
-from pixeltable.utils.filecache import FileCache
+from pixeltable import exceptions as excs
+from pixeltable.env import Env
 from pixeltable.iterators import ComponentIterator
-
+from pixeltable.metadata import schema
+from pixeltable.utils.filecache import FileCache
+from pixeltable.utils.media_store import MediaStore
+from .column import Column
+from .globals import UpdateStatus, POS_COLUMN_NAME, is_valid_identifier
 
 _logger = logging.getLogger('pixeltable')
 
@@ -271,7 +270,7 @@ class TableVersion:
 
         row_count = self.store_tbl.count()
         if row_count > 0 and not col.col_type.nullable and not col.is_computed:
-            raise exc.Error(f'Cannot add non-nullable column "{col.name}" to table {self.name} with existing rows')
+            raise excs.Error(f'Cannot add non-nullable column "{col.name}" to table {self.name} with existing rows')
 
         # we're creating a new schema version
         ts = time.time()
@@ -310,7 +309,7 @@ class TableVersion:
                 num_excs = self.store_tbl.load_column(col, plan, value_expr_slot_idx, embedding_slot_idx, conn)
         except sql.exc.DBAPIError as e:
             self.drop_column(col.name)
-            raise exc.Error(f'Error during SQL execution:\n{e}')
+            raise excs.Error(f'Error during SQL execution:\n{e}')
         finally:
             plan.close()
 
@@ -328,10 +327,10 @@ class TableVersion:
         """
         assert not self.is_snapshot
         if name not in self.cols_by_name:
-            raise exc.Error(f'Unknown column: {name}')
+            raise excs.Error(f'Unknown column: {name}')
         col = self.cols_by_name[name]
         if len(col.dependent_cols) > 0:
-            raise exc.Error(
+            raise excs.Error(
                 f'Cannot drop column {name} because the following columns depend on it:\n',
                 f'{", ".join([c.name for c in col.dependent_cols])}')
 
@@ -364,11 +363,11 @@ class TableVersion:
         """
         assert not self.is_snapshot
         if old_name not in self.cols_by_name:
-            raise exc.Error(f'Unknown column: {old_name}')
+            raise excs.Error(f'Unknown column: {old_name}')
         if not is_valid_identifier(new_name):
-            raise exc.Error(f"Invalid column name: '{new_name}'")
+            raise excs.Error(f"Invalid column name: '{new_name}'")
         if new_name in self.cols_by_name:
-            raise exc.Error(f'Column {new_name} already exists')
+            raise excs.Error(f'Column {new_name} already exists')
         col = self.cols_by_name[old_name]
         del self.cols_by_name[old_name]
         col.name = new_name
@@ -422,7 +421,6 @@ class TableVersion:
         """Insert rows produced by exec_plan and propagate to views"""
         # we're creating a new version
         self.version += 1
-        from pixeltable.plan import Planner
         result = UpdateStatus()
         num_rows, num_excs, cols_with_excs = self.store_tbl.insert_rows(exec_plan, conn, v_min=self.version)
         self.next_rowid = num_rows
@@ -550,7 +548,7 @@ class TableVersion:
         """
         assert not self.is_snapshot
         if self.version == 0:
-            raise exc.Error('Cannot revert version 0')
+            raise excs.Error('Cannot revert version 0')
         with orm.Session(Env.get().engine, future=True) as session:
             self._revert(session)
             session.commit()
@@ -569,7 +567,7 @@ class TableVersion:
         result = list(conn.execute(sql.text(query)))
         if len(result) > 0:
             names = [row[1] for row in result]
-            raise exc.Error((
+            raise excs.Error((
                 f'Current version is needed for {len(result)} snapshot{"s" if len(result) > 1 else ""} '
                 f'({", ".join(names)})'
             ))
@@ -694,7 +692,7 @@ class TableVersion:
         for param_name in params:
             param = path.get_column(param_name)
             if param is None:
-                raise exc.Error(
+                raise excs.Error(
                     f'Column {col.name}: Callable parameter refers to an unknown column: {param_name}')
             args.append(exprs.ColumnRef(param))
         fn = func.make_function(

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -1,29 +1,13 @@
 from __future__ import annotations
 
-import copy
-import dataclasses
-import inspect
 import logging
-from typing import Optional, List, Dict, Any, Union, Tuple, Type, Set
+from typing import Optional, List, Union
 from uuid import UUID
-import time
-import importlib
 
-import sqlalchemy as sql
-import sqlalchemy.orm as orm
-
-from .globals import UpdateStatus, POS_COLUMN_NAME, is_valid_identifier
-from .column import Column
-from .table_version import TableVersion
 import pixeltable
-from pixeltable import exceptions as exc
-from pixeltable.env import Env
-import pixeltable.func as func
-from pixeltable.metadata import schema
-from pixeltable.utils.media_store import MediaStore
-from pixeltable.utils.filecache import FileCache
-from pixeltable.iterators import ComponentIterator
-
+from .column import Column
+from .globals import POS_COLUMN_NAME
+from .table_version import TableVersion
 
 _logger = logging.getLogger('pixeltable')
 

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -6,7 +6,7 @@ import sqlalchemy as sql
 import pixeltable.exec as exec
 import pixeltable.func as func
 from pixeltable import catalog
-from pixeltable import exceptions as exc
+from pixeltable import exceptions as excs
 from pixeltable import exprs
 
 
@@ -68,16 +68,16 @@ class Analyzer:
                 similarity_clauses, self.filter = self.filter.split_conjuncts(
                     lambda e: isinstance(e, exprs.ImageSimilarityPredicate))
                 if len(similarity_clauses) > 1:
-                    raise exc.Error(f'More than one nearest() not supported')
+                    raise excs.Error(f'More than one nearest() not supported')
                 if len(similarity_clauses) == 1:
                     if len(self.order_by_clause) > 0:
-                        raise exc.Error((
+                        raise excs.Error((
                             f'nearest() returns results in order of proximity and cannot be used in conjunction with '
                             f'order_by()'))
                     self.similarity_clause = similarity_clauses[0]
                     img_col = self.similarity_clause.img_col_ref.col
                     if not img_col.is_indexed:
-                        raise exc.Error(f'nearest() not available for unindexed column {img_col.name}')
+                        raise excs.Error(f'nearest() not available for unindexed column {img_col.name}')
 
         # all exprs that are evaluated in Python; not executable
         self.all_exprs = self.select_list.copy()
@@ -107,22 +107,22 @@ class Analyzer:
         grouping_expr_ids = {e.id for e in self.group_by_clause}
         is_agg_output = [self._determine_agg_status(e, grouping_expr_ids)[0] for e in self.select_list]
         if is_agg_output.count(False) > 0:
-            raise exc.Error(
+            raise excs.Error(
                 f'Invalid non-aggregate expression in aggregate query: {self.select_list[is_agg_output.index(False)]}')
 
         # check that filter doesn't contain aggregates
         if self.filter is not None:
             agg_fn_calls = [e for e in self.filter.subexprs(filter=lambda e: _is_agg_fn_call(e))]
             if len(agg_fn_calls) > 0:
-                raise exc.Error(f'Filter cannot contain aggregate functions: {self.filter}')
+                raise excs.Error(f'Filter cannot contain aggregate functions: {self.filter}')
 
         # check that grouping exprs don't contain aggregates and can be expressed as SQL (we perform sort-based
         # aggregation and rely on the SqlScanNode returning data in the correct order)
         for e in self.group_by_clause:
             if e.sql_expr() is None:
-                raise exc.Error(f'Invalid grouping expression, needs to be expressible in SQL: {e}')
+                raise excs.Error(f'Invalid grouping expression, needs to be expressible in SQL: {e}')
             if e.contains(filter=lambda e: _is_agg_fn_call(e)):
-                raise exc.Error(f'Grouping expression contains aggregate function: {e}')
+                raise excs.Error(f'Grouping expression contains aggregate function: {e}')
 
         # check that agg fn calls don't have contradicting ordering requirements
         order_by: List[exprs.Exprs] = []
@@ -138,7 +138,7 @@ class Analyzer:
                 combined = _get_combined_ordering(
                     [(e, True) for e in order_by], [(e, True) for e in fn_call_order_by])
                 if len(combined) == 0:
-                    raise exc.Error((
+                    raise excs.Error((
                         f"Incompatible ordering requirements between expressions '{order_by_origin}' and "
                         f"'{agg_fn_call}':\n"
                         f"{exprs.Expr.print_list(order_by)} vs {exprs.Expr.print_list(fn_call_order_by)}"
@@ -156,7 +156,7 @@ class Analyzer:
             for c in e.components:
                 _, is_input = self._determine_agg_status(c, grouping_expr_ids)
                 if not is_input:
-                    raise exc.Error(f'Invalid nested aggregates: {e}')
+                    raise excs.Error(f'Invalid nested aggregates: {e}')
             return True, False
         elif isinstance(e, exprs.Literal):
             return True, True
@@ -171,7 +171,7 @@ class Analyzer:
             is_output = component_is_output.count(True) == len(e.components)
             is_input = component_is_input.count(True) == len(e.components)
             if not is_output and not is_input:
-                raise exc.Error(f'Invalid expression, mixes aggregate with non-aggregate: {e}')
+                raise excs.Error(f'Invalid expression, mixes aggregate with non-aggregate: {e}')
             return is_output, is_input
 
 
@@ -204,9 +204,9 @@ class Planner:
         if where_clause is not None:
             analyzer = cls.analyze(tbl, where_clause)
             if analyzer.similarity_clause is not None:
-                raise exc.Error('nearest() cannot be used with count()')
+                raise excs.Error('nearest() cannot be used with count()')
             if analyzer.filter is not None:
-                raise exc.Error(f'Filter {analyzer.filter} not expressible in SQL')
+                raise excs.Error(f'Filter {analyzer.filter} not expressible in SQL')
             clause_element = analyzer.sql_where_clause.sql_expr()
             assert clause_element is not None
             stmt = stmt.where(clause_element)
@@ -437,7 +437,7 @@ class Planner:
                     other_order_by_clauses = fn_call_ordering
                     combined = _get_combined_ordering(order_by_items, other_order_by_clauses)
                     if len(combined) == 0:
-                        raise exc.Error((
+                        raise excs.Error((
                             f"Incompatible ordering requirements between expressions '{order_by_origin}' and "
                             f"'{fn_call}':\n"
                             f"{exprs.Expr.print_list(order_by_items)} vs {exprs.Expr.print_list(other_order_by_clauses)}"
@@ -450,7 +450,7 @@ class Planner:
                 # check for compatibility
                 combined = _get_combined_ordering(order_by_items, agg_ordering)
                 if len(combined) == 0:
-                    raise exc.Error((
+                    raise excs.Error((
                         f"Incompatible ordering requirements between expressions '{order_by_origin}' and "
                         f"grouping expressions:\n"
                         f"{exprs.Expr.print_list([e for e, _ in order_by_items])} vs "
@@ -465,7 +465,7 @@ class Planner:
                 # check for compatibility
                 combined = _get_combined_ordering(order_by_items, analyzer.order_by_clause)
                 if len(combined) == 0:
-                    raise exc.Error((
+                    raise excs.Error((
                         f"Incompatible ordering requirements between expressions '{order_by_origin}' and "
                         f"order-by expressions:\n"
                         f"{exprs.Expr.print_list([e for e, _ in order_by_items])} vs "
@@ -497,7 +497,7 @@ class Planner:
 
         for e in [e for e, _ in order_by_items]:
             if e.sql_expr() is None:
-                raise exc.Error(f'order_by element cannot be expressed in SQL: {e}')
+                raise excs.Error(f'order_by element cannot be expressed in SQL: {e}')
         # we do ascending ordering by default, if not specified otherwise
         order_by_items = [(e, True) if asc is None else (e, asc) for e, asc in order_by_items]
         return order_by_items

--- a/pixeltable/tests/conftest.py
+++ b/pixeltable/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import List
 import numpy as np
 import pytest
 
-import pixeltable as pt
+import pixeltable as pxt
 import pixeltable.catalog as catalog
 from pixeltable import exprs
 from pixeltable import functions as ptf
@@ -37,12 +37,12 @@ def init_env(tmp_path_factory) -> None:
     # leave db in place for debugging purposes
 
 @pytest.fixture(scope='function')
-def test_client(init_env) -> pt.Client:
+def test_client(init_env) -> pxt.Client:
     # Clean the DB *before* instantiating a client object. This is because some tests
     # (such as test_migration.py) may leave the DB in a broken state, from which the
     # client is uninstantiable.
     clean_db()
-    cl = pt.Client(reload=True)
+    cl = pxt.Client(reload=True)
     cl.logging(level=logging.DEBUG, to_stdout=True)
     yield cl
 
@@ -74,7 +74,7 @@ def clean_db(restore_tables: bool = True) -> None:
 
 
 @pytest.fixture(scope='function')
-def test_tbl(test_client: pt.Client) -> catalog.Table:
+def test_tbl(test_client: pxt.Client) -> catalog.Table:
     return create_test_tbl(test_client)
 
 # @pytest.fixture(scope='function')
@@ -123,11 +123,11 @@ def test_tbl_exprs(test_tbl: catalog.Table) -> List[exprs.Expr]:
     ]
 
 @pytest.fixture(scope='function')
-def all_datatypes_tbl(test_client: pt.Client) -> catalog.Table:
+def all_datatypes_tbl(test_client: pxt.Client) -> catalog.Table:
     return create_all_datatypes_tbl(test_client)
 
 @pytest.fixture(scope='function')
-def img_tbl(test_client: pt.Client) -> catalog.Table:
+def img_tbl(test_client: pxt.Client) -> catalog.Table:
     schema = {
         'img': ImageType(nullable=False),
         'category': StringType(nullable=False),
@@ -157,7 +157,7 @@ def img_tbl_exprs(img_tbl: catalog.Table) -> List[exprs.Expr]:
 #    cl = pt.Client()
 #    db = cl.create_db('test_indexed')
 @pytest.fixture(scope='function')
-def indexed_img_tbl(test_client: pt.Client) -> catalog.Table:
+def indexed_img_tbl(test_client: pxt.Client) -> catalog.Table:
     skip_test_if_not_installed('nos')
     cl = test_client
     schema = {

--- a/pixeltable/tests/test_audio.py
+++ b/pixeltable/tests/test_audio.py
@@ -1,12 +1,12 @@
 from typing import Optional
+
 import av
 
 import pixeltable as pxt
-from pixeltable.type_system import VideoType, AudioType
-from pixeltable.tests.utils import get_video_files, get_audio_files
-from pixeltable import catalog
-from pixeltable.utils.media_store import MediaStore
 import pixeltable.env as env
+from pixeltable.tests.utils import get_video_files, get_audio_files
+from pixeltable.type_system import VideoType, AudioType
+from pixeltable.utils.media_store import MediaStore
 
 
 class TestAudio:

--- a/pixeltable/tests/test_client.py
+++ b/pixeltable/tests/test_client.py
@@ -1,21 +1,21 @@
 import pytest
 
-import pixeltable as pt
-from pixeltable import exceptions as exc
+import pixeltable as pxt
+import pixeltable.exceptions as excs
 
 
 class TestClient:
     def test_list_functions(self, init_env) -> None:
-        cl = pt.Client()
+        cl = pxt.Client()
         _ = cl.list_functions()
         print(_)
 
-    def test_drop_table(self, test_tbl: pt.Table) -> None:
-        cl = pt.Client()
+    def test_drop_table(self, test_tbl: pxt.Table) -> None:
+        cl = pxt.Client()
         t = cl.get_table('test_tbl')
         cl.drop_table('test_tbl')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = cl.get_table('test_tbl')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.show(1)
 

--- a/pixeltable/tests/test_component_view.py
+++ b/pixeltable/tests/test_component_view.py
@@ -1,19 +1,16 @@
-import math
-from pathlib import Path
 from typing import Dict, Any, List, Tuple
 
 import PIL
-import cv2
 import numpy as np
 import pandas as pd
 import pytest
 
-import pixeltable as pt
-from pixeltable import exceptions as exc
+import pixeltable as pxt
+from pixeltable import exceptions as excs
 from pixeltable.iterators import ComponentIterator
+from pixeltable.iterators.video import FrameIterator
 from pixeltable.tests.utils import assert_resultset_eq, get_video_files
 from pixeltable.type_system import IntType, VideoType, JsonType
-from pixeltable.iterators.video import FrameIterator
 
 
 class TestIterator(ComponentIterator):
@@ -26,19 +23,19 @@ class TestIterator(ComponentIterator):
         self.pos_frame = 0.0
 
     @classmethod
-    def input_schema(cls) -> Dict[str, pt.ColumnType]:
+    def input_schema(cls) -> Dict[str, pxt.ColumnType]:
         return {
             'video': VideoType(nullable=False),
-            'fps': pt.FloatType()
+            'fps': pxt.FloatType()
         }
 
     @classmethod
-    def output_schema(cls, *args: Any, **kwargs: Any) -> Tuple[Dict[str, pt.ColumnType], List[str]]:
+    def output_schema(cls, *args: Any, **kwargs: Any) -> Tuple[Dict[str, pxt.ColumnType], List[str]]:
         return {
             'frame_idx': IntType(),
-            'pos_msec': pt.FloatType(),
-            'pos_frame': pt.FloatType(),
-            'frame': pt.ImageType(),
+            'pos_msec': pxt.FloatType(),
+            'pos_frame': pxt.FloatType(),
+            'frame': pxt.ImageType(),
         }, ['frame']
 
     def __next__(self) -> Dict[str, Any]:
@@ -64,7 +61,7 @@ class TestIterator(ComponentIterator):
 
 
 class TestComponentView:
-    def test_basic(self, test_client: pt.Client) -> None:
+    def test_basic(self, test_client: pxt.Client) -> None:
         cl = test_client
         # create video table
         schema = {'video': VideoType(), 'angle': IntType(), 'other_angle': IntType()}
@@ -72,24 +69,24 @@ class TestComponentView:
         video_filepaths = get_video_files()
 
         # cannot add 'pos' column
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             video_t.add_column(pos=IntType())
         assert 'reserved' in str(excinfo.value)
 
         # parameter missing
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             args = {'fps': 1}
             _ = cl.create_view('test_view', video_t, iterator_class=FrameIterator, iterator_args=args)
         assert 'missing a required argument' in str(excinfo.value)
 
         # bad parameter type
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             args = {'video': video_t.video, 'fps': '1'}
             _ = cl.create_view('test_view', video_t, iterator_class=FrameIterator, iterator_args=args)
         assert 'expected float' in str(excinfo.value)
 
         # bad parameter type
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             args = {'video': 1, 'fps': 1}
             _ = cl.create_view('test_view', video_t, iterator_class=FrameIterator, iterator_args=args)
         assert 'expected file path' in str(excinfo.value)
@@ -123,7 +120,7 @@ class TestComponentView:
         assert len(result) > 0
         assert np.all(result['frame_idx'] == pd.Series(range(len(result))))
 
-    def test_add_column(self, test_client: pt.Client) -> None:
+    def test_add_column(self, test_client: pxt.Client) -> None:
         cl = test_client
         # create video table
         video_t = cl.create_table('video_tbl', {'video': VideoType()})
@@ -142,11 +139,11 @@ class TestComponentView:
         _ = view_t.where(view_t.annotation == None).count()
         assert view_t.count() == view_t.where(view_t.annotation == None).count()
 
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             view_t.add_column(annotation=JsonType(nullable=False))
         assert 'must be nullable' in str(excinfo.value)
 
-    def test_update(self, test_client: pt.Client) -> None:
+    def test_update(self, test_client: pxt.Client) -> None:
         cl = test_client
         # create video table
         video_t = cl.create_table('video_tbl', {'video': VideoType()})
@@ -167,42 +164,42 @@ class TestComponentView:
         c2 = view_t.where(view_t.video == video_url).count()
         assert c1 == c2
 
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             _ = cl.create_view(
                 'bad_view', video_t, schema={'annotation': JsonType(nullable=False)},
                 iterator_class=FrameIterator, iterator_args=args)
         assert 'must be nullable' in str(excinfo.value)
 
     # break up the snapshot tests for better (future) parallelization
-    def test_snapshot1(self, test_client: pt.Client) -> None:
+    def test_snapshot1(self, test_client: pxt.Client) -> None:
         has_column = False
         has_filter  = False
         for reload_md in [False, True]:
-            cl = pt.Client(reload=True)
+            cl = pxt.Client(reload=True)
             self.run_snapshot_test(cl, has_column=has_column, has_filter=has_filter, reload_md=reload_md)
 
-    def test_snapshot2(self, test_client: pt.Client) -> None:
+    def test_snapshot2(self, test_client: pxt.Client) -> None:
         has_column = True
         has_filter  = False
         for reload_md in [False, True]:
-            cl = pt.Client(reload=True)
+            cl = pxt.Client(reload=True)
             self.run_snapshot_test(cl, has_column=has_column, has_filter=has_filter, reload_md=reload_md)
 
-    def test_snapshot3(self, test_client: pt.Client) -> None:
+    def test_snapshot3(self, test_client: pxt.Client) -> None:
         has_column = False
         has_filter  = True
         for reload_md in [False, True]:
-            cl = pt.Client(reload=True)
+            cl = pxt.Client(reload=True)
             self.run_snapshot_test(cl, has_column=has_column, has_filter=has_filter, reload_md=reload_md)
 
-    def test_snapshot4(self, test_client: pt.Client) -> None:
+    def test_snapshot4(self, test_client: pxt.Client) -> None:
         has_column = True
         has_filter  = True
         for reload_md in [False, True]:
-            cl = pt.Client(reload=True)
+            cl = pxt.Client(reload=True)
             self.run_snapshot_test(cl, has_column=has_column, has_filter=has_filter, reload_md=reload_md)
 
-    def run_snapshot_test(self, cl: pt.Client, has_column: bool, has_filter: bool, reload_md: bool) -> None:
+    def run_snapshot_test(self, cl: pxt.Client, has_column: bool, has_filter: bool, reload_md: bool) -> None:
         base_path = 'video_tbl'
         view_path = 'test_view'
         snap_path = 'test_snap'
@@ -245,7 +242,7 @@ class TestComponentView:
         assert_resultset_eq(snap_query.collect(), orig_resultset)
 
         if reload_md:
-            cl = pt.Client(reload=True)
+            cl = pxt.Client(reload=True)
             video_t = cl.get_table(base_path)
             snap_t = cl.get_table(snap_path)
             snap_cols = [snap_t.c1] if has_column else []
@@ -274,7 +271,7 @@ class TestComponentView:
         cl.drop_table(view_path)
         cl.drop_table(base_path)
 
-    def test_chained_views(self, test_client: pt.Client) -> None:
+    def test_chained_views(self, test_client: pxt.Client) -> None:
         """Component view followed by a standard view"""
         cl = test_client
         # create video table

--- a/pixeltable/tests/test_dataframe.py
+++ b/pixeltable/tests/test_dataframe.py
@@ -1,19 +1,20 @@
-from typing import Any, Dict
 import datetime
-import pytest
 import pickle
-import numpy as np
 from pathlib import Path
-import bs4
-import requests
+from typing import Any, Dict
 
+import bs4
+import numpy as np
+import pytest
+import requests
 from pycocotools.coco import COCO
 
+import pixeltable as pxt
 from pixeltable import catalog
-from pixeltable import exceptions as exc
-import pixeltable as pt
+from pixeltable import exceptions as excs
 from pixeltable.iterators import FrameIterator
 from pixeltable.tests.utils import get_video_files, get_audio_files, skip_test_if_not_installed
+
 
 class TestDataFrame:
     def test_select_where(self, test_tbl: catalog.Table) -> None:
@@ -35,7 +36,7 @@ class TestDataFrame:
         _ = t.where(t.c2 < 10).select(t.c2, t.c2).show(0) # repeated name no error
         
         # duplicate select list
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(t.c1).select(t.c2).show(0)
         assert 'already specified' in str(exc_info.value)
 
@@ -46,28 +47,28 @@ class TestDataFrame:
 
         # catch invalid name in select list from user input
         # only check stuff that's not caught by python kwargs checker
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(t.c1, **{'c2-1': t.c2}).show(0)
         assert 'Invalid name' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(t.c1, **{'': t.c2}).show(0)
         assert 'Invalid name' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(t.c1, **{'foo.bar': t.c2}).show(0)
         assert 'Invalid name' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(t.c1, _c3=t.c2).show(0)
         assert 'Invalid name' in str(exc_info.value)
 
         # catch repeated name from user input
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(t.c2, c2=t.c1).show(0)
         assert 'Repeated column name' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(t.c2+1, col_0=t.c2).show(0)
         assert 'Repeated column name' in str(exc_info.value)
 
@@ -101,19 +102,19 @@ class TestDataFrame:
         assert res[0, 'c2'] == pd_df['c2'][0]
         assert res[0, 'c2'] == res[0, 1]
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = res['does_not_exist']
         assert 'Invalid column name' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = res[0, 'does_not_exist']
         assert 'Invalid column name' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = res[0, 0, 0]
         assert 'Bad index' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = res['c2', 0]
         assert 'Bad index' in str(exc_info.value)
 
@@ -122,7 +123,7 @@ class TestDataFrame:
         res = t.select(t.c4, t.c2).order_by(t.c4).order_by(t.c2, asc=False).show(0)
 
         # invalid expr in order_by()
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.order_by(datetime.datetime.now()).show(0)
         assert 'Invalid expression' in str(exc_info.value)
 
@@ -134,7 +135,7 @@ class TestDataFrame:
         res = t.where(t.c2 > 9).head(10).to_pandas()
         assert np.all(res.c2 == list(range(10, 20)))
         # order_by() is an error
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.order_by(t.c2).head(10)
         assert 'cannot be used with order_by' in str(exc_info.value)
 
@@ -143,7 +144,7 @@ class TestDataFrame:
         res = t.where(t.c2 < 90).tail().to_pandas()
         assert np.all(res.c2 == list(range(80, 90)))
         # order_by() is an error
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.order_by(t.c2).tail(10)
         assert 'cannot be used with order_by' in str(exc_info.value)
 
@@ -169,13 +170,13 @@ class TestDataFrame:
         t = indexed_img_tbl
         probe = t.select(t.img).show(1)
         img = probe[0, 0]
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.where(t.img.nearest(img)).count()
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.where(t.img.nearest('car')).count()
 
         # for now, count() doesn't work with non-SQL Where clauses
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.where(t.img.width > 100).count()
 
     def test_select_literal(self, test_tbl: catalog.Table) -> None:
@@ -183,8 +184,8 @@ class TestDataFrame:
         res = t.select(1.0).where(t.c2 < 10).collect()
         assert res[res.column_names()[0]] == [1.0] * 10
 
-    def test_html_media_url(self, test_client: pt.Client) -> None:
-        tab = test_client.create_table('test_html_repr', {'video': pt.VideoType(), 'audio': pt.AudioType()})
+    def test_html_media_url(self, test_client: pxt.Client) -> None:
+        tab = test_client.create_table('test_html_repr', {'video': pxt.VideoType(), 'audio': pxt.AudioType()})
         status = tab.insert([{'video': get_video_files()[0], 'audio': get_audio_files()[0]}])
         assert status.num_rows == 1
         assert status.num_excs == 0
@@ -295,7 +296,7 @@ class TestDataFrame:
             2. compatibility of all types with default collate_fn
         """
         import torch.utils.data
-        @pt.udf(param_types=[pt.JsonType()], return_type=pt.JsonType())
+        @pxt.udf(param_types=[pxt.JsonType()], return_type=pxt.JsonType())
         def restrict_json_for_default_collate(obj):
             keys = ['id', 'label', 'iscrowd', 'bounding_box']
             return {k: obj[k] for k in keys}
@@ -380,17 +381,17 @@ class TestDataFrame:
         ds4 = t.select(t.row_id).to_pytorch_dataset(image_format='pt')
         assert ds4.path != ds3.path, 'different select list, hence different path should be used'
 
-    def test_to_coco(self, test_client: pt.Client) -> None:
+    def test_to_coco(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('nos')
         cl = test_client
-        base_t = cl.create_table('videos', {'video': pt.VideoType()})
+        base_t = cl.create_table('videos', {'video': pxt.VideoType()})
         args = {'video': base_t.video, 'fps': 1}
         view_t = cl.create_view('frames', base_t, iterator_class=FrameIterator, iterator_args=args)
         from pixeltable.functions.nos.object_detection_2d import yolox_medium
         view_t.add_column(detections=yolox_medium(view_t.frame))
         base_t.insert([{'video': get_video_files()[0]}])
 
-        @pt.udf(return_type=pt.JsonType(nullable=False), param_types=[pt.JsonType(nullable=False)])
+        @pxt.udf(return_type=pxt.JsonType(nullable=False), param_types=[pxt.JsonType(nullable=False)])
         def yolo_to_coco(detections):
             bboxes, labels = detections['bboxes'], detections['labels']
             num_annotations = len(detections['bboxes'])
@@ -423,10 +424,10 @@ class TestDataFrame:
         assert len(coco_ds.imgs) == view_t.count()
 
         # incorrect select list
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = view_t.select({'image': view_t.frame, 'annotations': view_t.detections}).to_coco_dataset()
         assert '"annotations" is not a list' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = view_t.select(view_t.detections).to_coco_dataset()
         assert 'missing key "image"' in str(exc_info.value).lower()

--- a/pixeltable/tests/test_dataframe.py
+++ b/pixeltable/tests/test_dataframe.py
@@ -355,7 +355,7 @@ class TestDataFrame:
         t = all_datatypes_tbl
 
         t.drop_column('c_video') # null value video column triggers internal assertions in DataRow
-        # see https://github.com/mkornacker/pixeltable/issues/38
+        # see https://github.com/pixeltable/pixeltable/issues/38
 
         t.drop_column('c_array') # no support yet for null array values in the pytorch dataset
 

--- a/pixeltable/tests/test_dirs.py
+++ b/pixeltable/tests/test_dirs.py
@@ -1,54 +1,53 @@
 import pytest
 
-import pixeltable as pt
-from pixeltable import exceptions as exc
+import pixeltable as pxt
+from pixeltable import exceptions as excs
 from pixeltable.tests.utils import make_tbl
-from pixeltable import catalog
 
 
 class TestDirs:
-    def test_create(self, test_client: pt.Client) -> None:
+    def test_create(self, test_client: pxt.Client) -> None:
         cl = test_client
         dirs = ['dir1', 'dir1.sub1', 'dir1.sub1.subsub1']
         for name in dirs:
             cl.create_dir(name)
 
         # invalid names
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('1dir')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('_dir1')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir 1')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir1..sub2')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir1.sub2.')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir1:sub2.')
 
         # existing dirs
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir1')
         cl.create_dir('dir1', ignore_errors=True)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir1.sub1')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir1.sub1.subsub1')
 
         # existing table
         make_tbl(cl, 'dir1.t1')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir1.t1')
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('dir2.sub2')
         make_tbl(cl, 't2')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.create_dir('t2.sub2')
 
         # new client: force loading from store
-        cl2 = pt.Client(reload=True)
+        cl2 = pxt.Client(reload=True)
 
         listing = cl2.list_dirs(recursive=True)
         assert listing == dirs
@@ -63,7 +62,7 @@ class TestDirs:
         listing = cl2.list_dirs('dir1.sub1', recursive=False)
         assert listing == ['dir1.sub1.subsub1']
 
-    def test_rm(self, test_client: pt.Client) -> None:
+    def test_rm(self, test_client: pxt.Client) -> None:
         cl = test_client
         dirs = ['dir1', 'dir1.sub1', 'dir1.sub1.subsub1']
         for name in dirs:
@@ -72,26 +71,26 @@ class TestDirs:
         make_tbl(cl, 'dir1.t1')
 
         # bad name
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.rm_dir('1dir')
         # bad path
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.rm_dir('dir1..sub1')
         # doesn't exist
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.rm_dir('dir2')
         # not empty
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.rm_dir('dir1')
 
         cl.rm_dir('dir1.sub1.subsub1')
         assert cl.list_dirs('dir1.sub1') == []
 
         # check after reloading
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         assert cl.list_dirs('dir1.sub1') == []
 
-    def test_move(self, test_client: pt.Client) -> None:
+    def test_move(self, test_client: pxt.Client) -> None:
         cl = test_client
         cl.create_dir('dir1')
         cl.create_dir('dir1.sub1')
@@ -104,5 +103,5 @@ class TestDirs:
         assert cl.list_tables('dir2') == ['dir2.dir1.sub1.t2']
 
         # new client: force loading from store
-        cl2 = pt.Client(reload=True)
+        cl2 = pxt.Client(reload=True)
         assert cl2.list_tables('dir2') == ['dir2.dir1.sub1.t2']

--- a/pixeltable/tests/test_document.py
+++ b/pixeltable/tests/test_document.py
@@ -1,14 +1,14 @@
-from typing import Optional, Set, List
+import itertools
 import json
 import re
-import itertools
+from typing import Optional, Set, List
 
 import pytest
 
 import pixeltable as pxt
-from pixeltable.type_system import DocumentType
-from pixeltable.tests.utils import get_documents, get_video_files, get_audio_files, get_image_files
 from pixeltable.iterators.document import DocumentSplitter
+from pixeltable.tests.utils import get_documents, get_video_files, get_audio_files, get_image_files
+from pixeltable.type_system import DocumentType
 
 
 class TestDocument:

--- a/pixeltable/tests/test_exprs.py
+++ b/pixeltable/tests/test_exprs.py
@@ -1,24 +1,23 @@
 import json
-import typing
-from typing import List, Dict
 import urllib.parse
+from typing import List, Dict
 
-import sqlalchemy as sql
 import pytest
+import sqlalchemy as sql
 
-import pixeltable as pt
+import pixeltable as pxt
+import pixeltable.func as func
 from pixeltable import catalog
-from pixeltable.type_system import StringType, BoolType, IntType, ImageType, ArrayType, ColumnType, FloatType, \
-    VideoType, JsonType
-from pixeltable.exprs import Expr, CompoundPredicate, FunctionCall, Literal, InlineDict, InlineArray, ColumnRef
+from pixeltable import exceptions as excs
+from pixeltable import exprs
+from pixeltable.exprs import Expr, ColumnRef
 from pixeltable.exprs import RELATIVE_PATH_ROOT as R
 from pixeltable.functions import cast, sum, count
 from pixeltable.functions.pil.image import blend
-from pixeltable import exceptions as exc
-from pixeltable import exprs
-import pixeltable.func as func
-from pixeltable.tests.utils import get_image_files, skip_test_if_not_installed
 from pixeltable.iterators import FrameIterator
+from pixeltable.tests.utils import get_image_files, skip_test_if_not_installed
+from pixeltable.type_system import StringType, BoolType, IntType, ArrayType, ColumnType, FloatType, \
+    VideoType
 
 
 class TestExprs:
@@ -63,10 +62,10 @@ class TestExprs:
         assert 'cannot be used in conjunction with python boolean operators' in str(exc_info.value).lower()
 
         # compound predicates with Python functions
-        @pt.udf(return_type=BoolType(), param_types=[StringType()])
+        @pxt.udf(return_type=BoolType(), param_types=[StringType()])
         def udf(_: str) -> bool:
             return True
-        @pt.udf(return_type=BoolType(), param_types=[IntType()])
+        @pxt.udf(return_type=BoolType(), param_types=[IntType()])
         def udf2(_: int) -> bool:
             return True
 
@@ -112,54 +111,54 @@ class TestExprs:
         t = test_tbl
 
         # error in expr that's handled in SQL
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[(t.c2 + 1) / t.c2].show()
 
         # error in expr that's handled in Python
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[(t.c6.f2 + 1) / (t.c2 - 10)].show()
 
         # the same, but with an inline function
-        @pt.udf(return_type=FloatType(), param_types=[IntType(), IntType()])
+        @pxt.udf(return_type=FloatType(), param_types=[IntType(), IntType()])
         def f(a: int, b: int) -> float:
             return a / b
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[f(t.c2 + 1, t.c2)].show()
 
         # error in agg.init()
-        @pt.uda(update_types=[IntType()], value_type=IntType(), name='agg')
-        class Aggregator(pt.Aggregator):
+        @pxt.uda(update_types=[IntType()], value_type=IntType(), name='agg')
+        class Aggregator(pxt.Aggregator):
             def __init__(self):
                 self.sum = 1 / 0
             def update(self, val):
                 pass
             def value(self):
                 return 1
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[agg(t.c2)].show()
 
         # error in agg.update()
-        @pt.uda(update_types=[IntType()], value_type=IntType(), name='agg')
-        class Aggregator(pt.Aggregator):
+        @pxt.uda(update_types=[IntType()], value_type=IntType(), name='agg')
+        class Aggregator(pxt.Aggregator):
             def __init__(self):
                 self.sum = 0
             def update(self, val):
                 self.sum += 1 / val
             def value(self):
                 return 1
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[agg(t.c2 - 10)].show()
 
         # error in agg.value()
-        @pt.uda(update_types=[IntType()], value_type=IntType(), name='agg')
-        class Aggregator(pt.Aggregator):
+        @pxt.uda(update_types=[IntType()], value_type=IntType(), name='agg')
+        class Aggregator(pxt.Aggregator):
             def __init__(self):
                 self.sum = 0
             def update(self, val):
                 self.sum += val
             def value(self):
                 return 1 / self.sum
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[t.c2 <= 2][agg(t.c2 - 1)].show()
 
     def test_props(self, test_tbl: catalog.Table, img_tbl: catalog.Table) -> None:
@@ -193,28 +192,28 @@ class TestExprs:
 
         for c in [t.c1, t.c1n, t.c2, t.c3, t.c4, t.c5, t.c6, t.c7]:
             # errortype/errormsg only applies to stored computed and media columns
-            with pytest.raises(exc.Error) as excinfo:
+            with pytest.raises(excs.Error) as excinfo:
                 _ = t.select(c.errortype).show()
             assert 'only valid for' in str(excinfo.value)
-            with pytest.raises(exc.Error) as excinfo:
+            with pytest.raises(excs.Error) as excinfo:
                 _ = t.select(c.errormsg).show()
             assert 'only valid for' in str(excinfo.value)
 
             # fileurl/localpath only applies to media columns
-            with pytest.raises(exc.Error) as excinfo:
+            with pytest.raises(excs.Error) as excinfo:
                 _ = t.select(t.c1.fileurl).show()
             assert 'only valid for' in str(excinfo.value)
-            with pytest.raises(exc.Error) as excinfo:
+            with pytest.raises(excs.Error) as excinfo:
                 _ = t.select(t.c1.localpath).show()
             assert 'only valid for' in str(excinfo.value)
 
         # fileurl/localpath doesn't apply to unstored computed img columns
         img_t.add_column(c9=img_t.img.rotate(30))
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             _ = img_t.select(img_t.c9.localpath).show()
         assert 'computed unstored' in str(excinfo.value)
 
-    def test_null_args(self, test_client: pt.Client) -> None:
+    def test_null_args(self, test_client: pxt.Client) -> None:
         # create table with two int columns
         schema = {'c1': FloatType(nullable=True), 'c2': FloatType(nullable=True)}
         t = test_client.create_table('test', schema)
@@ -222,8 +221,8 @@ class TestExprs:
         # computed column that doesn't allow nulls
         t.add_column(c3=lambda c1, c2: c1 + c2, type=FloatType(nullable=False))
         # function that does allow nulls
-        @pt.udf(return_type=FloatType(nullable=True),
-                param_types=[FloatType(nullable=False), FloatType(nullable=True)])
+        @pxt.udf(return_type=FloatType(nullable=True),
+                 param_types=[FloatType(nullable=False), FloatType(nullable=True)])
         def f(a: int, b: int) -> int:
             if b is None:
                 return a
@@ -255,13 +254,13 @@ class TestExprs:
             (t.c1, t.c2), (t.c1, 1), (t.c2, t.c1), (t.c2, 'a'),
             (t.c1, t.c3), (t.c1, 1.0), (t.c3, t.c1), (t.c3, 'a')
         ]:
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 + op2]
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 - op2]
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 * op2]
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 / op2]
 
         # TODO: test division; requires predicate
@@ -269,18 +268,18 @@ class TestExprs:
             _ = t[op1 + op2].show()
             _ = t[op1 - op2].show()
             _ = t[op1 * op2].show()
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 / op2].show()
 
         for op1, op2 in [
             (t.c6.f1, t.c6.f2), (t.c6.f1, t.c6.f3), (t.c6.f1, 1), (t.c6.f1, 1.0),
             (t.c6.f2, t.c6.f1), (t.c6.f3, t.c6.f1), (t.c6.f2, 'a'), (t.c6.f3, 'a'),
         ]:
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 + op2].show()
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 - op2].show()
-            with pytest.raises(exc.Error):
+            with pytest.raises(excs.Error):
                 _ = t[op1 * op2].show()
 
 
@@ -409,7 +408,7 @@ class TestExprs:
             return str(x)
 
         # Now test that a function without a return type throws an exception ...
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.c2.apply(f1)
         assert 'Column type of `f1` cannot be inferred.' in str(exc_info.value)
 
@@ -429,21 +428,21 @@ class TestExprs:
         def f3(x, y) -> str:
             return f'{x}{y}'
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.c2.apply(f3)  # Too many required parameters
         assert str(exc_info.value) == 'Function `f3` has multiple required parameters.'
 
         def f4() -> str:
             return "pixeltable"
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.c2.apply(f4)  # No positional parameters
         assert str(exc_info.value) == 'Function `f4` has no positional parameters.'
 
         def f5(**kwargs) -> str:
             return ""
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.c2.apply(f5)  # No positional parameters
         assert str(exc_info.value) == 'Function `f5` has no positional parameters.'
 
@@ -471,7 +470,7 @@ class TestExprs:
         df = t[[t.img, t.img.rotate(60)]]
         _ = df.show(n=100)._repr_html_()
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[t.img.rotate]
 
     def test_img_members(self, img_tbl) -> None:
@@ -525,7 +524,7 @@ class TestExprs:
         result = t[t.img.nearest(img) & (t.category == probe[0, 1]) & (t.img.width > 1)].show(10)
         # TODO: figure out how to verify results
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t[t.img.nearest(img)].order_by(t.category).show()
         assert 'cannot be used in conjunction with' in str(exc_info.value)
 
@@ -537,7 +536,7 @@ class TestExprs:
             t.img.nearest('musical instrument') & (t.category == french_horn_category) & (t.img.width > 1)
         ].show(10)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t[t.img.nearest(5)].show()
         assert 'requires' in str(exc_info.value)
 
@@ -548,9 +547,9 @@ class TestExprs:
         probe = t[t.img].show(1)
         img = probe[0, 0]
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[t.img.nearest(img)].show(10)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t[t.img.nearest('musical instrument')].show(10)
 
     def test_ids(
@@ -601,15 +600,15 @@ class TestExprs:
         assert len(subexprs) == 1
         assert t.img.equals(subexprs[0])
 
-    def test_window_fns(self, test_client: pt.Client, test_tbl: catalog.Table) -> None:
+    def test_window_fns(self, test_client: pxt.Client, test_tbl: catalog.Table) -> None:
         cl = test_client
         t = test_tbl
         _ = t.select(sum(t.c2, group_by=t.c4, order_by=t.c3)).show(100)
 
         # conflicting ordering requirements
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.select(sum(t.c2, group_by=t.c4, order_by=t.c3), sum(t.c2, group_by=t.c3, order_by=t.c4)).show(100)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.select(sum(t.c2, group_by=t.c4, order_by=t.c3), sum(t.c2, group_by=t.c3, order_by=t.c4)).show(100)
 
         # backfill works
@@ -622,7 +621,7 @@ class TestExprs:
         v = cl.create_view('frame_view', base_t, iterator_class=FrameIterator, iterator_args=args)
         # compatible ordering
         _ = v.select(v.frame, sum(v.frame_idx, group_by=base_t, order_by=v.pos)).show(100)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # incompatible ordering
             _ = v.select(v.frame, sum(v.c2, order_by=base_t, group_by=v.pos)).show(100)
 
@@ -643,23 +642,23 @@ class TestExprs:
             .group_by(t.c2 % 2).show()
 
         # check that aggregates don't show up in the wrong places
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # aggregate in where clause
             _ = t[sum(t.c2) > 0][sum(t.c2)].group_by(t.c2 % 2).show()
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # aggregate in group_by clause
             _ = t[sum(t.c2)].group_by(sum(t.c2)).show()
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # mixing aggregates and non-aggregates
             _ = t[sum(t.c2) + t.c2].group_by(t.c2 % 2).show()
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # nested aggregates
             _ = t[sum(count(t.c2))].group_by(t.c2 % 2).show()
 
     def test_udas(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
 
-        @pt.uda(
+        @pxt.uda(
             name='window_agg', init_types=[IntType()], update_types=[IntType()], value_type=IntType(),
             allows_window=True, requires_order_by=False)
         class WindowAgg:
@@ -670,7 +669,7 @@ class TestExprs:
             def value(self) -> int:
                 return self.val
 
-        @pt.uda(
+        @pxt.uda(
             name='ordered_agg', init_types=[IntType()], update_types=[IntType()], value_type=IntType(),
             requires_order_by=True, allows_window=True)
         class WindowAgg:
@@ -681,7 +680,7 @@ class TestExprs:
             def value(self) -> int:
                 return self.val
 
-        @pt.uda(
+        @pxt.uda(
             name='std_agg', init_types=[IntType()], update_types=[IntType()], value_type=IntType(),
             requires_order_by=False, allows_window=False)
         class StdAgg:
@@ -696,33 +695,33 @@ class TestExprs:
         assert t.select(out=window_agg(t.c2, order_by=t.c2)).collect()[0]['out'] == 0
         assert t.select(out=window_agg(t.c2, val=1, order_by=t.c2)).collect()[0]['out'] == 1
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(window_agg(t.c2, val=t.c2, order_by=t.c2)).collect()
         assert 'needs to be a constant' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # ordering expression not a pixeltable expr
             _ = t.select(ordered_agg(1, t.c2)).collect()
         assert 'but instead is a' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # explicit order_by
             _ = t.select(ordered_agg(t.c2, order_by=t.c2)).collect()
         assert 'order_by invalid' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # order_by for non-window function
             _ = t.select(std_agg(t.c2, order_by=t.c2)).collect()
         assert 'does not allow windows' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # group_by for non-window function
             _ = t.select(std_agg(t.c2, group_by=t.c4)).collect()
         assert 'group_by invalid' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # missing init type
-            @pt.uda(update_types=[IntType()], value_type=IntType())
+            @pxt.uda(update_types=[IntType()], value_type=IntType())
             class WindowAgg:
                 def __init__(self, val: int = 0):
                     self.val = val
@@ -732,9 +731,9 @@ class TestExprs:
                     return self.val
         assert 'init_types must be a list of' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # missing update parameter
-            @pt.uda(init_types=[IntType()], update_types=[], value_type=IntType())
+            @pxt.uda(init_types=[IntType()], update_types=[], value_type=IntType())
             class WindowAgg:
                 def __init__(self, val: int = 0):
                     self.val = val
@@ -744,9 +743,9 @@ class TestExprs:
                     return self.val
         assert 'must have at least one parameter' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # missing update type
-            @pt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
+            @pxt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
             class WindowAgg:
                 def __init__(self, val: int = 0):
                     self.val = val
@@ -756,9 +755,9 @@ class TestExprs:
                     return self.val
         assert 'update_types must be a list of' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # duplicate parameter names
-            @pt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
+            @pxt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
             class WindowAgg:
                 def __init__(self, val: int = 0):
                     self.val = val
@@ -768,9 +767,9 @@ class TestExprs:
                     return self.val
         assert 'cannot have parameters with the same name: val' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # invalid name
-            @pt.uda(name='not an identifier', init_types=[IntType()], update_types=[IntType()], value_type=IntType())
+            @pxt.uda(name='not an identifier', init_types=[IntType()], update_types=[IntType()], value_type=IntType())
             class WindowAgg:
                 def __init__(self, val: int = 0):
                     self.val = val
@@ -780,9 +779,9 @@ class TestExprs:
                     return self.val
         assert 'invalid name' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # reserved parameter name
-            @pt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
+            @pxt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
             class WindowAgg:
                 def __init__(self, val: int = 0):
                     self.val = val
@@ -792,9 +791,9 @@ class TestExprs:
                     return self.val
         assert 'order_by is reserved' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # reserved parameter name
-            @pt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
+            @pxt.uda(init_types=[IntType()], update_types=[IntType()], value_type=IntType())
             class WindowAgg:
                 def __init__(self, val: int = 0):
                     self.val = val

--- a/pixeltable/tests/test_functions.py
+++ b/pixeltable/tests/test_functions.py
@@ -2,7 +2,7 @@ from typing import Dict, Any
 
 import pytest
 
-import pixeltable as pt
+import pixeltable as pxt
 from pixeltable import catalog
 from pixeltable.env import Env
 from pixeltable.functions.pil.image import blend
@@ -16,7 +16,7 @@ class TestFunctions:
         t = img_tbl
         _ = t[t.img, t.img.rotate(90), blend(t.img, t.img.rotate(90), 0.5)].show()
 
-    def test_eval_detections(self, test_client: pt.Client) -> None:
+    def test_eval_detections(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('nos')
         cl = test_client
         video_t = cl.create_table('video_tbl', {'video': VideoType()})
@@ -51,7 +51,7 @@ class TestFunctions:
         # for k in common_classes:
         # assert ap_a[k] <= ap_b[k]
 
-    def test_str(self, test_client: pt.Client) -> None:
+    def test_str(self, test_client: pxt.Client) -> None:
         cl = test_client
         t = cl.create_table('test_tbl', {'input': StringType()})
         from pixeltable.functions.string import str_format
@@ -64,7 +64,7 @@ class TestFunctions:
         row = t.head()[0]
         assert row == {'input': 'MNO', 's1': 'ABC MNO', 's2': 'DEF MNO', 's3': 'GHI MNO JKL MNO'}
 
-    def test_openai(self, test_client: pt.Client) -> None:
+    def test_openai(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('openai')
         TestFunctions.skip_test_if_no_openai_client()
         if Env.get().openai_client is None:
@@ -86,7 +86,7 @@ class TestFunctions:
         t.insert([{'input': 'I find you really annoying'}])
         _ = t.head()
 
-    def test_gpt_4_vision(self, test_client: pt.Client) -> None:
+    def test_gpt_4_vision(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('openai')
         TestFunctions.skip_test_if_no_openai_client()
         cl = test_client
@@ -116,7 +116,7 @@ class TestFunctions:
         if Env.get().openai_client is None:
             pytest.skip(f'OpenAI client does not exist (missing API key?)')
 
-    def test_together(self, test_client: pt.Client) -> None:
+    def test_together(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('together')
         if not Env.get().has_together_client:
             pytest.skip(f'Together client does not exist (missing API key?)')
@@ -129,7 +129,7 @@ class TestFunctions:
         result = t.select(t.output_text).collect()['output_text'][0]
         assert len(result) > 0
 
-    def test_fireworks(self, test_client: pt.Client) -> None:
+    def test_fireworks(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('fireworks')
         try:
             from pixeltable.functions.fireworks import initialize
@@ -144,7 +144,7 @@ class TestFunctions:
         result = t.select(t.output).collect()['output'][0]
         assert len(result) > 0
 
-    def test_hf_function(self, test_client: pt.Client) -> None:
+    def test_hf_function(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('sentence_transformers')
         cl = test_client
         t = cl.create_table('test_tbl', {'input': StringType(), 'bool_col': BoolType()})
@@ -168,7 +168,7 @@ class TestFunctions:
         # TODO: is there some way to capture the output?
         t.describe()
 
-    def test_sentence_transformer(self, test_client: pt.Client) -> None:
+    def test_sentence_transformer(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('sentence_transformers')
         cl = test_client
         t = cl.create_table('test_tbl', {'input': StringType(), 'input_list': JsonType()})
@@ -198,14 +198,14 @@ class TestFunctions:
         verify_row(t.tail(1)[0])
 
         # execution still works after reload
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table('test_tbl')
         status = t.insert([{'input': s, 'input_list': sents} for s in sents])
         assert status.num_rows == len(sents)
         assert status.num_excs == 0
         verify_row(t.tail(1)[0])
 
-    def test_cross_encoder(self, test_client: pt.Client) -> None:
+    def test_cross_encoder(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('sentence_transformers')
         cl = test_client
         t = cl.create_table('test_tbl', {'input': StringType(), 'input_list': JsonType()})
@@ -233,14 +233,14 @@ class TestFunctions:
         verify_row(t.tail(1)[0])
 
         # execution still works after reload
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table('test_tbl')
         status = t.insert([{'input': s, 'input_list': sents} for s in sents])
         assert status.num_rows == len(sents)
         assert status.num_excs == 0
         verify_row(t.tail(1)[0])
 
-    def test_clip(self, test_client: pt.Client) -> None:
+    def test_clip(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('transformers')
         cl = test_client
         t = cl.create_table('test_tbl', {'text': StringType(), 'img': ImageType()})
@@ -270,7 +270,7 @@ class TestFunctions:
         verify_row(t.tail(1)[0])
 
         # execution still works after reload
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table('test_tbl')
         status = t.insert([{'text': text, 'img': img} for text, img in zip(sents, imgs)])
         assert status.num_rows == len(sents)

--- a/pixeltable/tests/test_functions.py
+++ b/pixeltable/tests/test_functions.py
@@ -106,7 +106,7 @@ class TestFunctions:
         t.add_column(response_content=t.response.choices[0].message.content)
         t.insert([{
             'prompt': "What's in this image?",
-            'img': 'https://raw.githubusercontent.com/mkornacker/pixeltable/master/docs/source/data/images/000000000009.jpg'
+            'img': 'https://raw.githubusercontent.com/pixeltable/pixeltable/master/docs/source/data/images/000000000009.jpg'
         }])
         result = t.collect()['response_content'][0]
         assert len(result) > 0

--- a/pixeltable/tests/test_migration.py
+++ b/pixeltable/tests/test_migration.py
@@ -5,7 +5,7 @@ import subprocess
 
 import pgserver
 
-import pixeltable as pt
+import pixeltable as pxt
 from pixeltable.env import Env
 from pixeltable.tests.conftest import clean_db
 
@@ -38,4 +38,4 @@ class TestMigration:
                 )
             # TODO(aaron-siegel) This will test that the migration succeeds without raising any exceptions.
             # We should also add some assertions to sanity-check the outcome.
-            _ = pt.Client()
+            _ = pxt.Client()

--- a/pixeltable/tests/test_nos.py
+++ b/pixeltable/tests/test_nos.py
@@ -1,13 +1,13 @@
 import pytest
 
-import pixeltable as pt
-from pixeltable.type_system import ImageType, VideoType
-from pixeltable.tests.utils import get_video_files, skip_test_if_not_installed
+import pixeltable as pxt
 from pixeltable.iterators import FrameIterator
+from pixeltable.tests.utils import get_video_files, skip_test_if_not_installed
+from pixeltable.type_system import ImageType, VideoType
 
 
 class TestNOS:
-    def test_basic(self, test_client: pt.Client) -> None:
+    def test_basic(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('nos')
         cl = test_client
         video_t = cl.create_table('video_tbl', {'video': VideoType()})
@@ -26,7 +26,7 @@ class TestNOS:
         status = video_t.insert([{'video': get_video_files()[0]}])
         pass
 
-    def test_exceptions(self, test_client: pt.Client) -> None:
+    def test_exceptions(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('nos')
         cl = test_client
         video_t = cl.create_table('video_tbl', {'video': VideoType()})
@@ -43,10 +43,10 @@ class TestNOS:
         assert v.where(v.detections.errortype != None).count() == 1
 
     @pytest.mark.skip(reason='too slow')
-    def test_sd(self, test_client: pt.Client) -> None:
+    def test_sd(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('nos')
         """Test model that mixes batched with scalar parameters"""
-        t = test_client.create_table('sd_test', {'prompt': pt.StringType()})
+        t = test_client.create_table('sd_test', {'prompt': pxt.StringType()})
         t.insert([{'prompt': 'cat on a sofa'}])
         from pixeltable.functions.nos.image_generation import stabilityai_stable_diffusion_2 as sd2
         t.add_column(img=sd2(t.prompt, 1, 512, 512), stored=True)

--- a/pixeltable/tests/test_table.py
+++ b/pixeltable/tests/test_table.py
@@ -297,7 +297,7 @@ class TestTable:
             },
             # test http url
             {
-                'media': 'https://github.com/mkornacker/pixeltable/raw/master/pixeltable/tests/data/videos/bangkok.mp4',
+                'media': 'https://github.com/pixeltable/pixeltable/raw/master/pixeltable/tests/data/videos/bangkok.mp4',
                 'is_bad_media': False
             },
 

--- a/pixeltable/tests/test_table.py
+++ b/pixeltable/tests/test_table.py
@@ -1,42 +1,42 @@
-import pytest
-import math
-import numpy as np
-import pandas as pd
 import datetime
-import random
+import math
 import os
+import random
+from typing import List, Tuple
 
 import PIL
 import cv2
+import numpy as np
+import pandas as pd
+import pytest
 
-from typing import List, Tuple
-import pixeltable as pt
+import pixeltable as pxt
 import pixeltable.functions as ptf
-from pixeltable import exceptions as exc
 from pixeltable import catalog
-from pixeltable.type_system import \
-    StringType, IntType, FloatType, TimestampType, ImageType, VideoType, JsonType, BoolType, ArrayType, AudioType, \
-    DocumentType
+from pixeltable import exceptions as excs
+from pixeltable.iterators import FrameIterator
 from pixeltable.tests.utils import \
     make_tbl, create_table_data, read_data_file, get_video_files, get_audio_files, get_image_files, get_documents, \
     assert_resultset_eq
-from pixeltable.utils.media_store import MediaStore
+from pixeltable.type_system import \
+    StringType, IntType, FloatType, TimestampType, ImageType, VideoType, JsonType, BoolType, ArrayType, AudioType, \
+    DocumentType
 from pixeltable.utils.filecache import FileCache
-from pixeltable.iterators import FrameIterator
+from pixeltable.utils.media_store import MediaStore
 
 
 class TestTable:
     # exc for a % 10 == 0
-    @pt.udf(return_type=FloatType(), param_types=[IntType()])
+    @pxt.udf(return_type=FloatType(), param_types=[IntType()])
     def f1(a: int) -> float:
         return a / (a % 10)
 
     # exception for a == None; this should not get triggered
-    @pt.udf(return_type=FloatType(), param_types=[FloatType()])
+    @pxt.udf(return_type=FloatType(), param_types=[FloatType()])
     def f2(a: float) -> float:
         return a + 1
 
-    def test_create(self, test_client: pt.Client) -> None:
+    def test_create(self, test_client: pxt.Client) -> None:
         cl = test_client
         cl.create_dir('dir1')
         schema = {
@@ -48,25 +48,25 @@ class TestTable:
         tbl = cl.create_table('test', schema)
         _ = cl.create_table('dir1.test', schema)
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = cl.create_table('1test', schema)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = catalog.Column('1c', StringType())
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = cl.create_table('test', schema)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = cl.create_table('dir2.test2', schema)
 
         _ = cl.list_tables()
         _ = cl.list_tables('dir1')
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = cl.list_tables('1dir')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = cl.list_tables('dir2')
 
         # test loading with new client
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
 
         tbl = cl.get_table('test')
         assert isinstance(tbl, catalog.InsertableTable)
@@ -79,14 +79,14 @@ class TestTable:
         cl.drop_table('test2')
         cl.drop_table('dir1.test')
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.drop_table('test')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.drop_table('dir1.test2')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             cl.drop_table('.test2')
 
-    def test_table_attrs(self, test_client: pt.Client) -> None:
+    def test_table_attrs(self, test_client: pxt.Client) -> None:
         cl = test_client
         schema = {'c': StringType(nullable=False)}
         num_retained_versions = 20
@@ -105,7 +105,7 @@ class TestTable:
         tbl.revert()
         assert tbl.num_retained_versions == num_retained_versions
 
-    def test_image_table(self, test_client: pt.Client) -> None:
+    def test_image_table(self, test_client: pxt.Client) -> None:
         n_sample_rows = 20
         cl = test_client
         schema = {
@@ -153,73 +153,73 @@ class TestTable:
         cl.drop_table('test')
         assert(MediaStore.count(tbl.get_id()) == 0)
 
-    def test_schema_spec(self, test_client: pt.Client) -> None:
+    def test_schema_spec(self, test_client: pxt.Client) -> None:
         cl = test_client
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c 1': IntType()})
         assert 'invalid column name' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {}})
         assert '"type" is required' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {'xyz': IntType()}})
         assert "invalid key 'xyz'" in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {'stored': True}})
         assert '"type" is required' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {'type': 'string'}})
         assert 'must be a ColumnType' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {'value': 1, 'type': StringType()}})
         assert '"type" is redundant' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {'value': pytest}})
         assert 'value needs to be either' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             def f() -> float:
                 return 1.0
             cl.create_table('test', {'c1': {'value': f}})
         assert '"type" is required' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {'type': StringType(), 'stored': 'true'}})
         assert '"stored" must be a bool' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': {'type': StringType(), 'indexed': 'true'}})
         assert '"indexed" must be a bool' in str(exc_info.value)
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': StringType()}, primary_key='c2')
         assert 'primary key column c2 not found' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': StringType()}, primary_key=['c1', 'c2'])
         assert 'primary key column c2 not found' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': StringType()}, primary_key=['c2'])
         assert 'primary key column c2 not found' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': StringType()}, primary_key=0)
         assert 'primary_key must be a' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.create_table('test', {'c1': StringType(nullable=True)}, primary_key='c1')
         assert 'cannot be nullable' in str(exc_info.value).lower()
 
     def check_bad_media(
-            self, test_client: pt.Client, rows: List[Tuple[str, bool]], col_type: pt.ColumnType,
+            self, test_client: pxt.Client, rows: List[Tuple[str, bool]], col_type: pxt.ColumnType,
             validate_local_path: bool = True
     ) -> None:
         schema = {
@@ -234,7 +234,7 @@ class TestTable:
 
         # Mode 1: Validation error on bad input (default)
         # we ignore the exact error here, because it depends on the media type
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             tbl.insert(rows, fail_on_exception=True)
 
         # Mode 2: ignore_errors=True, store error information in table
@@ -262,22 +262,22 @@ class TestTable:
             for path in paths:
                 assert os.path.exists(path) and os.path.isfile(path)
 
-    def test_validate_image(self, test_client: pt.Client) -> None:
+    def test_validate_image(self, test_client: pxt.Client) -> None:
         rows = read_data_file('imagenette2-160', 'manifest_bad.csv', ['img'])
         rows = [{'media': r['img'], 'is_bad_media': r['is_bad_image']} for r in rows]
         self.check_bad_media(test_client, rows, ImageType(nullable=True), validate_local_path=False)
 
-    def test_validate_video(self, test_client: pt.Client) -> None:
+    def test_validate_video(self, test_client: pxt.Client) -> None:
         files = get_video_files(include_bad_video=True)
         rows = [{'media': f, 'is_bad_media': f.endswith('bad_video.mp4')} for f in files]
         self.check_bad_media(test_client, rows, VideoType(nullable=True))
 
-    def test_validate_audio(self, test_client: pt.Client) -> None:
+    def test_validate_audio(self, test_client: pxt.Client) -> None:
         files = get_audio_files(include_bad_audio=True)
         rows = [{'media': f, 'is_bad_media': f.endswith('bad_audio.mp3')} for f in files]
         self.check_bad_media(test_client, rows, AudioType(nullable=True))
 
-    def test_validate_docs(self, test_client: pt.Client) -> None:
+    def test_validate_docs(self, test_client: pxt.Client) -> None:
         valid_doc_paths = get_documents()
         invalid_doc_paths = [get_video_files()[0], get_audio_files()[0], get_image_files()[0]]
         doc_paths = valid_doc_paths + invalid_doc_paths
@@ -285,7 +285,7 @@ class TestTable:
         rows = [{'media': f, 'is_bad_media': not is_valid} for f, is_valid in zip(doc_paths, is_valid)]
         self.check_bad_media(test_client, rows, DocumentType(nullable=True))
 
-    def test_validate_external_url(self, test_client: pt.Client) -> None:
+    def test_validate_external_url(self, test_client: pxt.Client) -> None:
         rows = [
             {'media': 's3://open-images-dataset/validation/doesnotexist.jpg', 'is_bad_media': True},
             {'media': 'https://archive.random.org/download?file=2024-01-28.bin', 'is_bad_media': True},  # 403 error
@@ -304,7 +304,7 @@ class TestTable:
         ]
         self.check_bad_media(test_client, rows, VideoType(nullable=True))
 
-    def test_create_s3_image_table(self, test_client: pt.Client) -> None:
+    def test_create_s3_image_table(self, test_client: pxt.Client) -> None:
         cl = test_client
         tbl = cl.create_table('test', {'img': ImageType(nullable=False)})
         # this is needed because Client.reset_catalog() doesn't call TableVersion.drop(), which would
@@ -346,7 +346,7 @@ class TestTable:
         assert cache_stats.num_hits == 0
 
         # start with fresh client and FileCache instance to test FileCache initialization with pre-existing files
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         # is there a better way to do this?
         FileCache._instance = None
         t = cl.get_table('test')
@@ -360,7 +360,7 @@ class TestTable:
         cache_stats = FileCache.get().stats()
         assert cache_stats.total_size == 0
 
-    def test_video_url(self, test_client: pt.Client) -> None:
+    def test_video_url(self, test_client: pxt.Client) -> None:
         cl = test_client
         schema = {
             'payload': IntType(nullable=False),
@@ -379,7 +379,7 @@ class TestTable:
         assert cap.isOpened()
         cap.release()
 
-    def test_create_video_table(self, test_client: pt.Client) -> None:
+    def test_create_video_table(self, test_client: pxt.Client) -> None:
         cl = test_client
         tbl = cl.create_table(
             'test_tbl',
@@ -392,7 +392,7 @@ class TestTable:
         # a non-materialized column that refers to another non-materialized column
         view.add_column(c4=view.c2.rotate(60), stored=False)
 
-        @pt.uda(
+        @pxt.uda(
             name='window_fn', update_types=[IntType()], value_type=IntType(), requires_order_by = True,
             allows_window = True)
         class WindowFnAggregator:
@@ -406,7 +406,7 @@ class TestTable:
         view.add_column(c5=window_fn(view.frame_idx, 1, group_by=view.video))
 
         # reload to make sure that metadata gets restored correctly
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         tbl = cl.get_table('test_tbl')
         view = cl.get_table('test_view')
         # we're inserting only a single row and the video column is not in position 0
@@ -428,23 +428,23 @@ class TestTable:
         tbl.revert()
         assert MediaStore.count(view.get_id()) == 0
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # can't drop frame col
             view.drop_column('frame')
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # can't drop frame_idx col
             view.drop_column('frame_idx')
 
         # drop() clears stored images and the cache
         tbl.insert([{'payload': 1, 'video': get_video_files()[0]}])
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             cl.drop_table('test_tbl')
         assert 'has dependents: test_view' in str(exc_info.value)
         cl.drop_table('test_view')
         cl.drop_table('test_tbl')
         assert MediaStore.count(view.get_id()) == 0
 
-    def test_insert(self, test_client: pt.Client) -> None:
+    def test_insert(self, test_client: pxt.Client) -> None:
         cl = test_client
         schema = {
             'c1': StringType(nullable=False),
@@ -477,12 +477,12 @@ class TestTable:
         assert status.num_excs == 0
 
         # empty input
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.insert([])
         assert 'empty' in str(exc_info.value)
 
         # missing column
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             # drop first column
             col_names = list(rows[0].keys())[1:]
             new_rows = [{col_name: row[col_name] for col_name in col_names} for row in rows]
@@ -493,32 +493,32 @@ class TestTable:
         for (col_name, col_type), value_col_name in zip(schema.items(), ['c2', 'c3', 'c5', 'c5', 'c6', 'c7', 'c2', 'c2']):
             cl.drop_table('test1', ignore_errors=True)
             t = cl.create_table('test1', {col_name: col_type})
-            with pytest.raises(exc.Error) as exc_info:
+            with pytest.raises(excs.Error) as exc_info:
                 t.insert([{col_name: r[value_col_name]} for r in rows])
             assert 'expected' in str(exc_info.value).lower()
 
         # rows not list of dicts
         cl.drop_table('test1', ignore_errors=True)
         t = cl.create_table('test1', {'c1': StringType()})
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.insert(['1'])
         assert 'list of dictionaries' in str(exc_info.value)
 
         # bad null value
         cl.drop_table('test1', ignore_errors=True)
         t = cl.create_table('test1', {'c1': StringType(nullable=False)})
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.insert([{'c1': None}])
         assert 'expected non-None' in str(exc_info.value)
 
         # bad array literal
         cl.drop_table('test1', ignore_errors=True)
         t = cl.create_table('test1', {'c5': ArrayType((2, 3), dtype=IntType(), nullable=False)})
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             t.insert([{'c5': np.ndarray((3, 2))}])
         assert 'expected ndarray((2, 3)' in str(exc_info.value)
 
-    def test_query(self, test_client: pt.Client) -> None:
+    def test_query(self, test_client: pxt.Client) -> None:
         cl = test_client
         col_names = ['c1', 'c2', 'c3', 'c4', 'c5']
         t = make_tbl(cl, 'test', col_names)
@@ -527,11 +527,11 @@ class TestTable:
         _ = t.show(n=0)
 
         # test querying existing table
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t2 = cl.get_table('test')
         _  = t2.show(n=0)
 
-    def test_update(self, test_tbl: pt.Table, indexed_img_tbl: pt.Table) -> None:
+    def test_update(self, test_tbl: pxt.Table, indexed_img_tbl: pxt.Table) -> None:
         t = test_tbl
         # update every type with a literal
         test_cases = [
@@ -584,7 +584,7 @@ class TestTable:
         assert np.all(t.order_by(t.computed3).show(0).to_pandas()['computed3'] == computed3)
 
         # revert, then verify that we're back to where we started
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         t.revert()
         assert t.where(t.c3 < 10.0).count() == 10
@@ -602,58 +602,58 @@ class TestTable:
         assert np.all(t.order_by(t.computed3).show(0).to_pandas()['computed3'][:10] == pd.Series([3.0] * 10))
 
         # bad update spec
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.update({1: 1})
         assert 'dict key' in str(excinfo.value)
 
         # unknown column
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.update({'unknown': 1})
         assert 'unknown unknown' in str(excinfo.value)
 
         # incompatible type
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.update({'c1': 1})
         assert 'not compatible' in str(excinfo.value)
 
         # can't update primary key
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.update({'c2': 1})
         assert 'primary key' in str(excinfo.value)
 
         # can't update computed column
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.update({'computed1': 1})
         assert 'is computed' in str(excinfo.value)
 
         # non-expr
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.update({'c3': lambda c3: math.sqrt(c3)})
         assert 'not a recognized' in str(excinfo.value)
 
         # non-Predicate filter
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.update({'c3': 1.0}, where=lambda c2: c2 == 10)
         assert 'Predicate' in str(excinfo.value)
 
         img_t = indexed_img_tbl
 
         # can't update image col
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             img_t.update({'img': 17}, where=img_t.img.nearest('car'))
         assert 'has type image' in str(excinfo.value)
 
         # similarity search is not supported
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             img_t.update({'split': 'train'}, where=img_t.img.nearest('car'))
         assert 'nearest()' in str(excinfo.value)
 
         # filter not expressible in SQL
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             img_t.update({'split': 'train'}, where=img_t.img.width > 100)
         assert 'not expressible' in str(excinfo.value)
 
-    def test_cascading_update(self, test_tbl: pt.InsertableTable) -> None:
+    def test_cascading_update(self, test_tbl: pxt.InsertableTable) -> None:
         t = test_tbl
         t.add_column(d1=t.c3 - 1)
         # add column that can be updated
@@ -666,7 +666,7 @@ class TestTable:
         r2 = t.where(t.c2 < 5).select(t.c3, t.c10, t.d1, t.d2).order_by(t.c2).show(0)
         assert_resultset_eq(r1, r2)
 
-    def test_delete(self, test_tbl: pt.Table, indexed_img_tbl: pt.Table) -> None:
+    def test_delete(self, test_tbl: pxt.Table, indexed_img_tbl: pxt.Table) -> None:
         t = test_tbl
 
         cnt = t.where(t.c3 < 10.0).count()
@@ -681,7 +681,7 @@ class TestTable:
         assert cnt == 1
 
         # revert, then verify that we're back where we started
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         t.revert()
         cnt = t.where(t.c3 < 10.0).count()
@@ -690,29 +690,29 @@ class TestTable:
         assert cnt == 1
 
         # non-Predicate filter
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t.delete(where=lambda c2: c2 == 10)
         assert 'Predicate' in str(excinfo.value)
 
         img_t = indexed_img_tbl
         # similarity search is not supported
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             img_t.delete(where=img_t.img.nearest('car'))
         assert 'nearest()' in str(excinfo.value)
 
         # filter not expressible in SQL
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             img_t.delete(where=img_t.img.width > 100)
         assert 'not expressible' in str(excinfo.value)
 
-    def test_computed_cols(self, test_client: pt.client) -> None:
+    def test_computed_cols(self, test_client: pxt.client) -> None:
         cl = test_client
         schema = {
             'c1': IntType(nullable=False),
             'c2': FloatType(nullable=False),
             'c3': JsonType(nullable=False),
         }
-        t : pt.InsertableTable = cl.create_table('test', schema)
+        t : pxt.InsertableTable = cl.create_table('test', schema)
         status = t.add_column(c4=t.c1 + 1)
         assert status.num_excs == 0
         status = t.add_column(c5=t.c4 + 1)
@@ -727,7 +727,7 @@ class TestTable:
         assert status.num_excs == 0
 
         # unstored cols that compute window functions aren't currently supported
-        with pytest.raises((exc.Error)):
+        with pytest.raises((excs.Error)):
             t.add_column(c10=ptf.sum(t.c1, group_by=t.c1), stored=False)
 
         # Column.dependent_cols are computed correctly
@@ -745,12 +745,12 @@ class TestTable:
         _ = t.show()
 
         # not allowed to pass values for computed cols
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             rows2 = create_table_data(t, ['c1', 'c2', 'c3', 'c4'], num_rows=10)
             t.insert(rows2)
 
         # test loading from store
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table('test')
         assert len(t.columns()) == len(t.columns())
         for i in range(len(t.columns())):
@@ -764,13 +764,13 @@ class TestTable:
         tbl_df = t.show(0).to_pandas()
 
         # can't drop c4: c5 depends on it
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             t.drop_column('c4')
         t.drop_column('c5')
         # now it works
         t.drop_column('c4')
 
-    def test_computed_col_exceptions(self, test_client: pt.Client, test_tbl: catalog.Table) -> None:
+    def test_computed_col_exceptions(self, test_client: pxt.Client, test_tbl: catalog.Table) -> None:
         cl = test_client
 
         # exception during insert()
@@ -804,7 +804,7 @@ class TestTable:
         assert MediaStore.count(t.get_id()) == t.count() * stores_img_col
 
         # test loading from store
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t2 = cl.get_table(t.get_name())
         assert len(t.columns()) == len(t2.columns())
         for i in range(len(t.columns())):
@@ -821,7 +821,7 @@ class TestTable:
         t2.revert()
         assert MediaStore.count(t2.get_id()) == t2.count() * stores_img_col
 
-    def test_computed_img_cols(self, test_client: pt.Client) -> None:
+    def test_computed_img_cols(self, test_client: pxt.Client) -> None:
         cl = test_client
         schema = {'img': ImageType(nullable=False)}
         t = cl.create_table('test', schema)
@@ -838,7 +838,7 @@ class TestTable:
 
         # computed img col with exceptions
         t = cl.create_table('test3', schema)
-        @pt.udf(return_type=ImageType(), param_types=[ImageType()])
+        @pxt.udf(return_type=ImageType(), param_types=[ImageType()])
         def f(img: PIL.Image.Image) -> PIL.Image.Image:
             raise RuntimeError
         t.add_column(c3=f(t.img), stored=True)
@@ -847,7 +847,7 @@ class TestTable:
         t.insert(rows, fail_on_exception=False)
         _ = t[t.c3.errortype].show(0)
 
-    def test_computed_window_fn(self, test_client: pt.Client, test_tbl: catalog.Table) -> None:
+    def test_computed_window_fn(self, test_client: pxt.Client, test_tbl: catalog.Table) -> None:
         cl = test_client
         t = test_tbl
         # backfill
@@ -865,7 +865,7 @@ class TestTable:
         new_t.insert(rows)
         _ = new_t.show(0)
 
-    def test_revert(self, test_client: pt.Client) -> None:
+    def test_revert(self, test_client: pxt.Client) -> None:
         cl = test_client
         t1 = make_tbl(cl, 'test1', ['c1', 'c2'])
         assert t1.version() == 0
@@ -887,55 +887,55 @@ class TestTable:
         # can't revert past version 0
         t1.revert()
         t1.revert()
-        with pytest.raises(exc.Error) as excinfo:
+        with pytest.raises(excs.Error) as excinfo:
             t1.revert()
         assert 'version 0' in str(excinfo.value)
 
     def test_add_column(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
         num_orig_cols = len(t.columns())
-        t.add_column(add1=pt.IntType(nullable=True))
+        t.add_column(add1=pxt.IntType(nullable=True))
         assert len(t.columns()) == num_orig_cols + 1
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t.add_column(add2=pt.IntType(nullable=False))
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.add_column(add2=pxt.IntType(nullable=False))
         assert 'cannot add non-nullable' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t.add_column(add2=pt.IntType(nullable=False), add3=pt.StringType())
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.add_column(add2=pxt.IntType(nullable=False), add3=pxt.StringType())
         assert 'requires exactly one keyword argument' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t.add_column(pos=pt.StringType(nullable=True))
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.add_column(pos=pxt.StringType(nullable=True))
         assert 'is reserved' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t.add_column(add2=pt.IntType(nullable=False), type=pt.StringType())
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.add_column(add2=pxt.IntType(nullable=False), type=pxt.StringType())
         assert '"type" is redundant' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t.add_column(add2=[[1.0, 2.0], [3.0, 4.0]], type=pt.StringType())
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.add_column(add2=[[1.0, 2.0], [3.0, 4.0]], type=pxt.StringType())
         assert '"type" is redundant' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t.add_column(add2=pt.IntType(nullable=False), stored=False)
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.add_column(add2=pxt.IntType(nullable=False), stored=False)
         assert 'stored=false only applies' in str(exc_info.value).lower()
 
         # duplicate name
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t.add_column(c1=pt.IntType())
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.add_column(c1=pxt.IntType())
         assert 'duplicate column name' in str(exc_info.value).lower()
 
         # 'stored' kwarg only applies to computed image columns
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.add_column(c5=IntType(), stored=False)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.add_column(c5=ImageType(), stored=False)
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             _ = t.add_column(c5=(t.c2 + t.c3), stored=False)
 
         # make sure this is still true after reloading the metadata
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         assert len(t.columns()) == num_orig_cols + 1
 
@@ -944,49 +944,49 @@ class TestTable:
         assert len(t.columns()) == num_orig_cols
 
         # make sure this is still true after reloading the metadata once more
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         assert len(t.columns()) == num_orig_cols
 
     def test_add_column_setitem(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
         num_orig_cols = len(t.columns())
-        t['add1'] = pt.IntType(nullable=True)
+        t['add1'] = pxt.IntType(nullable=True)
         assert len(t.columns()) == num_orig_cols + 1
         t['computed1'] = t.c2 + 1
         assert len(t.columns()) == num_orig_cols + 2
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t['pos'] = pt.StringType()
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t['pos'] = pxt.StringType()
         assert 'is reserved' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t[2] = pt.StringType()
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t[2] = pxt.StringType()
         assert 'must be a string' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t['add 2'] = pt.StringType()
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t['add 2'] = pxt.StringType()
         assert 'invalid column name' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t['add2'] = {'value': t.c2 + 1, 'type': pt.StringType()}
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t['add2'] = {'value': t.c2 + 1, 'type': pxt.StringType()}
         assert '"type" is redundant' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t['add2'] = {'value': pt.IntType()}
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t['add2'] = {'value': pxt.IntType()}
         assert 'value needs to be either' in str(exc_info.value).lower()
 
-        with pytest.raises(exc.Error) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t['add2'] = {'value': t.c2 + 1, 'stored': False}
         assert 'stored=false only applies' in str(exc_info.value).lower()
 
         # duplicate name
-        with pytest.raises(exc.Error) as exc_info:
-            _ = t['c1'] = pt.IntType()
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t['c1'] = pxt.IntType()
         assert 'duplicate column name' in str(exc_info.value).lower()
 
         # make sure this is still true after reloading the metadata
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         assert len(t.columns()) == num_orig_cols + 2
 
@@ -996,7 +996,7 @@ class TestTable:
         assert len(t.columns()) == num_orig_cols
 
         # make sure this is still true after reloading the metadata once more
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         assert len(t.columns()) == num_orig_cols
 
@@ -1006,11 +1006,11 @@ class TestTable:
         t.drop_column('c1')
         assert len(t.columns()) == num_orig_cols - 1
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             t.drop_column('unknown')
 
         # make sure this is still true after reloading the metadata
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         assert len(t.columns()) == num_orig_cols - 1
 
@@ -1019,7 +1019,7 @@ class TestTable:
         assert len(t.columns()) == num_orig_cols
 
         # make sure this is still true after reloading the metadata once more
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         assert len(t.columns()) == num_orig_cols
 
@@ -1029,7 +1029,7 @@ class TestTable:
         t.rename_column('c1', 'c1_renamed')
         assert len(t.columns()) == num_orig_cols
 
-        def check_rename(t: pt.Table, known: str, unknown: str) -> None:
+        def check_rename(t: pxt.Table, known: str, unknown: str) -> None:
             with pytest.raises(AttributeError) as exc_info:
                 _ = t.select(t[unknown]).collect()
             assert 'unknown' in str(exc_info.value).lower()
@@ -1038,17 +1038,17 @@ class TestTable:
         check_rename(t, 'c1_renamed', 'c1')
 
         # unknown column
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             t.rename_column('unknown', 'unknown_renamed')
         # bad name
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             t.rename_column('c2', 'bad name')
         # existing name
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             t.rename_column('c2', 'c3')
 
         # make sure this is still true after reloading the metadata
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         check_rename(t, 'c1_renamed', 'c1')
 
@@ -1058,7 +1058,7 @@ class TestTable:
         #check_rename(t, 'c1', 'c1_renamed')
 
         # make sure this is still true after reloading the metadata once more
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         t = cl.get_table(t.get_name())
         check_rename(t, 'c1', 'c1_renamed')
 
@@ -1069,7 +1069,7 @@ class TestTable:
         _ = t.show()
 
         # with exception in SQL
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             t.add_column(add2=(t.c2 - 10) / (t.c3 - 10))
 
         # with exception in Python for c6.f2 == 10
@@ -1096,7 +1096,7 @@ class TestTable:
         _ = repr(t)
         _ = t._repr_html_()
 
-    def test_common_col_names(self, test_client: pt.Client) -> None:
+    def test_common_col_names(self, test_client: pxt.Client) -> None:
         """Make sure that commonly used column names don't collide with Table member vars"""
         cl = test_client
         schema = {'id': IntType(nullable=False), 'name': StringType(nullable=False)}

--- a/pixeltable/tests/test_transactional_directory.py
+++ b/pixeltable/tests/test_transactional_directory.py
@@ -1,6 +1,7 @@
-from pixeltable.utils.transactional_directory import transactional_directory
 import pathlib
 import tempfile
+
+from pixeltable.utils.transactional_directory import transactional_directory
 
 
 class MyException(Exception):

--- a/pixeltable/tests/test_types.py
+++ b/pixeltable/tests/test_types.py
@@ -1,11 +1,5 @@
-import pytest
-import pandas as pd
-
-import pixeltable as pt
 from pixeltable.type_system import \
     ColumnType, StringType, IntType, BoolType, ImageType, InvalidType, FloatType, TimestampType, JsonType, ArrayType
-from pixeltable.tests.utils import get_video_files
-from pixeltable import catalog
 
 
 class TestTypes:

--- a/pixeltable/tests/test_video.py
+++ b/pixeltable/tests/test_video.py
@@ -1,19 +1,20 @@
 from typing import Optional, List, Tuple
-import pytest
-import PIL
 
-import pixeltable as pt
-from pixeltable.type_system import VideoType, IntType, ImageType
-from pixeltable.tests.utils import get_video_files
+import PIL
+import pytest
+
+import pixeltable as pxt
 from pixeltable import catalog
-from pixeltable import exceptions as exc
-from pixeltable.utils.media_store import MediaStore
+from pixeltable import exceptions as excs
 from pixeltable.iterators import FrameIterator
+from pixeltable.tests.utils import get_video_files
+from pixeltable.type_system import VideoType, ImageType
+from pixeltable.utils.media_store import MediaStore
 
 
 class TestVideo:
     def create_tbls(
-            self, cl: pt.Client, base_name: str = 'video_tbl', view_name: str = 'frame_view'
+            self, cl: pxt.Client, base_name: str = 'video_tbl', view_name: str = 'frame_view'
     ) -> Tuple[catalog.InsertableTable, catalog.Table]:
         cl.drop_table(view_name, ignore_errors=True)
         cl.drop_table(base_name, ignore_errors=True)
@@ -23,7 +24,7 @@ class TestVideo:
         return base_t, view_t
 
     def create_and_insert(
-            self, cl: pt.Client, stored: Optional[bool], paths: List[str]
+            self, cl: pxt.Client, stored: Optional[bool], paths: List[str]
     ) -> Tuple[catalog.InsertableTable, catalog.Table]:
         base_t, view_t = self.create_tbls(cl)
 
@@ -38,7 +39,7 @@ class TestVideo:
         assert len(result) == total_num_rows
         return base_t, view_t
 
-    def test_basic(self, test_client: pt.Client) -> None:
+    def test_basic(self, test_client: pxt.Client) -> None:
         video_filepaths = get_video_files()
         cl = test_client
 
@@ -59,7 +60,7 @@ class TestVideo:
         tbl.revert()
         assert MediaStore.count(view.get_id()) == view.count()
 
-    def test_query(self, test_client: pt.client) -> None:
+    def test_query(self, test_client: pxt.client) -> None:
         video_filepaths = get_video_files()
         cl = test_client
         base_t, view_t = self.create_tbls(cl)
@@ -76,7 +77,7 @@ class TestVideo:
         res = view_t.where(view_t.video == url).collect()
         assert len(res) == len(all_rows[all_rows.url == url])
 
-    def test_fps(self, test_client: pt.client) -> None:
+    def test_fps(self, test_client: pxt.client) -> None:
         cl = test_client
         path = get_video_files()[0]
         videos = cl.create_table('videos', {'video': VideoType()})
@@ -90,7 +91,7 @@ class TestVideo:
         assert frames_0_5.count() == frames_1_0.count() // 2 or frames_0_5.count() == frames_1_0.count() // 2 + 1
         assert frames_0_33.count() == frames_1_0.count() // 3 or frames_0_33.count() == frames_1_0.count() // 3 + 1
 
-    def test_computed_cols(self, test_client: pt.client) -> None:
+    def test_computed_cols(self, test_client: pxt.client) -> None:
         video_filepaths = get_video_files()
         cl = test_client
         base_t, view_t = self.create_tbls(cl)
@@ -104,7 +105,7 @@ class TestVideo:
         base_t.insert([{'video': p} for p in video_filepaths])
         _ = view_t[view_t.c1, view_t.c2, view_t.c3, view_t.c4].show(0)
 
-    def test_make_video(self, test_client: pt.Client) -> None:
+    def test_make_video(self, test_client: pxt.Client) -> None:
         video_filepaths = get_video_files()
         cl = test_client
         base_t, view_t = self.create_tbls(cl)
@@ -116,20 +117,20 @@ class TestVideo:
         view_t.add_column(transformed=view_t.frame.rotate(30), stored=True)
         _ = view_t.select(make_video(view_t.pos, view_t.transformed)).group_by(base_t).show()
 
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # make_video() doesn't allow windows
             _ = view_t.select(make_video(view_t.pos, view_t.frame, group_by=base_t)).show()
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # make_video() requires ordering
             _ = view_t.select(make_video(view_t.frame, order_by=view_t.pos)).show()
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             # incompatible ordering requirements
             _ = view_t.select(
                 make_video(view_t.pos, view_t.frame),
                 make_video(view_t.pos - 1, view_t.transformed)).group_by(base_t).show()
 
         # window function that simply passes through the frame
-        @pt.uda(
+        @pxt.uda(
             update_types=[ImageType()], value_type=ImageType(), name='agg_fn',
             requires_order_by=True, allows_std_agg=False, allows_window=True)
         class WindowAgg:
@@ -147,10 +148,10 @@ class TestVideo:
         _ = view_t.select(make_video(view_t.pos, view_t.agg)).group_by(base_t).show()
 
         # image cols computed with a window function currently need to be stored
-        with pytest.raises(exc.Error):
+        with pytest.raises(excs.Error):
             view_t.add_column(agg2=agg_fn(view_t.pos, view_t.frame, group_by=base_t), stored=False)
 
         # reload from store
-        cl = pt.Client(reload=True)
+        cl = pxt.Client(reload=True)
         base_t, view_t = cl.get_table(base_t.get_name()), cl.get_table(view_t.get_name())
         _ = view_t.select(agg_fn(view_t.pos, view_t.frame, group_by=base_t)).show()

--- a/pixeltable/tests/utils.py
+++ b/pixeltable/tests/utils.py
@@ -1,21 +1,21 @@
 import datetime
 import glob
-import os
-import pytest
-from pathlib import Path
-from typing import Dict, Any, List, Tuple, Optional
 import json
+import os
+from pathlib import Path
+from typing import Dict, Any, List, Optional
 
 import numpy as np
 import pandas as pd
+import pytest
 
-import pixeltable as pt
+import pixeltable as pxt
+import pixeltable.type_system as ts
 from pixeltable import catalog
+from pixeltable.dataframe import DataFrameResultSet
 from pixeltable.env import Env
 from pixeltable.type_system import \
     ColumnType, StringType, IntType, FloatType, ArrayType, BoolType, TimestampType, JsonType, ImageType, VideoType
-from pixeltable.dataframe import DataFrameResultSet
-import pixeltable.type_system as ts
 
 
 def make_default_type(t: ColumnType.Type) -> ColumnType:
@@ -31,7 +31,7 @@ def make_default_type(t: ColumnType.Type) -> ColumnType:
         return TimestampType()
     assert False
 
-def make_tbl(cl: pt.Client, name: str = 'test', col_names: Optional[List[str]] = None) -> catalog.InsertableTable:
+def make_tbl(cl: pxt.Client, name: str = 'test', col_names: Optional[List[str]] = None) -> catalog.InsertableTable:
     if col_names is None:
         col_names = ['c1']
     schema: Dict[str, ts.ColumnType] = {}
@@ -112,7 +112,7 @@ def create_table_data(t: catalog.Table, col_names: Optional[List[str]] = None, n
     rows = [{col_name: data[col_name][i] for col_name in col_names} for i in range(num_rows)]
     return rows
 
-def create_test_tbl(client: pt.Client, name: str = 'test_tbl') -> catalog.Table:
+def create_test_tbl(client: pxt.Client, name: str = 'test_tbl') -> catalog.Table:
     schema = {
         'c1': StringType(nullable=False),
         'c1n': StringType(nullable=True),
@@ -177,7 +177,7 @@ def create_test_tbl(client: pt.Client, name: str = 'test_tbl') -> catalog.Table:
     t.insert(rows)
     return t
 
-def create_all_datatypes_tbl(test_client: pt.Client) -> catalog.Table:
+def create_all_datatypes_tbl(test_client: pxt.Client) -> catalog.Table:
     """ Creates a table with all supported datatypes.
     """
     schema = {

--- a/pixeltable/tool/create_test_db_dump.py
+++ b/pixeltable/tool/create_test_db_dump.py
@@ -8,7 +8,7 @@ import subprocess
 import pgserver
 import toml
 
-import pixeltable as pt
+import pixeltable as pxt
 import pixeltable.metadata as metadata
 from pixeltable.env import Env
 from pixeltable.type_system import \
@@ -30,7 +30,7 @@ class Dumper:
         os.environ['PIXELTABLE_PGDATA'] = str(shared_home / 'pgdata')
 
         Env.get().set_up(reinit_db=True)
-        self.cl = pt.Client()
+        self.cl = pxt.Client()
         self.cl.logging(level=logging.DEBUG, to_stdout=True)
 
     def dump_db(self) -> None:

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -15,7 +15,7 @@ import av
 import numpy as np
 import sqlalchemy as sql
 
-from pixeltable import exceptions as exc
+from pixeltable import exceptions as excs
 
 
 class ColumnType:
@@ -385,7 +385,6 @@ class ColumnType:
 
     @abc.abstractmethod
     def to_arrow_type(self) -> 'pyarrow.DataType':
-        import pyarrow as pa # pylint: disable=import-outside-toplevel
         assert False, f'Have not implemented {self.__class__.__name__} to Arrow'
  
     @staticmethod
@@ -804,7 +803,7 @@ class ImageType(ColumnType):
         try:
             _ = PIL.Image.open(val)
         except PIL.UnidentifiedImageError:
-            raise exc.Error(f'Not a valid image: {val}') from None
+            raise excs.Error(f'Not a valid image: {val}') from None
 
 class VideoType(ColumnType):
     def __init__(self, nullable: bool = False):
@@ -829,7 +828,7 @@ class VideoType(ColumnType):
         try:
             with av.open(val, 'r') as fh:
                 if len(fh.streams.video) == 0:
-                    raise exc.Error(f'Not a valid video: {val}')
+                    raise excs.Error(f'Not a valid video: {val}')
                 # decode a few frames to make sure it's playable
                 # TODO: decode all frames? but that's very slow
                 num_decoded = 0
@@ -840,9 +839,9 @@ class VideoType(ColumnType):
                         break
                 if num_decoded < 2:
                     # this is most likely an image file
-                    raise exc.Error(f'Not a valid video: {val}')
+                    raise excs.Error(f'Not a valid video: {val}')
         except av.AVError:
-            raise exc.Error(f'Not a valid video: {val}') from None
+            raise excs.Error(f'Not a valid video: {val}') from None
 
 class AudioType(ColumnType):
     def __init__(self, nullable: bool = False):
@@ -866,7 +865,7 @@ class AudioType(ColumnType):
         try:
             with av.open(val) as container:
                 if len(container.streams.audio) == 0:
-                    raise exc.Error(f'No audio stream in file: {val}')
+                    raise excs.Error(f'No audio stream in file: {val}')
                 audio_stream = container.streams.audio[0]
 
                 # decode everything to make sure it's playable
@@ -875,7 +874,7 @@ class AudioType(ColumnType):
                     for _ in packet.decode():
                         pass
         except av.AVError as e:
-            raise exc.Error(f'Not a valid audio file: {val}\n{e}') from None
+            raise excs.Error(f'Not a valid audio file: {val}\n{e}') from None
 
 class DocumentType(ColumnType):
     @enum.unique
@@ -917,9 +916,9 @@ class DocumentType(ColumnType):
                 s = fh.read()
                 dh = get_document_handle(s)
                 if dh is None:
-                    raise exc.Error(f'Not a recognized document format: {val}')
+                    raise excs.Error(f'Not a recognized document format: {val}')
             except Exception as e:
-                raise exc.Error(f'Not a recognized document format: {val}') from None
+                raise excs.Error(f'Not a recognized document format: {val}') from None
 
 
 # A dictionary mapping various Python types to their respective ColumnTypes.

--- a/pixeltable/utils/pytorch.py
+++ b/pixeltable/utils/pytorch.py
@@ -81,7 +81,7 @@ class PixeltablePytorchDataset(torch.utils.data.IterableDataset):
 
             # use arr instead of im in ToTensor() to guarantee array input
             # to torch.from_numpy is writable. Using im is a suspected cause of
-            # https://github.com/mkornacker/pixeltable/issues/69
+            # https://github.com/pixeltable/pixeltable/issues/69
             return torchvision.transforms.ToTensor()(arr)
         elif self.column_types[k].is_json_type():
             assert isinstance(v, str)

--- a/pixeltable/utils/transactional_directory.py
+++ b/pixeltable/utils/transactional_directory.py
@@ -1,8 +1,9 @@
-from contextlib import contextmanager
-import pixeltable.exceptions as exc
-from typing import Any, Generator
-from pathlib import Path
 import shutil
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Generator
+
+import pixeltable.exceptions as excs
 
 
 @contextmanager
@@ -23,7 +24,7 @@ def transactional_directory(folder_path: Path) -> Generator[Path, Any, Any]:
             (temp_folder / "subfolder2").mkdir()
     """
     if folder_path.exists():
-        raise exc.Error(f"Folder {folder_path} already exists")
+        raise excs.Error(f"Folder {folder_path} already exists")
 
     tmp_folder = folder_path.parent / f".tmp_{folder_path.name}"
     # Remove the temporary folder if it already exists, eg if the previous run crashed


### PR DESCRIPTION
- Replace references to `mkornacker` fork with references to official `pixeltable` organization repo
- Standardize import names: `import pixeltable as pxt`, `import pixeltable.exceptions as excs`
- Reorganize imports in affected files to conform to PEP8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pixeltable/pixeltable/107)
<!-- Reviewable:end -->
