### PR TITLE
Widen numpy version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6677,4 +6677,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "ddf2e82da9207cb075251126db6f7f9e9f07d091f1cd4562b3584c9bd3c358b8"
+content-hash = "dbf3de40298d352932df16b80d59764827f7ee874b61d1552df915c64197c96a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-numpy = ">=1.26"
+numpy = ">=1.25"
 pandas = ">=2.0,<3.0"
 pillow = ">=9.3.0"
 opencv-python-headless = "^4.7.0.68"


### PR DESCRIPTION
Requiring numpy 1.26 was causing intermittent problems with colab. This widens the version spec in pyproject.toml.