### PR TITLE
Bug fix: exception in insert()

### DIFF
--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -939,12 +939,12 @@ class TableVersion:
     def get_required_col_names(self) -> List[str]:
         """Return the names of all columns for which values must be specified in insert()"""
         assert not self.is_view()
-        names = [c.name for c in self.cols if not c.is_computed and not c.col_type.nullable]
+        names = [c.name for c in self.cols_by_name.values() if not c.is_computed and not c.col_type.nullable]
         return names
 
     def get_computed_col_names(self) -> List[str]:
         """Return the names of all computed columns"""
-        names = [c.name for c in self.cols if c.is_computed]
+        names = [c.name for c in self.cols_by_name.values() if c.is_computed]
         return names
 
     @classmethod


### PR DESCRIPTION
This happens after dropping a non-nullable column from a table, reloading the catalog and then running insert(), at which point
TableVersion.get_required_col_names() would include this column with a None name.