### PR TITLE
Dynamic versioning

### DIFF
--- a/pixeltable/__init__.py
+++ b/pixeltable/__init__.py
@@ -10,6 +10,7 @@ from .type_system import \
 from .utils.help import help
 # noinspection PyUnresolvedReferences
 from . import functions
+from .__version__ import __version__, __version_tuple__
 
 __all__ = [
     'Client',

--- a/pixeltable/__version__.py
+++ b/pixeltable/__version__.py
@@ -1,2 +1,3 @@
+# These version placeholders will be replaced during build.
 __version__ = "0.0.0"
 __version_tuple__ = (0, 0, 0)

--- a/pixeltable/__version__.py
+++ b/pixeltable/__version__.py
@@ -1,0 +1,2 @@
+__version__ = "0.0.0"
+__version_tuple__ = (0, 0, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ setuptools = "~69.1"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
-metadata = true
 dirty = true
 
 [tool.poetry-dynamic-versioning.substitution]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core", "poetry-dynamic-versioning>=1.3.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "pixeltable"
-version = "0.2.5"
+version = "0.0.0"
 description = "Pixeltable: The Multimodal AI Data Plane"
 authors = ["Marcel Kornacker <marcelk@gmail.com>"]
 readme = "README.md"
@@ -83,6 +83,13 @@ transformers = "^4.20"
 datasets = ">=2.15.0"
 # setuptools >= 69.2 has known issues with Github Actions
 setuptools = "~69.1"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+
+[tool.poetry-dynamic-versioning.substitution]
+files = ["pixeltable/__version__.py"]
 
 [tool.mypy]
 plugins = "sqlalchemy.ext.mypy.plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ setuptools = "~69.1"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
+metadata = true
+dirty = true
 
 [tool.poetry-dynamic-versioning.substitution]
 files = ["pixeltable/__version__.py"]


### PR DESCRIPTION
Quick PR thinking back on our chat with obvio today re. which version are they running:
They should simply run `python -c 'import pixeltable as pxt; print(pxt.__version__)` and be able to tell (and tell us) which version is running, in line with most other python packages:
```
orm@jetboiler ~ > python -c 'import pandas as pd; print(pd.__version__)'
2.2.1
```
The main goal here is that this version is accurate and that is also available for non-official releases, eg debug builds we give people, like we have given obvio.

I looked around and found https://github.com/mtkennerly/poetry-dynamic-versioning in multiple poetry github threads, to generate versions automatically at `poetry build`. A few more established alternatives that pre-date poetry do not integrate well with it (packages like versioneer and setuptools_scm)

We simply add a `__version__` field to `__init__.py`, this `__version__` field is written dynamically by a poetry plugin
(during poetry build)

Example (after applying these PR changes)
```
orm@jetboiler ~/r/pixeltable (dynamic-versioning)> poetry build                                                                                                                                     (pixeltable_39) 
Building pixeltable (0.2.5.post15.dev0+ff33dca)
  - Building sdist
  - Built pixeltable-0.2.5.post15.dev0+ff33dca.tar.gz
  - Building wheel
  - Built pixeltable-0.2.5.post15.dev0+ff33dca-py3-none-any.whl
```

0.2.5 is the latest ancestor tag in the current branch,  post15 means 15 commits after that tag, ff33dca is the actual commit number for later reference, because this is not a release. This numbering is meant to be compliant with python specifications.

If I tag the current commit, you get a clean name:
```
orm@jetboiler ~/r/pixeltable (dynamic-versioning)> git tag v0.2.6                                                                                                                                   (pixeltable_39) 
orm@jetboiler ~/r/pixeltable (dynamic-versioning)> poetry build                                                                                                                                     (pixeltable_39) 
Building pixeltable (0.2.6)
  - Building sdist
  - Built pixeltable-0.2.6.tar.gz
  - Building wheel
  - Built pixeltable-0.2.6-py3-none-any.whl
```

Most importantly, if I install this wheel I can print __version__:
```
orm@jetboiler ~> pip install dist/pixeltable-0.2.5.post15.dev0+ff33dca-py3-none-any.whl 
orm@jetboiler ~> python -c 'import pixeltable as pxt; print(pxt.__version__)'                                                                                                                       (pixeltable_39) 
0.2.5.post15.dev0+ff33dca
```