### PR TITLE
Support for batch updates

### DIFF
--- a/pixeltable/catalog/column.py
+++ b/pixeltable/catalog/column.py
@@ -22,7 +22,7 @@ class Column:
     def __init__(
             self, name: str, col_type: Optional[ColumnType] = None,
             computed_with: Optional[Union['Expr', Callable]] = None,
-            primary_key: bool = False, stored: Optional[bool] = None,
+            is_primary_key: bool = False, stored: Optional[bool] = None,
             indexed: bool = False,
             # these parameters aren't set by users
             col_id: Optional[int] = None):
@@ -32,7 +32,7 @@ class Column:
             name: column name
             col_type: column type; can be None if the type can be derived from ``computed_with``
             computed_with: a callable or an Expr object that computes the column value
-            primary_key: if True, this column is part of the primary key
+            is_primary_key: if True, this column is part of the primary key
             stored: determines whether a computed column is present in the stored table or recomputed on demand
             indexed: if True, this column has a nearest neighbor index (only valid for image columns)
             col_id: column ID (only used internally)
@@ -90,7 +90,7 @@ class Column:
         self.stored = stored
         self.dependent_cols: Set[Column] = set()  # cols with value_exprs that reference us; set by TableVersion
         self.id = col_id
-        self.primary_key = primary_key
+        self.is_primary_key = is_primary_key
 
         # column in the stored table for the values of this Column
         self.sa_col: Optional[sql.schema.Column] = None
@@ -114,7 +114,7 @@ class Column:
         Leaves out value_expr, because that requires TableVersion.cols to be complete.
         """
         col = cls(
-            md.name, col_type=ColumnType.from_dict(md.col_type), primary_key=md.is_pk,
+            md.name, col_type=ColumnType.from_dict(md.col_type), is_primary_key=md.is_pk,
             stored=md.stored, indexed=md.is_indexed, col_id=col_id)
         col.tbl = tbl
         return col

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -158,7 +158,7 @@ class TableVersion:
             value_expr_dict = col.value_expr.as_dict() if col.value_expr is not None else None
             column_md[col.id] = schema.SchemaColumn(
                 pos=pos, name=col.name, col_type=col.col_type.as_dict(),
-                is_pk=col.primary_key, value_expr=value_expr_dict, stored=col.stored, is_indexed=col.is_indexed)
+                is_pk=col.is_primary_key, value_expr=value_expr_dict, stored=col.stored, is_indexed=col.is_indexed)
 
         schema_version_md = schema.TableSchemaVersionMd(
             schema_version=0, preceding_schema_version=None, columns=column_md,
@@ -448,7 +448,66 @@ class TableVersion:
         return result
 
     def update(
-            self, update_targets: Optional[List[Tuple[Column, 'pixeltable.exprs.Expr']]] = None,
+            self, update_targets: dict[Column, 'pixeltable.exprs.Expr'],
+            where_clause: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True
+    ) -> UpdateStatus:
+        with Env.get().engine.begin() as conn:
+            return self._update(conn, update_targets, where_clause, cascade)
+
+    def batch_update(
+            self, batch: list[dict[Column, 'pixeltable.exprs.Expr']], rowids: list[Tuple[int, ...]],
+            cascade: bool = True
+    ) -> UpdateStatus:
+        """Update rows in batch.
+        Args:
+            batch: one dict per row, each mapping Columns to LiteralExprs representing the new values
+            rowids: if not empty, one tuple per row, each containing the rowid values for the corresponding row in batch
+        """
+        # if we do lookups of rowids, we must have one for each row in the batch
+        assert len(rowids) == 0 or len(rowids) == len(batch)
+        import pixeltable.exprs as exprs
+        result_status = UpdateStatus()
+        cols_with_excs: set[str] = set()
+        updated_cols: set[str] = set()
+        pk_cols = self.primary_key_columns()
+        use_rowids = len(rowids) > 0
+
+        with Env.get().engine.begin() as conn:
+            for i, row in enumerate(batch):
+                where_clause: Optional[exprs.Expr] = None
+                if use_rowids:
+                    # construct Where clause to match rowid
+                    num_rowid_cols = len(self.store_tbl.rowid_columns())
+                    for col_idx in range(num_rowid_cols):
+                        clause = exprs.RowidRef(self, col_idx) == rowids[i][col_idx]
+                        if where_clause is None:
+                            where_clause = clause
+                        else:
+                            where_clause = where_clause & clause
+                else:
+                    # construct Where clause for primary key columns
+                    for col in pk_cols:
+                        assert col in row
+                        clause = exprs.ColumnRef(col) == row[col]
+                        if where_clause is None:
+                            where_clause = clause
+                        else:
+                            where_clause = where_clause & clause
+
+                update_targets = {col: row[col] for col in row if col not in pk_cols}
+                status = self._update(conn, update_targets, where_clause, cascade)
+                result_status.num_rows += status.num_rows
+                result_status.num_excs += status.num_excs
+                result_status.num_computed_values += status.num_computed_values
+                cols_with_excs.update(status.cols_with_excs)
+                updated_cols.update(status.updated_cols)
+
+            result_status.cols_with_excs = list(cols_with_excs)
+            result_status.updated_cols = list(updated_cols)
+            return result_status
+
+    def _update(
+            self, conn: sql.engine.Connection, update_targets: dict[Column, 'pixeltable.exprs.Expr'],
             where_clause: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True
     ) -> UpdateStatus:
         """Update rows in this table.
