### PR TITLE
Add unit test that verifies the DB dump tool is working properly

### DIFF
--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -37,11 +37,15 @@ class Env:
     @classmethod
     def get(cls) -> Env:
         if cls._instance is None:
-            env = Env()
-            env._set_up()
-            env._upgrade_metadata()
-            cls._instance = env
+            cls._init_env()
         return cls._instance
+
+    @classmethod
+    def _init_env(cls, reinit_db: bool = False) -> None:
+        env = Env()
+        env._set_up(reinit_db=reinit_db)
+        env._upgrade_metadata()
+        cls._instance = env
 
     def __init__(self):
         self._home: Optional[Path] = None

--- a/pixeltable/tool/create_test_db_dump.py
+++ b/pixeltable/tool/create_test_db_dump.py
@@ -30,6 +30,8 @@ class Dumper:
         os.environ['PIXELTABLE_DB'] = db_name
         os.environ['PIXELTABLE_PGDATA'] = str(shared_home / 'pgdata')
 
+        Env._init_env(reinit_db=True)
+
         Env.get().configure_logging(level=logging.DEBUG, to_stdout=True)
 
     def dump_db(self) -> None:
@@ -164,7 +166,7 @@ class Dumper:
 
         # Add remotes
         from pixeltable.datatransfer.remote import MockRemote
-        v.link_remote(
+        v._link(
             MockRemote({'int_field': pxt.IntType()}, {'str_field': pxt.StringType()}),
             col_mapping={'test_udf': 'int_field', 'c1': 'str_field'}
         )

--- a/tests/tool/test_db_dump_tool.py
+++ b/tests/tool/test_db_dump_tool.py
@@ -1,7 +1,10 @@
 import subprocess
 
+from ..utils import skip_test_if_not_installed
+
 
 class TestDbDumpTool:
 
     def test_db_dump_tool(self) -> None:
+        skip_test_if_not_installed('label_studio_sdk')
         subprocess.run('python pixeltable/tool/create_test_db_dump.py'.split(' '), check=True)

--- a/tests/tool/test_db_dump_tool.py
+++ b/tests/tool/test_db_dump_tool.py
@@ -1,0 +1,7 @@
+import subprocess
+
+
+class TestDbDumpTool:
+
+    def test_db_dump_tool(self) -> None:
+        subprocess.run('python pixeltable/tool/create_test_db_dump.py'.split(' '), check=True)


### PR DESCRIPTION
Backports a fix for the db dump tool from the `label-studio-2` branch, along with another change that makes the db dump tool easier to use.

Adds a unit test that verifies the db dump tool is working properly, to guard against any future regressions.