### PR TITLE
Bugfix for `create_view`

### DIFF
--- a/pixeltable/exprs/literal.py
+++ b/pixeltable/exprs/literal.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import datetime
 from typing import Optional, List, Any, Dict, Tuple
 
 import sqlalchemy as sql
 
+import pixeltable.exceptions as excs
 import pixeltable.type_system as ts
 from .data_row import DataRow
 from .expr import Expr
@@ -47,9 +49,20 @@ class Literal(Expr):
         data_row[self.slot_idx] = self.val
 
     def _as_dict(self) -> Dict:
-        return {'val': self.val, **super()._as_dict()}
+        # For some types, we need to explictly record their type, because JSON does not know
+        # how to interpret them unambiguously
+        if self.col_type.is_timestamp_type():
+            return {'val': self.val.isoformat(), 'val_t': self.col_type._type.name, **super()._as_dict()}
+        else:
+            return {'val': self.val, **super()._as_dict()}
 
     @classmethod
     def _from_dict(cls, d: Dict, components: List[Expr]) -> Expr:
         assert 'val' in d
+        if 'val_t' in d:
+            val_t = d['val_t']
+            if val_t == ts.ColumnType.Type.TIMESTAMP.name:
+                return cls(datetime.datetime.fromisoformat(d['val']), ts.TimestampType())
+            else:
+                excs.Error(f'Invalid literal metadata: val_t = {val_t}')
         return cls(d['val'])

--- a/pixeltable/exprs/literal.py
+++ b/pixeltable/exprs/literal.py
@@ -61,8 +61,6 @@ class Literal(Expr):
         assert 'val' in d
         if 'val_t' in d:
             val_t = d['val_t']
-            if val_t == ts.ColumnType.Type.TIMESTAMP.name:
-                return cls(datetime.datetime.fromisoformat(d['val']), ts.TimestampType())
-            else:
-                excs.Error(f'Invalid literal metadata: val_t = {val_t}')
+            assert val_t == ts.ColumnType.Type.TIMESTAMP.name
+            return cls(datetime.datetime.fromisoformat(d['val']))
         return cls(d['val'])

--- a/pixeltable/tests/test_view.py
+++ b/pixeltable/tests/test_view.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 import PIL
@@ -413,6 +414,10 @@ class TestView:
         assert_resultset_eq(
             v.order_by(v.c2).show(0),
             t.where(t.c2 < 10).order_by(t.c2).show(0))
+
+        # create views with filters containing date and datetime
+        _ = cl.create_view('test_view_2', t, filter=t.c5 >= datetime.date.today())
+        _ = cl.create_view('test_view_3', t, filter=t.c5 < datetime.datetime.now())
 
     def test_view_of_snapshot(self, test_client: pxt.Client) -> None:
         """Test view over a snapshot"""


### PR DESCRIPTION
Fixes a bug where `create_view` throws an exception if the predicate contains a reference to a `date` or `datetime` literal.