### PR TITLE
fix ci runner versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-12, macos-13-arm, windows-2022]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         poetry-version: ["1.7.1"]
         poetry-options: ["--with dev"]


### PR DESCRIPTION
Ensure we test both an old x86 mac  (which is equivalent to current macos-latest )
as well as a newer arm mac (mostly to detect issues with any present and future binary dependencies of pixeltable, the ptyhon side should be ok). 
Also name runners so the meaning doesnt change (macos-latest is switching form x86 to arm64, or did in pgserver)