### PR TITLE
Add retry logic to "install dependencies" CI step

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,6 +81,7 @@ jobs:
         # Retry 3 times to be (hopefully) resilient against transient connection errors.
         shell: bash -l {0}  # Don't use -e flag
         run: |
+          set +e
           RETRIES=3
           while (( RETRIES-- > 0 )); do
             poetry install ${{ matrix.poetry-options }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,12 +84,13 @@ jobs:
           RETRIES=3
           while (( RETRIES-- > 0 )); do
             poetry install ${{ matrix.poetry-options }}
-            if [[ "$?" == 0 ]]; then
+            RESULT="$?"
+            if [[ "$RESULT" == 0 ]]; then
               break
             fi
-            echo "Poetry installation failed; $RETRIES tries remaining."
+            echo "Poetry installation failed with exit code $RESULT; $RETRIES tries remaining."
           done
-          if [[ "$RETRIES" == 0 ]]; then
+          if [[ "$RESULT" != 0 ]]; then
             exit 1
           fi
           echo "Poetry installation succeeded."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,7 +84,7 @@ jobs:
           set +e
           RETRIES=3
           while (( RETRIES-- > 0 )); do
-            poetry install ${{ matrix.poetry-options }}
+            poetry instaljl ${{ matrix.poetry-options }}
             RESULT="$?"
             if [[ "$RESULT" == 0 ]]; then
               break

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -91,8 +91,7 @@ jobs:
             fi
             echo "Poetry installation failed; $RETRIES tries remaining."
           done
-          sleep 5
-          exit "$RESULT"
+          echo "Done."
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10
         if: ${{ matrix.poetry-options != '' && matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,8 +81,10 @@ jobs:
         # Retry 3 times to be (hopefully) resilient against transient connection errors.
         run: |
           RETRIES=3
-          while (( RETRIES > 0 )); do
-            [[ $(poetry install ${{ matrix.poetry-options }}) == 0 ]] && exit
+          while (( RETRIES-- > 0 )); do
+            poetry install ${{ matrix.poetry-options }}
+            [[ $? == 0 ]] && exit
+            echo "Poetry install failed; $RETRIES tries remaining."
           done
           exit 1
       - name: Install yolox

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,7 +79,7 @@ jobs:
         # The `poetry config` setting is intended to improve CI stability.
         run: |
           python -m pip install setuptools==69.1.1
-          poetry config installer.max-workers=1
+          poetry config installer.max-workers 1
           poetry install ${{ matrix.poetry-options }}
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,7 +79,7 @@ jobs:
             matrix.poetry-options }}-${{ hashFiles('poetry.lock', 'poetry.toml', 'pyproject.toml', 'Makefile') }}
       - name: Install the project dependencies
         # Retry 3 times to be (hopefully) resilient against transient connection errors.
-        shell: bash {0}  # Don't use -e flag
+        shell: bash -l {0}  # Don't use -e flag
         run: |
           RETRIES=3
           while (( RETRIES-- > 0 )); do
@@ -91,7 +91,7 @@ jobs:
             fi
             echo "Poetry installation failed; $RETRIES tries remaining."
           done
-          echo "$RESULT"
+          sleep 5
           exit "$RESULT"
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -76,8 +76,10 @@ jobs:
       - name: Install the project dependencies
         # setuptools >= 69.2 has been causing problems with github actions even when its
         # version is enforced in poetry. For now, explicitly install setuptools 69.1.1 first.
+        # The `poetry config` setting is intended to improve CI stability.
         run: |
           python -m pip install setuptools==69.1.1
+          poetry config installer.max-workers=1
           poetry install ${{ matrix.poetry-options }}
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,6 +79,7 @@ jobs:
             matrix.poetry-options }}-${{ hashFiles('poetry.lock', 'poetry.toml', 'pyproject.toml', 'Makefile') }}
       - name: Install the project dependencies
         # Retry 3 times to be (hopefully) resilient against transient connection errors.
+        shell: bash -l {0}  # Don't use -e flag
         run: |
           RETRIES=3
           while (( RETRIES-- > 0 )); do

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -91,6 +91,7 @@ jobs:
             fi
             echo "Poetry installation failed; $RETRIES tries remaining."
           done
