### PR TITLE
Fix broken retries in unit tests

### DIFF
--- a/pixeltable/functions/openai.py
+++ b/pixeltable/functions/openai.py
@@ -26,8 +26,8 @@ def openai_client() -> openai.OpenAI:
 def _retry(fn: Callable) -> Callable:
     return tenacity.retry(
         retry=tenacity.retry_if_exception_type(openai.RateLimitError),
-        wait=tenacity.wait_random_exponential(min=1, max=60),
-        stop=tenacity.stop_after_attempt(6)
+        wait=tenacity.wait_random_exponential(multiplier=3, max=180),
+        stop=tenacity.stop_after_attempt(20)
     )(fn)
 
 

--- a/pixeltable/tests/functions/test_openai.py
+++ b/pixeltable/tests/functions/test_openai.py
@@ -33,8 +33,8 @@ class TestOpenai:
         results = t.collect()
         assert results[0]['transcription']['text'] in ['I am a banana.', "I'm a banana."]
         assert results[0]['transcription_2']['text'] in ['I am a banana.', "I'm a banana."]
-        assert 'easy to translate from Spanish' in results[1]['translation']['text']
-        assert 'easy to translate from Spanish' in results[1]['translation_2']['text']
+        assert 'easy to translate' in results[1]['translation']['text']
+        assert 'easy to translate' in results[1]['translation_2']['text']
 
     def test_chat_completions(self, test_client: pxt.Client) -> None:
         skip_test_if_not_installed('openai')


### PR DESCRIPTION
Increases the retry window and number of retry attempts for OpenAI unit tests. This is necessary because of the strict rate limits on my low-tier personal account. We can continue to iterate on the right rate limit settings if need be - I didn't think them through too much; I just want to get the unit tests working again in CI.

Also contains an unrelated tweak for a slightly flaky unit test.