### PR TITLE
Suggestion for handling dynamic embedding dims [PROPOSAL]

### DIFF
--- a/pixeltable/func/udf.py
+++ b/pixeltable/func/udf.py
@@ -156,8 +156,9 @@ def expr_udf(*args: Any, **kwargs: Any) -> Any:
         template = py_fn(*var_exprs)
         assert isinstance(template, exprs.Expr)
         py_sig = inspect.signature(py_fn)
-        if function_path is not None:
-            validate_symbol_path(function_path)
+        # `function_path` does not need to be resolvable for an `expr_udf`
+        # if function_path is not None:
+        #   validate_symbol_path(function_path)
         return ExprTemplateFunction(template, py_signature=py_sig, self_path=function_path, name=py_fn.__name__)
 
     if len(args) == 1:


### PR DESCRIPTION
Here's a suggestion for an alternate way of handling embedding dimensions that vary with the model parameter. It's a simpler change (not reliant on "parameter-dependent" return types), with an added advantage: it can be used directly in index creation, in most cases saving the user from having to deal with `expr_udf` boilerplate. The user can just directly write

`t.add_embedding_index('category', text_embed=together.embedding_fn('my_model'))`

(for example).

Ad hoc creation of `expr_udf`s should be safe, since (unlike with ordinary `udf`s) we'll never actually need the path to the function.

**This is an example/template only - not a working implementation.