+          echo "$RESULT"
           exit "$RESULT"
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -59,9 +59,13 @@ jobs:
         if: ${{ matrix.poetry-options != '' }}
         run: conda install -c conda-forge libiconv ffmpeg
       - name: Install poetry
+        # setuptools >= 69.2 has been causing problems with github actions even when its
+        # version is enforced in poetry. For now, explicitly revert to setuptools 69.1.1
+        # prior to installing project dependencies.
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry==${{ matrix.poetry-version }}
+          python -m pip install setuptools==69.1.1
       - name: Define a venv cache
         uses: actions/cache@v4
         if: false
@@ -74,13 +78,13 @@ jobs:
           key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.poetry-version }}-${{
             matrix.poetry-options }}-${{ hashFiles('poetry.lock', 'poetry.toml', 'pyproject.toml', 'Makefile') }}
       - name: Install the project dependencies
-        # setuptools >= 69.2 has been causing problems with github actions even when its
-        # version is enforced in poetry. For now, explicitly install setuptools 69.1.1 first.
-        # The `poetry config` setting is intended to improve CI stability.
+        # Retry 3 times to be (hopefully) resilient against transient connection errors.
         run: |
-          python -m pip install setuptools==69.1.1
-          poetry config installer.max-workers 1
-          poetry install ${{ matrix.poetry-options }}
+          RETRIES=3
+          while (( RETRIES > 0 )); do
+            [[ $(poetry install ${{ matrix.poetry-options }}) == 0 ]] && exit
+          done
+          exit 1
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10
         if: ${{ matrix.poetry-options != '' && matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,14 +84,14 @@ jobs:
           RETRIES=3
           while (( RETRIES-- > 0 )); do
             poetry install ${{ matrix.poetry-options }}
-            if [[ $? == 0 ]]; then
+            RESULT=$?
+            if [[ "$RESULT" == 0 ]]; then
               echo "Poetry installation succeeded."
-              exit 0
+              break
             fi
-            echo "Poetry install failed; $RETRIES tries remaining."
+            echo "Poetry installation failed; $RETRIES tries remaining."
           done
-          echo "Failed 3 times."
-          exit 1
+          exit "$RESULT"
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10
         if: ${{ matrix.poetry-options != '' && matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,7 +84,7 @@ jobs:
           set +e
           RETRIES=3
           while (( RETRIES-- > 0 )); do
-            poetry instaljl ${{ matrix.poetry-options }}
+            poetry install ${{ matrix.poetry-options }}
             RESULT="$?"
             if [[ "$RESULT" == 0 ]]; then
               break

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -83,9 +83,13 @@ jobs:
           RETRIES=3
           while (( RETRIES-- > 0 )); do
             poetry install ${{ matrix.poetry-options }}
-            [[ $? == 0 ]] && exit
+            if [[ $? == 0 ]]; then
+              echo "Poetry installation succeeded."
+              exit 0
+            fi
             echo "Poetry install failed; $RETRIES tries remaining."
           done
+          echo "Failed 3 times."
           exit 1
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,14 +84,15 @@ jobs:
           RETRIES=3
           while (( RETRIES-- > 0 )); do
             poetry install ${{ matrix.poetry-options }}
-            RESULT=$?
-            if [[ "$RESULT" == 0 ]]; then
-              echo "Poetry installation succeeded."
+            if [[ "$?" == 0 ]]; then
               break
             fi
             echo "Poetry installation failed; $RETRIES tries remaining."
           done
-          echo "Done."
+          if [[ "$RETRIES" == 0 ]]; then
+            exit 1
+          fi
+          echo "Poetry installation succeeded."
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10
         if: ${{ matrix.poetry-options != '' && matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,7 +79,7 @@ jobs:
             matrix.poetry-options }}-${{ hashFiles('poetry.lock', 'poetry.toml', 'pyproject.toml', 'Makefile') }}
       - name: Install the project dependencies
         # Retry 3 times to be (hopefully) resilient against transient connection errors.
-        shell: bash -l {0}  # Don't use -e flag
+        shell: bash {0}  # Don't use -e flag
         run: |
           RETRIES=3
           while (( RETRIES-- > 0 )); do


### PR DESCRIPTION
Adds retry logic to the "install dependencies" CI step. This should reduce the frequency of CI failures due to connection errors on the runners.

It isn't perfect (in particular, a connection error could still occur after the tests have started - say, while downloading a model) but hopefully will help somewhat.