### PR TITLE
Introduce `remote_api` test group into Pixeltable pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ matrix.poetry-options == '' }}
         run: poetry run pip install pytest coverage
       - name: Run the unit tests
-        run: poetry run coverage run -m --source=pixeltable pytest -v
+        run: poetry run coverage run -m --source=pixeltable pytest -v -m ''
         env:
           # In a PR, these secrets will be empty, and the relevant tests will be skipped
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}

--- a/pixeltable/tests/functions/test_fireworks.py
+++ b/pixeltable/tests/functions/test_fireworks.py
@@ -5,6 +5,7 @@ import pixeltable.exceptions as excs
 from pixeltable.tests.utils import skip_test_if_not_installed, validate_update_status
 
 
+@pytest.mark.remote_api
 class TestFireworks:
 
     def test_fireworks(self, test_client: pxt.Client) -> None:

--- a/pixeltable/tests/functions/test_openai.py
+++ b/pixeltable/tests/functions/test_openai.py
@@ -6,6 +6,7 @@ from pixeltable.tests.utils import SAMPLE_IMAGE_URL, skip_test_if_not_installed,
 from pixeltable.type_system import StringType, ImageType
 
 
+@pytest.mark.remote_api
 class TestOpenai:
 
     def test_audio(self, test_client: pxt.Client) -> None:

--- a/pixeltable/tests/functions/test_together.py
+++ b/pixeltable/tests/functions/test_together.py
@@ -5,6 +5,7 @@ import pixeltable.exceptions as excs
 from pixeltable.tests.utils import skip_test_if_not_installed, validate_update_status
 
 
+@pytest.mark.remote_api
 class TestTogether:
 
     def test_completions(self, test_client: pxt.Client) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,12 @@ max-line-length = 120
 # W0511: TODO
 disable = ["C0114","C0116","C0415","E1121","R0401","R0801","R0902","R0913","R0914","W0511"]
 
+[tool.pytest.ini_options]
+addopts = "-v -m \"not remote_api\""
+markers = [
+    "remote_api: marks tests as calling a remote API (such as OpenAI)"
+]
+
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
Introduces a `remote_api` test group into Pixeltable pytest. The `remote_api` tests are disabled by default. To run them:

`pytest -m repote_api`

To run ALL tests including remote_api (but not skipped),

`pytest -m ''`