### PR TITLE
Use a decorator pattern for schema converters

### DIFF
--- a/pixeltable/metadata/__init__.py
+++ b/pixeltable/metadata/__init__.py
@@ -26,13 +26,11 @@ def create_system_info(engine: sql.engine.Engine) -> None:
 # key: old schema version
 converter_cbs: Dict[int, Callable[[sql.engine.Engine], None]] = {}
 
-def register_converter(version: int, cb: Callable[[sql.engine.Engine], None]) -> None:
-    global converter_cbs
-    converter_cbs[version] = cb
-
-def noop_converter(engine: sql.engine.Engine) -> None:
-    # Converter to use when incrementing the schema version, but without any functional changes
-    pass
+def register_converter(version: int) -> Callable[[Callable[[sql.engine.Engine], None]], None]:
+    def decorator(fn: Callable[[sql.engine.Engine], None]) -> None:
+        global converter_cbs
+        converter_cbs[version] = fn
+    return decorator
 
 # load all converter modules
 for _, modname, _ in pkgutil.iter_modules([os.path.dirname(__file__) + '/converters']):

--- a/pixeltable/metadata/converters/convert_10.py
+++ b/pixeltable/metadata/converters/convert_10.py
@@ -4,7 +4,8 @@ from pixeltable.metadata.schema import Table, TableSchemaVersion
 from pixeltable.metadata import register_converter
 
 
-def convert_10(engine: sql.engine.Engine) -> None:
+@register_converter(version=10)
+def _(engine: sql.engine.Engine) -> None:
     default_table_attrs = {"comment": None, "num_retained_versions": 10}
     with engine.begin() as conn:
         # Because `parameters` wasn't actually used for anything,
@@ -13,6 +14,3 @@ def convert_10(engine: sql.engine.Engine) -> None:
         # Add `table_attrs` to all instances of tableschemaversions.md.
         conn.execute(sql.update(TableSchemaVersion).values(md=TableSchemaVersion.md.concat(default_table_attrs)))
     return
-
-
-register_converter(10, convert_10)

--- a/pixeltable/metadata/converters/convert_12.py
+++ b/pixeltable/metadata/converters/convert_12.py
@@ -1,3 +1,8 @@
-from pixeltable.metadata import register_converter, noop_converter
+import sqlalchemy as sql
 
-register_converter(12, noop_converter)
+from pixeltable.metadata import register_converter
+
+
+@register_converter(version=12)
+def _(engine: sql.engine.Engine) -> None:
+    pass

--- a/pixeltable/metadata/converters/convert_13.py
+++ b/pixeltable/metadata/converters/convert_13.py
@@ -9,7 +9,8 @@ from pixeltable.metadata.schema import Table
 _logger = logging.getLogger('pixeltable')
 
 
-def convert_13(engine: sql.engine.Engine) -> None:
+@register_converter(version=13)
+def _(engine: sql.engine.Engine) -> None:
     with engine.begin() as conn:
         for row in conn.execute(sql.select(Table)):
             id = row[0]
@@ -36,6 +37,3 @@ def _update_md(md: Any) -> Any:
         return [_update_md(v) for v in md]
     else:
         return md
-
-
-register_converter(13, convert_13)


### PR DESCRIPTION
Right now, in order to define a schema converter, we have to mention the version number three times:

```
def convert_n(engine): ...

register_converter(n, convert_n)
```

By using a decorator pattern, we can reduce this to once:
```
@register_converter(version=n)
def _(engine): ...
```