@@ -458,21 +517,18 @@ class TableVersion:
             cascade: if True, also update all computed columns that transitively depend on the updated columns,
                 including within views.
         """
-        if update_targets is None:
-            update_targets = []
         assert not self.is_snapshot
         from pixeltable.plan import Planner
         plan, updated_cols, recomputed_cols = \
             Planner.create_update_plan(self.path, update_targets, [], where_clause, cascade)
-        with Env.get().engine.begin() as conn:
-            ts = time.time()
-            result = self._update(
-                plan, where_clause.sql_expr() if where_clause is not None else None, recomputed_cols,
-                base_versions=[], conn=conn, ts=ts, cascade=cascade)
-            result.updated_cols = updated_cols
-            return result
+        ts = time.time()
+        result = self._propagate_update(
+            plan, where_clause.sql_expr() if where_clause is not None else None, recomputed_cols,
+            base_versions=[], conn=conn, ts=ts, cascade=cascade)
+        result.updated_cols = updated_cols
+        return result
 
-    def _update(
+    def _propagate_update(
             self, plan: Optional[exec.ExecNode], where_clause: Optional[sql.ClauseElement],
             recomputed_view_cols: List[Column], base_versions: List[Optional[int]], conn: sql.engine.Connection,
             ts: float, cascade: bool
@@ -497,7 +553,7 @@ class TableVersion:
                 if len(recomputed_cols) > 0:
                     from pixeltable.plan import Planner
                     plan = Planner.create_view_update_plan(view.path, recompute_targets=recomputed_cols)
-                status = view._update(
+                status = view._propagate_update(
                     plan, None, recomputed_view_cols, base_versions=base_versions, conn=conn, ts=ts, cascade=True)
                 result.num_rows += status.num_rows
                 result.num_excs += status.num_excs
@@ -667,6 +723,10 @@ class TableVersion:
         """Return all non-system columns"""
         return [c for c in self.cols if not self.is_system_column(c)]
 
+    def primary_key_columns(self) -> List[Column]:
+        """Return all non-system columns"""
+        return [c for c in self.cols if c.is_primary_key]
+
     def get_required_col_names(self) -> List[str]:
         """Return the names of all columns for which values must be specified in insert()"""
         assert not self.is_view()
@@ -742,7 +802,7 @@ class TableVersion:
             value_expr_dict = col.value_expr.as_dict() if col.value_expr is not None else None
             column_md[col.id] = schema.SchemaColumn(
                 pos=pos, name=col.name, col_type=col.col_type.as_dict(),
-                is_pk=col.primary_key, value_expr=value_expr_dict, stored=col.stored, is_indexed=col.is_indexed)
+                is_pk=col.is_primary_key, value_expr=value_expr_dict, stored=col.stored, is_indexed=col.is_indexed)
         # preceding_schema_version to be set by the caller
         return schema.TableSchemaVersionMd(
             schema_version=self.schema_version, preceding_schema_version=preceding_schema_version,

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -661,6 +661,7 @@ class TableVersion:
                     # construct Where clause to match rowid
                     num_rowid_cols = len(self.store_tbl.rowid_columns())
                     for col_idx in range(num_rowid_cols):
+                        assert len(rowids[i]) == num_rowid_cols
                         clause = exprs.RowidRef(self, col_idx) == rowids[i][col_idx]
                         if where_clause is None:
                             where_clause = clause
@@ -1022,4 +1023,3 @@ class TableVersion:
         return schema.TableSchemaVersionMd(
             schema_version=self.schema_version, preceding_schema_version=preceding_schema_version,
             columns=column_md, num_retained_versions=self.num_retained_versions, comment=self.comment)
-

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -932,7 +932,7 @@ class TableVersion:
 
     def primary_key_columns(self) -> List[Column]:
         """Return all non-system columns"""
-        return [c for c in self.cols if c.is_primary_key]
+        return [c for c in self.cols if c.is_pk]
 
     def get_required_col_names(self) -> List[str]:
         """Return the names of all columns for which values must be specified in insert()"""

--- a/pixeltable/exprs/comparison.py
+++ b/pixeltable/exprs/comparison.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
+
 from typing import Optional, List, Any, Dict, Tuple
 
 import sqlalchemy as sql
 
-from .globals import ComparisonOperator
-from .expr import Expr
-from .predicate import Predicate
 from .data_row import DataRow
+from .expr import Expr
+from .globals import ComparisonOperator
+from .predicate import Predicate
 from .row_builder import RowBuilder
-import pixeltable.catalog as catalog
 
 
 class Comparison(Predicate):

--- a/pixeltable/exprs/literal.py
+++ b/pixeltable/exprs/literal.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
+
 from typing import Optional, List, Any, Dict, Tuple
 
 import sqlalchemy as sql
 
-from .expr import Expr
-from .data_row import DataRow
-from .row_builder import RowBuilder
-import pixeltable.catalog as catalog
 import pixeltable.type_system as ts
+from .data_row import DataRow
+from .expr import Expr
+from .row_builder import RowBuilder
+
 
 class Literal(Expr):
     def __init__(self, val: Any, col_type: Optional[ts.ColumnType] = None):

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -260,7 +260,7 @@ class Planner:
     @classmethod
     def create_update_plan(
             cls, tbl: catalog.TableVersionPath,
-            update_targets: List[Tuple[catalog.Column, exprs.Expr]],
+            update_targets: dict[catalog.Column, exprs.Expr],
             recompute_targets: List[catalog.Column],
             where_clause: Optional[exprs.Predicate], cascade: bool
     ) -> Tuple[exec.ExecNode, List[str], List[catalog.Column]]:
@@ -279,7 +279,7 @@ class Planner:
         # retrieve all stored cols and all target exprs
         assert isinstance(tbl, catalog.TableVersionPath)
         target = tbl.tbl_version  # the one we need to update
-        updated_cols = [col for col, _ in update_targets]
+        updated_cols = list(update_targets.keys())
         if len(recompute_targets) > 0:
             recomputed_cols = recompute_targets.copy()
         else:
@@ -291,12 +291,12 @@ class Planner:
             col for col in target.cols if col.is_stored and not col in updated_cols and not col in recomputed_base_cols
         ]
         select_list = [exprs.ColumnRef(col) for col in copied_cols]
-        select_list.extend([expr for _, expr in update_targets])
+        select_list.extend(update_targets.values())
 
         recomputed_exprs = \
             [c.value_expr.copy().resolve_computed_cols(resolve_cols=recomputed_base_cols) for c in recomputed_base_cols]
         # recomputed cols reference the new values of the updated cols
-        for col, e in update_targets:
+        for col, e in update_targets.items():
             exprs.Expr.list_substitute(recomputed_exprs, exprs.ColumnRef(col), e)
         select_list.extend(recomputed_exprs)
 

--- a/pixeltable/tests/test_snapshot.py
+++ b/pixeltable/tests/test_snapshot.py
@@ -99,6 +99,10 @@ class TestSnapshot:
         assert 'cannot update a snapshot' in str(excinfo.value).lower()
 
         with pytest.raises(pxt.Error) as excinfo:
+            _ = snap.batch_update([{'c3': 1.0, 'c2': 1}])
+        assert 'cannot update a snapshot' in str(excinfo.value).lower()
+
+        with pytest.raises(pxt.Error) as excinfo:
             _ = snap.revert()
         assert 'cannot revert a snapshot' in str(excinfo.value).lower()
 

--- a/pixeltable/tests/test_table.py
+++ b/pixeltable/tests/test_table.py
@@ -668,15 +668,15 @@ class TestTable:
         t2 = cl.get_table('test')
         _  = t2.show(n=0)
 
-    def test_batch_update(self, test_tbl: pxt.Table) -> None:
+    def test_update_batch(self, test_tbl: pxt.Table) -> None:
         t = test_tbl
         validate_update_status(
-            t.update([{'c1': '1', 'c2': 1}, {'c1': '2', 'c2': 2}]),
+            t.update_batch([{'c1': '1', 'c2': 1}, {'c1': '2', 'c2': 2}]),
             expected_rows=2)
         assert t.where(t.c2 == 1).collect()[0]['c1'] == '1'
         assert t.where(t.c2 == 2).collect()[0]['c1'] == '2'
         validate_update_status(
-            t.update([{'c1': 'one', '_rowid': (1,)}, {'c1': 'two', '_rowid': (2,)}]),
+            t.update_batch([{'c1': 'one', '_rowid': (1,)}, {'c1': 'two', '_rowid': (2,)}]),
             expected_rows=2)
         assert t.where(t.c2 == 1).collect()[0]['c1'] == 'one'
         assert t.where(t.c2 == 2).collect()[0]['c1'] == 'two'
@@ -689,18 +689,18 @@ class TestTable:
         validate_update_status(t.insert(rows), expected_rows=10)
 
         with pytest.raises(excs.Error) as exc_info:
-            t.update([{'c1': '1', 'c3': 2.0}])
+            t.update_batch([{'c1': '1', 'c3': 2.0}])
         assert 'primary key columns (c2) missing' in str(exc_info.value).lower()
 
         validate_update_status(
-            t.update([{'c1': '1', 'c2': 1, 'c3': 2.0}, {'c1': '2', 'c2': 2, 'c3': 3.0}]),
+            t.update_batch([{'c1': '1', 'c2': 1, 'c3': 2.0}, {'c1': '2', 'c2': 2, 'c3': 3.0}]),
             expected_rows=2)
 
         # table without primary key
         t2 = cl.create_table('no_pk', schema=schema)
         validate_update_status(t.insert(rows), expected_rows=10)
         with pytest.raises(excs.Error) as exc_info:
-            _ = t2.update([{'c1': '1', 'c2': 1, 'c3': 2.0}])
+            _ = t2.update_batch([{'c1': '1', 'c2': 1, 'c3': 2.0}])
         assert 'must have primary key for batch update' in str(exc_info.value).lower()
 
     def test_update(self, test_tbl: pxt.Table, small_img_tbl) -> None:

--- a/pixeltable/tests/test_table.py
+++ b/pixeltable/tests/test_table.py
@@ -668,15 +668,15 @@ class TestTable:
         t2 = cl.get_table('test')
         _  = t2.show(n=0)
 
-    def test_update_batch(self, test_tbl: pxt.Table) -> None:
+    def test_batch_update(self, test_tbl: pxt.Table) -> None:
         t = test_tbl
         validate_update_status(
-            t.update_batch([{'c1': '1', 'c2': 1}, {'c1': '2', 'c2': 2}]),
+            t.batch_update([{'c1': '1', 'c2': 1}, {'c1': '2', 'c2': 2}]),
             expected_rows=2)
         assert t.where(t.c2 == 1).collect()[0]['c1'] == '1'
         assert t.where(t.c2 == 2).collect()[0]['c1'] == '2'
         validate_update_status(
-            t.update_batch([{'c1': 'one', '_rowid': (1,)}, {'c1': 'two', '_rowid': (2,)}]),
+            t.batch_update([{'c1': 'one', '_rowid': (1,)}, {'c1': 'two', '_rowid': (2,)}]),
             expected_rows=2)
         assert t.where(t.c2 == 1).collect()[0]['c1'] == 'one'
         assert t.where(t.c2 == 2).collect()[0]['c1'] == 'two'
@@ -688,20 +688,41 @@ class TestTable:
         rows = [{'c1': str(i), 'c2': i, 'c3': float(i)} for i in range(10)]
         validate_update_status(t.insert(rows), expected_rows=10)
 
-        with pytest.raises(excs.Error) as exc_info:
-            t.update_batch([{'c1': '1', 'c3': 2.0}])
-        assert 'primary key columns (c2) missing' in str(exc_info.value).lower()
-
         validate_update_status(
-            t.update_batch([{'c1': '1', 'c2': 1, 'c3': 2.0}, {'c1': '2', 'c2': 2, 'c3': 3.0}]),
+            t.batch_update([{'c1': '1', 'c2': 1, 'c3': 2.0}, {'c1': '2', 'c2': 2, 'c3': 3.0}]),
             expected_rows=2)
+
+        with pytest.raises(excs.Error) as exc_info:
+            # can't mix _rowid with primary key
+            _ = t.batch_update([{'c1': '1', 'c2': 1, 'c3': 2.0, '_rowid': (1,)}])
+        assert 'c1 is a primary key column' in str(exc_info.value).lower()
+
+        with pytest.raises(excs.Error) as exc_info:
+            # bad literal
+            _ = t.batch_update([{'c2': 1, 'c3': 'a'}])
+        assert "'a' is not a valid literal" in str(exc_info.value).lower()
+
+        with pytest.raises(excs.Error) as exc_info:
+            # missing primary key column
+            t.batch_update([{'c1': '1', 'c3': 2.0}])
+        assert 'primary key columns (c2) missing' in str(exc_info.value).lower()
 
         # table without primary key
         t2 = cl.create_table('no_pk', schema=schema)
-        validate_update_status(t.insert(rows), expected_rows=10)
+        validate_update_status(t2.insert(rows), expected_rows=10)
         with pytest.raises(excs.Error) as exc_info:
-            _ = t2.update_batch([{'c1': '1', 'c2': 1, 'c3': 2.0}])
+            _ = t2.batch_update([{'c1': '1', 'c2': 1, 'c3': 2.0}])
         assert 'must have primary key for batch update' in str(exc_info.value).lower()
+
+        # updating with _rowid still works
+        validate_update_status(
+            t2.batch_update([{'c1': 'one', '_rowid': (1,)}, {'c1': 'two', '_rowid': (2,)}]),
+            expected_rows=2)
+        assert t2.where(t2.c2 == 1).collect()[0]['c1'] == 'one'
+        assert t2.where(t2.c2 == 2).collect()[0]['c1'] == 'two'
+        with pytest.raises(AssertionError):
+            # some rows are missing rowids
+            _ = t2.batch_update([{'c1': 'one', '_rowid': (1,)}, {'c1': 'two'}])
 
     def test_update(self, test_tbl: pxt.Table, small_img_tbl) -> None:
         t = test_tbl

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -433,6 +433,7 @@ class InvalidType(ColumnType):
     def _validate_literal(self, val: Any) -> None:
         assert False
 
+
 class StringType(ColumnType):
     def __init__(self, nullable: bool = False):
         super().__init__(self.Type.STRING, nullable=nullable)
@@ -469,6 +470,7 @@ class StringType(ColumnType):
             return val.replace('\x00', ' ')
         return val
 
+
 class IntType(ColumnType):
     def __init__(self, nullable: bool = False):
         super().__init__(self.Type.INT, nullable=nullable)
@@ -503,6 +505,7 @@ class FloatType(ColumnType):
             return float(val)
         return val
 
+
 class BoolType(ColumnType):
     def __init__(self, nullable: bool = False):
         super().__init__(self.Type.BOOL, nullable=nullable)
@@ -522,6 +525,7 @@ class BoolType(ColumnType):
             return bool(val)
         return val
 
+
 class TimestampType(ColumnType):
     def __init__(self, nullable: bool = False):
         super().__init__(self.Type.TIMESTAMP, nullable=nullable)
@@ -540,6 +544,7 @@ class TimestampType(ColumnType):
         if isinstance(val, str):
             return datetime.datetime.fromisoformat(val)
         return val
+
 
 class JsonType(ColumnType):
     # TODO: type_spec also needs to be able to express lists
@@ -587,6 +592,7 @@ class JsonType(ColumnType):
         if isinstance(val, tuple):
             val = list(val)
         return val
+
 
 class ArrayType(ColumnType):
     def __init__(
@@ -791,6 +797,7 @@ class ImageType(ColumnType):
         except PIL.UnidentifiedImageError:
             raise excs.Error(f'Not a valid image: {val}') from None
 
+
 class VideoType(ColumnType):
     def __init__(self, nullable: bool = False):
         super().__init__(self.Type.VIDEO, nullable=nullable)
@@ -825,6 +832,7 @@ class VideoType(ColumnType):
         except av.AVError:
             raise excs.Error(f'Not a valid video: {val}') from None
 
+
 class AudioType(ColumnType):
     def __init__(self, nullable: bool = False):
         super().__init__(self.Type.AUDIO, nullable=nullable)
@@ -853,6 +861,7 @@ class AudioType(ColumnType):
                         pass
         except av.AVError as e:
             raise excs.Error(f'Not a valid audio file: {val}\n{e}') from None
+
 
 class DocumentType(ColumnType):
     @enum.unique


### PR DESCRIPTION
This includes support for the '_rowid' pseudo-column; ex.: update([{'col1': 1, '_rowid': (1,)}])