### PR TITLE
New pattern for specifying iterators in views

### DIFF
--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -68,9 +68,9 @@ def create_table(
 
 def create_view(
         path_str: str, base: catalog.Table, *, schema: Optional[dict[str, Any]] = None,
-        filter: Optional[Predicate] = None,
-        is_snapshot: bool = False, iterator_class: Optional[Type[ComponentIterator]] = None,
-        iterator_args: Optional[dict[str, Any]] = None, num_retained_versions: int = 10, comment: str = '',
+        filter: Optional[Predicate] = None, is_snapshot: bool = False,
+        iterator: Optional[tuple[type[ComponentIterator], dict[str, Any]]] = None,
+        num_retained_versions: int = 10, comment: str = '',
         ignore_errors: bool = False) -> catalog.View:
     """Create a new `View`.
 
@@ -106,7 +106,6 @@ def create_view(
         >>> snapshot_view = cl.create_view(
             'my_snapshot', base, schema={'col3': base.col2 + 1}, filter=base.col1 > 10, is_snapshot=True)
     """
-    assert (iterator_class is None) == (iterator_args is None)
     assert isinstance(base, catalog.Table)
     path = catalog.Path(path_str)
     try:
@@ -120,6 +119,10 @@ def create_view(
 
     if schema is None:
         schema = {}
+    if iterator is None:
+        iterator_class, iterator_args = None, None
+    else:
+        iterator_class, iterator_args = iterator
     view = catalog.View.create(
         dir._id, path.name, base=base, schema=schema, predicate=filter, is_snapshot=is_snapshot,
         iterator_cls=iterator_class, iterator_args=iterator_args, num_retained_versions=num_retained_versions,

--- a/pixeltable/iterators/__init__.py
+++ b/pixeltable/iterators/__init__.py
@@ -1,3 +1,2 @@
 from .base import ComponentIterator
 from .video import FrameIterator
-

--- a/pixeltable/iterators/base.py
+++ b/pixeltable/iterators/base.py
@@ -46,3 +46,7 @@ class ComponentIterator(ABC):
     def set_pos(self, pos: int) -> None:
         """Set the iterator position to pos"""
         raise NotImplementedError
+
+    @classmethod
+    def create(cls, **kwargs: Any) -> tuple[type[ComponentIterator], dict[str, Any]]:
+        return cls, kwargs

--- a/pixeltable/iterators/document.py
+++ b/pixeltable/iterators/document.py
@@ -1,15 +1,15 @@
-from typing import Dict, Any, List, Tuple, Optional, Iterable, Iterator
-import logging
 import dataclasses
 import enum
+import logging
+from typing import Dict, Any, List, Tuple, Optional, Iterable, Iterator
+
 import ftfy
 
-from .base import ComponentIterator
-
-from pixeltable.type_system import ColumnType, DocumentType, StringType, IntType, JsonType
-from pixeltable.exceptions import Error
 from pixeltable.env import Env
+from pixeltable.exceptions import Error
+from pixeltable.type_system import ColumnType, DocumentType, StringType, IntType, JsonType
 from pixeltable.utils.documents import get_document_handle
+from .base import ComponentIterator
 
 _logger = logging.getLogger('pixeltable')
 

--- a/pixeltable/iterators/video.py
+++ b/pixeltable/iterators/video.py
@@ -1,21 +1,20 @@
-from typing import Dict, Any, List, Tuple
-from pathlib import Path
-import math
 import logging
+import math
+from pathlib import Path
+from typing import Dict, Any, List, Tuple
 
-import cv2
 import PIL.Image
+import cv2
 
-from .base import ComponentIterator
-
-from pixeltable.type_system import ColumnType, VideoType, ImageType, IntType, FloatType
+from pixeltable import exprs
 from pixeltable.exceptions import Error
-
+from pixeltable.type_system import ColumnType, VideoType, ImageType, IntType, FloatType
+from .base import ComponentIterator
 
 _logger = logging.getLogger('pixeltable')
 
 class FrameIterator(ComponentIterator):
-    def __init__(self, video: str, fps: float = 0.0):
+    def __init__(self, video: str, *, fps: float = 0.0):
         video_path = Path(video)
         assert video_path.exists() and video_path.is_file()
         self.video_path = video_path

--- a/tests/functions/test_functions.py
+++ b/tests/functions/test_functions.py
@@ -10,8 +10,7 @@ class TestFunctions:
         skip_test_if_not_installed('nos')
         video_t = pxt.create_table('video_tbl', {'video': VideoType()})
         # create frame view
-        args = {'video': video_t.video, 'fps': 1}
-        v = pxt.create_view('test_view', video_t, iterator_class=FrameIterator, iterator_args=args)
+        v = pxt.create_view('test_view', video_t, iterator=FrameIterator.create(video_t.video, fps=1))
 
         files = get_video_files()
         video_t.insert(video=files[-1])

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -414,8 +414,7 @@ class TestDataFrame:
         skip_test_if_not_installed('nos')
         from pycocotools.coco import COCO
         base_t = pxt.create_table('videos', {'video': pxt.VideoType()})
-        args = {'video': base_t.video, 'fps': 1}
-        view_t = pxt.create_view('frames', base_t, iterator_class=FrameIterator, iterator_args=args)
+        view_t = pxt.create_view('frames', base_t, iterator=FrameIterator.create(video=base_t.video, fps=1))
         from pixeltable.functions.nos.object_detection_2d import yolox_medium
         view_t.add_column(detections=yolox_medium(view_t.frame))
         base_t.insert(video=get_video_files()[0])

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -118,16 +118,15 @@ class TestDocument:
                                               ['', 'token_limit', 'char_limit']):
             chunk_limits = [10, 20, 100] if sep2 else [None]
             for limit in chunk_limits:
-                iterator_args = {
-                    'document': doc_t.doc,
-                    'separators': ','.join([sep1, sep2]),
-                    'metadata': 'title,heading,sourceline,page,bounding_box'
-                }
-                if sep2:
-                    iterator_args['limit'] = limit
-                    iterator_args['overlap'] = 0
                 chunks_t = pxt.create_view(
-                    f'chunks', doc_t, iterator_class=DocumentSplitter, iterator_args=iterator_args)
+                    'chunks', doc_t,
+                    iterator=DocumentSplitter.create(document=
+                        doc_t.doc,
+                        separators=','.join([sep1, sep2]),
+                        metadata='title,heading,sourceline,page,bounding_box',
+                        limit=limit if sep2 else None,
+                        overlap=0 if sep2 else None)
+                )
                 res = list(chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect())
 
                 if all_text_reference is None:
@@ -188,14 +187,10 @@ class TestDocument:
         md_tuples = list(itertools.chain.from_iterable(itertools.combinations(md_elements, i) for i in range(len(md_elements) + 1)))
         _ = [','.join(t) for t in md_tuples]
         for md_str in [','.join(t) for t in md_tuples]:
-            iterator_args = {
-                'document': doc_t.doc,
-                'separators': 'sentence',
-                'metadata': md_str
-            }
             print(f'{md_str=}')
             chunks_t = pxt.create_view(
-                f'chunks', doc_t, iterator_class=DocumentSplitter, iterator_args=iterator_args)
+                'chunks', doc_t,
+                iterator=DocumentSplitter.create(document=doc_t.doc, separators='sentence', metadata=md_str))
             res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
             requested_md_elements = set(md_str.split(','))
             for md_element in md_elements:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -120,8 +120,8 @@ class TestDocument:
             for limit in chunk_limits:
                 chunks_t = pxt.create_view(
                     'chunks', doc_t,
-                    iterator=DocumentSplitter.create(document=
-                        doc_t.doc,
+                    iterator=DocumentSplitter.create(
+                        document=doc_t.doc,
                         separators=','.join([sep1, sep2]),
                         metadata='title,heading,sourceline,page,bounding_box',
                         limit=limit if sep2 else None,

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -688,8 +688,7 @@ class TestExprs:
 
         # ordering conflict between frame extraction and window fn
         base_t = pxt.create_table('videos', {'video': VideoType(), 'c2': IntType(nullable=False)})
-        args = {'video': base_t.video, 'fps': 0}
-        v = pxt.create_view('frame_view', base_t, iterator_class=FrameIterator, iterator_args=args)
+        v = pxt.create_view('frame_view', base_t, iterator=FrameIterator.create(video=base_t.video, fps=0))
         # compatible ordering
         _ = v.select(v.frame, sum(v.frame_idx, group_by=base_t, order_by=v.pos)).show(100)
         with pytest.raises(excs.Error):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -506,7 +506,7 @@ class TestTable:
             'test_tbl',
             {'payload': IntType(nullable=False), 'video': VideoType(nullable=True)})
         args = {'video': tbl.video, 'fps': 0}
-        view = pxt.create_view('test_view', tbl, iterator_class=FrameIterator, iterator_args=args)
+        view = pxt.create_view('test_view', tbl, iterator=FrameIterator.create(video=tbl.video, fps=0))
         view.add_column(c1=view.frame.rotate(30), stored=True)
         view.add_column(c2=view.c1.rotate(40), stored=False)
         view.add_column(c3=view.c2.rotate(50), stored=True)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -19,8 +19,7 @@ class TestVideo:
         pxt.drop_table(view_name, ignore_errors=True)
         pxt.drop_table(base_name, ignore_errors=True)
         base_t = pxt.create_table(base_name, {'video': VideoType()})
-        args = {'video': base_t.video, 'fps': 1}
-        view_t = pxt.create_view(view_name, base_t, iterator_class=FrameIterator, iterator_args=args)
+        view_t = pxt.create_view(view_name, base_t, iterator=FrameIterator.create(video=base_t.video, fps=1))
         return base_t, view_t
 
     def create_and_insert(
@@ -80,11 +79,11 @@ class TestVideo:
         path = get_video_files()[0]
         videos = pxt.create_table('videos', {'video': VideoType()})
         frames_1_0 = pxt.create_view(
-            'frames_1_0', videos, iterator_class=FrameIterator, iterator_args={'video': videos.video, 'fps': 1})
+            'frames_1_0', videos, iterator=FrameIterator.create(video=videos.video, fps=1))
         frames_0_5 = pxt.create_view(
-            'frames_0_5', videos, iterator_class=FrameIterator, iterator_args={'video': videos.video, 'fps': 1/2})
+            'frames_0_5', videos, iterator=FrameIterator.create(video=videos.video, fps=1/2))
         frames_0_33 = pxt.create_view(
-            'frames_0_33', videos, iterator_class=FrameIterator, iterator_args={'video': videos.video, 'fps': 1/3})
+            'frames_0_33', videos, iterator=FrameIterator.create(video=videos.video, fps=1/3))
         videos.insert(video=path)
         assert frames_0_5.count() == frames_1_0.count() // 2 or frames_0_5.count() == frames_1_0.count() // 2 + 1
         assert frames_0_33.count() == frames_1_0.count() // 3 or frames_0_33.count() == frames_1_0.count() // 3 + 1


### PR DESCRIPTION
Following Marcel's suggestion, this basically does the simplest thing that gets the new pattern established. We can sort out getting dot/tab-completion working for iterator args as a separate problem.