### PR TITLE
Fix broken udf in eval.py

### DIFF
--- a/pixeltable/functions/eval.py
+++ b/pixeltable/functions/eval.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List, Tuple, Dict
 from collections import defaultdict
 import sys

--- a/pixeltable/tests/test_types.py
+++ b/pixeltable/tests/test_types.py
@@ -1,3 +1,7 @@
+import datetime
+from copy import copy
+from typing import List, Dict, Optional
+
 from pixeltable.type_system import \
     ColumnType, StringType, IntType, BoolType, ImageType, InvalidType, FloatType, TimestampType, JsonType, ArrayType
 
@@ -20,3 +24,29 @@ class TestTypes:
             t_serialized = t.serialize()
             t_deserialized = ColumnType.deserialize(t_serialized)
             assert t == t_deserialized
+
+    def test_from_python_type(self) -> None:
+        test_cases = {
+            str: StringType(),
+            int: IntType(),
+            float: FloatType(),
+            bool: BoolType(),
+            datetime.date: TimestampType(),
+            datetime.datetime: TimestampType(),
+            list: JsonType(),
+            dict: JsonType(),
+            list[int]: JsonType(),
+            list[dict[str, int]]: JsonType(),
+            dict[int, str]: JsonType(),
+            dict[dict[str, int], list[int]]: JsonType(),
+            List: JsonType(),
+            Dict: JsonType(),
+            List[int]: JsonType(),
+            List[Dict[str, int]]: JsonType(),
+            Dict[int, str]: JsonType()
+        }
+        for py_type, pxt_type in test_cases.items():
+            assert ColumnType.from_python_type(py_type) == pxt_type
+            opt_pxt_type = copy(pxt_type)
+            opt_pxt_type.nullable = True
+            assert ColumnType.from_python_type(Optional[py_type]) == opt_pxt_type


### PR DESCRIPTION
If `from __future__ import annotations` appears in a .py file, then any udfs in that file will fail to load. This is because for any function `fn` defined in that file, `inspect.signature(fn)` will contain strings rather than type objects.

This PR does not fix the underlying issue, but merely removes `from __future__ import annotations` from eval.py, remediating the broken udf in that file.

It also contains a unit test for `from_python_type` that turned out to be unrelated to the actual issue, but is nonetheless a good thing to have.