### PR TITLE
Some API enhancements

### DIFF
--- a/docs/release/api-cheat-sheet.md
+++ b/docs/release/api-cheat-sheet.md
@@ -11,9 +11,9 @@ import pixeltable.functions as pxtf
 | Task                        | Code                                                                                                                             |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | Create a (mutable) table    | t = [`pxt.create_table`][pixeltable.create_table]('table_name', {'col_1': pxt.StringType(), 'col_2': pxt.IntType(), ...})        |
-| Create a view               | t = [`pxt.create_view`][pixeltable.create_view]('view_name', base_tbl, filter=base_tbl.col > 10)                                 |
+| Create a view               | t = [`pxt.create_view`][pixeltable.create_view]('view_name', base_tbl.where(base_tbl.col > 10))                                  |
 | Create a view with iterator | t = [`pxt.create_view`][pixeltable.create_view]('view_name', base_tbl, iterator=FrameIterator.create(video=base_tbl.col, fps=0)) |
-| Create a snapshot           | t = [`pxt.create_view`][pixeltable.create_view]('snapshot_name', t, is_snapshot=True)                                            |
+| Create a snapshot           | t = [`pxt.create_view`][pixeltable.create_view]('snapshot_name', base_tbl, is_snapshot=True)                                     |
 
 The following functions apply to tables, views, and snapshots.
 

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -120,7 +120,7 @@ class Catalog:
                     base = base_version
                 assert base_path is not None
 
-                base_tbl = self.tbls[base_path.tbl_version.id]
+                base_tbl_id = base_path.tbl_id()
                 is_snapshot = view_md is not None and view_md.is_snapshot
                 snapshot_only = is_snapshot and view_md.predicate is None and len(schema_version_md.columns) == 0
                 if snapshot_only:
@@ -134,9 +134,9 @@ class Catalog:
                     view_path = TableVersionPath(tbl_version, base=base_path)
 
                 tbl = View(
-                    tbl_record.id, tbl_record.dir_id, tbl_md.name, view_path, base_tbl,
+                    tbl_record.id, tbl_record.dir_id, tbl_md.name, view_path, base_tbl_id,
                     snapshot_only=snapshot_only)
-                self.tbl_dependents[base_tbl._id].append(tbl)
+                self.tbl_dependents[base_tbl_id].append(tbl)
 
             else:
                 tbl_version = TableVersion(tbl_record.id, tbl_md, tbl_md.current_version, schema_version_md)

--- a/pixeltable/catalog/globals.py
+++ b/pixeltable/catalog/globals.py
@@ -7,6 +7,8 @@ _logger = logging.getLogger('pixeltable')
 
 # name of the position column in a component view
 POS_COLUMN_NAME = 'pos'
+_ROWID_COLUMN_NAME = '_rowid'
+
 
 @dataclasses.dataclass
 class UpdateStatus:

--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -144,4 +144,4 @@ class InsertableTable(Table):
 
             >>> tbl.delete(tbl.a > 5)
         """
-        return self._tbl_version_path.delete(where=where)
+        return self._tbl_version.delete(where=where)

--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -144,14 +144,4 @@ class InsertableTable(Table):
 
             >>> tbl.delete(tbl.a > 5)
         """
-        from pixeltable.exprs import Predicate
-        from pixeltable.plan import Planner
-        if where is not None:
-            if not isinstance(where, Predicate):
-                raise excs.Error(f"'where' argument must be a Predicate, got {type(where)}")
-            analysis_info = Planner.analyze(self._tbl_version_path, where)
-            # for now we require that the updated rows can be identified via SQL, rather than via a Python filter
-            if analysis_info.filter is not None:
-                raise excs.Error(f'Filter {analysis_info.filter} not expressible in SQL')
-
-        return self.tbl_version.delete(where)
+        return self._tbl_version_path.delete(where=where)

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -93,7 +93,7 @@ class Table(SchemaObject):
         else:
             return catalog.Catalog.get().tbl_dependents[self._get_id()]
 
-    def df(self) -> 'pixeltable.dataframe.DataFrame':
+    def _df(self) -> 'pixeltable.dataframe.DataFrame':
         """Return a DataFrame for this table.
         """
         # local import: avoid circular imports
@@ -132,30 +132,30 @@ class Table(SchemaObject):
 
     def collect(self) -> 'pixeltable.dataframe.DataFrameResultSet':
         """Return rows from this table."""
-        return self.df().collect()
+        return self._df().collect()
 
     def show(
             self, *args, **kwargs
     ) -> 'pixeltable.dataframe.DataFrameResultSet':
         """Return rows from this table.
         """
-        return self.df().show(*args, **kwargs)
+        return self._df().show(*args, **kwargs)
 
     def head(
             self, *args, **kwargs
     ) -> 'pixeltable.dataframe.DataFrameResultSet':
         """Return the first n rows inserted into this table."""
-        return self.df().head(*args, **kwargs)
+        return self._df().head(*args, **kwargs)
 
     def tail(
             self, *args, **kwargs
     ) -> 'pixeltable.dataframe.DataFrameResultSet':
         """Return the last n rows inserted into this table."""
-        return self.df().tail(*args, **kwargs)
+        return self._df().tail(*args, **kwargs)
 
     def count(self) -> int:
         """Return the number of rows in this table."""
-        return self.df().count()
+        return self._df().count()
 
     def column_names(self) -> list[str]:
         """Return the names of the columns in this table."""

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -749,7 +749,6 @@ class Table(SchemaObject):
             row_updates.append(col_vals)
         return self._tbl_version_path.batch_update(row_updates, rowids, cascade)
 
-    @abc.abstractmethod
     def delete(self, where: Optional['pixeltable.exprs.Predicate'] = None) -> UpdateStatus:
         """Delete rows in this table.
 

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -706,21 +706,8 @@ class Table(SchemaObject):
 
             >>> tbl.update({'int_col': tbl.int_col + 1}, where=tbl.int_col == 0)
         """
-        if self._tbl_version_path.is_snapshot():
-            raise excs.Error('Cannot update a snapshot')
         self._check_is_dropped()
-
-        update_spec = self._validate_update_spec(value_spec, allow_pk=False, allow_exprs=True)
-        from pixeltable.plan import Planner
-        if where is not None:
-            if not isinstance(where, exprs.Predicate):
-                raise excs.Error(f"'where' argument must be a Predicate, got {type(where)}")
-            analysis_info = Planner.analyze(self._tbl_version_path, where)
-            # for now we require that the updated rows can be identified via SQL, rather than via a Python filter
-            if analysis_info.filter is not None:
-                raise excs.Error(f'Filter {analysis_info.filter} not expressible in SQL')
-
-        return self._tbl_version.update(update_spec, where, cascade)
+        return self._tbl_version_path.update(value_spec, where, cascade)
 
     def batch_update(self, rows: Iterable[dict[str, Any]], cascade: bool = True) -> UpdateStatus:
         """Update rows in this table.

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -705,7 +705,7 @@ class Table(SchemaObject):
             >>> tbl.update({'int_col': tbl.int_col + 1}, where=tbl.int_col == 0)
         """
         self._check_is_dropped()
-        return self._tbl_version_path.update(value_spec, where, cascade)
+        return self._tbl_version.update(value_spec, where, cascade)
 
     def batch_update(self, rows: Iterable[dict[str, Any]], cascade: bool = True) -> UpdateStatus:
         """Update rows in this table.
@@ -735,7 +735,7 @@ class Table(SchemaObject):
             raise excs.Error('Table must have primary key for batch update')
 
         for row_spec in rows:
-            col_vals = self._tbl_version_path._validate_update_spec(row_spec, allow_pk=not has_rowid, allow_exprs=False)
+            col_vals = self._tbl_version._validate_update_spec(row_spec, allow_pk=not has_rowid, allow_exprs=False)
             if has_rowid:
                 # we expect the _rowid column to be present for each row
                 assert _ROWID_COLUMN_NAME in row_spec
@@ -746,7 +746,7 @@ class Table(SchemaObject):
                     missing_cols = pk_col_names - set(col.name for col in col_vals.keys())
                     raise excs.Error(f'Primary key columns ({", ".join(missing_cols)}) missing in {row_spec}')
             row_updates.append(col_vals)
-        return self._tbl_version_path.batch_update(row_updates, rowids, cascade)
+        return self._tbl_version.batch_update(row_updates, rowids, cascade)
 
     def delete(self, where: Optional['pixeltable.exprs.Predicate'] = None) -> UpdateStatus:
         """Delete rows in this table.

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -703,13 +703,6 @@ class TableVersion:
         _logger.info(f'TableVersion {self.name}: new version {self.version}')
         return result
 
-    def update(
-            self, update_targets: dict[Column, 'pixeltable.exprs.Expr'],
-            where_clause: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True
-    ) -> UpdateStatus:
-        with Env.get().engine.begin() as conn:
-            return self._update(conn, update_targets, where_clause, cascade)
-
     def batch_update(
             self, batch: list[dict[Column, 'pixeltable.exprs.Expr']], rowids: list[Tuple[int, ...]],
             cascade: bool = True

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -5,25 +5,26 @@ import importlib
 import inspect
 import logging
 import time
-from typing import Optional, List, Dict, Any, Tuple, Type, Set, Iterable
 import uuid
+from typing import Optional, List, Dict, Any, Tuple, Type, Iterable
 from uuid import UUID
 
 import sqlalchemy as sql
 import sqlalchemy.orm as orm
 
 import pixeltable
-import pixeltable.func as func
-import pixeltable.type_system as ts
 import pixeltable.exceptions as excs
+import pixeltable.exprs as exprs
+import pixeltable.func as func
 import pixeltable.index as index
+import pixeltable.type_system as ts
 from pixeltable.env import Env
 from pixeltable.iterators import ComponentIterator
 from pixeltable.metadata import schema
 from pixeltable.utils.filecache import FileCache
 from pixeltable.utils.media_store import MediaStore
 from .column import Column
-from .globals import UpdateStatus, POS_COLUMN_NAME, is_valid_identifier
+from .globals import UpdateStatus, POS_COLUMN_NAME, is_valid_identifier, _ROWID_COLUMN_NAME
 from ..func.globals import resolve_symbol
 
 _logger = logging.getLogger('pixeltable')
@@ -244,7 +245,6 @@ class TableVersion:
     def _init_cols(self, tbl_md: schema.TableMd, schema_version_md: schema.TableSchemaVersionMd) -> None:
         """Initialize self.cols with the columns visible in our effective version"""
         import pixeltable.exprs as exprs
-        from pixeltable.catalog import Catalog
 
         self.cols = []
         self.cols_by_name = {}
@@ -704,6 +704,143 @@ class TableVersion:
         _logger.info(f'TableVersion {self.name}: new version {self.version}')
         return result
 
+    def update(
+        self, value_spec: dict[str, Any], where: Optional['exprs.Predicate'] = None, cascade: bool = True
+    ) -> UpdateStatus:
+        """Update rows in this TableVersionPath.
+        Args:
+            value_spec: a list of (column, value) pairs specifying the columns to update and their new values.
+            where: a Predicate to filter rows to update.
+            cascade: if True, also update all computed columns that transitively depend on the updated columns,
+                including within views.
+        """
+        if self.is_snapshot:
+            raise excs.Error('Cannot update a snapshot')
+
+        from pixeltable.plan import Planner
+
+        update_spec = self._validate_update_spec(value_spec, allow_pk=False, allow_exprs=True)
+        if where is not None:
+            if not isinstance(where, exprs.Predicate):
+                raise excs.Error(f"'where' argument must be a Predicate, got {type(where)}")
+            analysis_info = Planner.analyze(self.path, where)
+            # for now we require that the updated rows can be identified via SQL, rather than via a Python filter
+            if analysis_info.filter is not None:
+                raise excs.Error(f'Filter {analysis_info.filter} not expressible in SQL')
+
+        with Env.get().engine.begin() as conn:
+            return self._update(conn, update_spec, where, cascade)
+
+    def batch_update(
+            self, batch: list[dict[Column, 'exprs.Expr']], rowids: list[tuple[int, ...]], cascade: bool = True
+    ) -> UpdateStatus:
+        """Update rows in batch.
+        Args:
+            batch: one dict per row, each mapping Columns to LiteralExprs representing the new values
+            rowids: if not empty, one tuple per row, each containing the rowid values for the corresponding row in batch
+        """
+        # if we do lookups of rowids, we must have one for each row in the batch
+        assert len(rowids) == 0 or len(rowids) == len(batch)
+        result_status = UpdateStatus()
+        cols_with_excs: set[str] = set()
+        updated_cols: set[str] = set()
+        pk_cols = self.primary_key_columns()
+        use_rowids = len(rowids) > 0
+
+        with Env.get().engine.begin() as conn:
+            for i, row in enumerate(batch):
+                where_clause: Optional[exprs.Expr] = None
+                if use_rowids:
+                    # construct Where clause to match rowid
+                    num_rowid_cols = len(self.store_tbl.rowid_columns())
+                    for col_idx in range(num_rowid_cols):
+                        assert len(rowids[i]) == num_rowid_cols, f'len({rowids[i]}) != {num_rowid_cols}'
+                        clause = exprs.RowidRef(self, col_idx) == rowids[i][col_idx]
+                        if where_clause is None:
+                            where_clause = clause
+                        else:
+                            where_clause = where_clause & clause
+                else:
+                    # construct Where clause for primary key columns
+                    for col in pk_cols:
+                        assert col in row
+                        clause = exprs.ColumnRef(col) == row[col]
+                        if where_clause is None:
+                            where_clause = clause
+                        else:
+                            where_clause = where_clause & clause
+
+                update_targets = {col: row[col] for col in row if col not in pk_cols}
+                status = self._update(conn, update_targets, where_clause, cascade, show_progress=False)
+                result_status.num_rows += status.num_rows
+                result_status.num_excs += status.num_excs
+                result_status.num_computed_values += status.num_computed_values
+                cols_with_excs.update(status.cols_with_excs)
+                updated_cols.update(status.updated_cols)
+
+            result_status.cols_with_excs = list(cols_with_excs)
+            result_status.updated_cols = list(updated_cols)
+            return result_status
+
+    def _update(
+            self, conn: sql.engine.Connection, update_targets: dict[Column, 'pixeltable.exprs.Expr'],
+            where_clause: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True,
+            show_progress: bool = True
+    ) -> UpdateStatus:
+        from pixeltable.plan import Planner
+
+        plan, updated_cols, recomputed_cols = (
+            Planner.create_update_plan(self.path, update_targets, [], where_clause, cascade)
+        )
+        result = self.propagate_update(
+            plan, where_clause.sql_expr() if where_clause is not None else None, recomputed_cols,
+            base_versions=[], conn=conn, timestamp=time.time(), cascade=cascade, show_progress=show_progress)
+        result.updated_cols = updated_cols
+        return result
+
+    def _validate_update_spec(
+            self, value_spec: dict[str, Any], allow_pk: bool, allow_exprs: bool
+    ) -> dict[Column, 'exprs.Expr']:
+        update_targets: dict[Column, exprs.Expr] = {}
+        for col_name, val in value_spec.items():
+            if not isinstance(col_name, str):
+                raise excs.Error(f'Update specification: dict key must be column name, got {col_name!r}')
+            if col_name == _ROWID_COLUMN_NAME:
+                # ignore pseudo-column _rowid
+                continue
+            col = self.path.get_column(col_name, include_bases=False)
+            if col is None:
+                # TODO: return more informative error if this is trying to update a base column
+                raise excs.Error(f'Column {col_name} unknown')
+            if col.is_computed:
+                raise excs.Error(f'Column {col_name} is computed and cannot be updated')
+            if col.is_pk and not allow_pk:
+                raise excs.Error(f'Column {col_name} is a primary key column and cannot be updated')
+            if col.col_type.is_media_type():
+                raise excs.Error(f'Column {col_name} has type image/video/audio/document and cannot be updated')
+
+            # make sure that the value is compatible with the column type
+            try:
+                # check if this is a literal
+                value_expr = exprs.Literal(val, col_type=col.col_type)
+            except TypeError:
+                if not allow_exprs:
+                    raise excs.Error(
+                        f'Column {col_name}: value {val!r} is not a valid literal for this column '
+                        f'(expected {col.col_type})')
+                # it's not a literal, let's try to create an expr from it
+                value_expr = exprs.Expr.from_object(val)
+                if value_expr is None:
+                    raise excs.Error(f'Column {col_name}: value {val!r} is not a recognized literal or expression')
+                if not col.col_type.matches(value_expr.col_type):
+                    raise excs.Error((
+                        f'Type of value {val!r} ({value_expr.col_type}) is not compatible with the type of column '
+                        f'{col_name} ({col.col_type})'
+                    ))
+            update_targets[col] = value_expr
+
+        return update_targets
+
     def propagate_update(
             self, plan: Optional[exec.ExecNode], where_clause: Optional[sql.ClauseElement],
             recomputed_view_cols: List[Column], base_versions: List[Optional[int]], conn: sql.engine.Connection,
@@ -738,8 +875,31 @@ class TableVersion:
         result.cols_with_excs = list(dict.fromkeys(result.cols_with_excs).keys())  # remove duplicates
         return result
 
+    def delete(self, where: Optional['exprs.Predicate'] = None) -> UpdateStatus:
+        """Delete rows in this table.
+        Args:
+            where: a Predicate to filter rows to delete.
+        """
+        assert self.is_insertable()
+        from pixeltable.exprs import Predicate
+        from pixeltable.plan import Planner
+        if where is not None:
+            if not isinstance(where, Predicate):
+                raise excs.Error(f"'where' argument must be a Predicate, got {type(where)}")
+            analysis_info = Planner.analyze(self.path, where)
+            # for now we require that the updated rows can be identified via SQL, rather than via a Python filter
+            if analysis_info.filter is not None:
+                raise excs.Error(f'Filter {analysis_info.filter} not expressible in SQL')
+
+        analysis_info = Planner.analyze(self.path, where)
+        with Env.get().engine.begin() as conn:
+            num_rows = self.propagate_delete(analysis_info.sql_where_clause, base_versions=[], conn=conn, timestamp=time.time())
+
+        status = UpdateStatus(num_rows=num_rows)
+        return status
+
     def propagate_delete(
-            self, where: Optional['pixeltable.exprs.Predicate'], base_versions: List[Optional[int]],
+            self, where: Optional['exprs.Predicate'], base_versions: List[Optional[int]],
             conn: sql.engine.Connection, timestamp: float) -> int:
         """Delete rows in this table and propagate to views.
         Args:

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
 import logging
-import time
-from typing import Optional, Union, Any
+from typing import Optional, Union
 from uuid import UUID
 
-import sqlalchemy as sql
-
 import pixeltable
-import pixeltable.exceptions as excs
-from pixeltable import exprs
-from pixeltable.env import Env
 from .column import Column
-from .globals import POS_COLUMN_NAME, _ROWID_COLUMN_NAME, UpdateStatus
+from .globals import POS_COLUMN_NAME
 from .table_version import TableVersion
 
 _logger = logging.getLogger('pixeltable')
@@ -148,167 +142,6 @@ class TableVersionPath:
             return self.base.has_column(col)
         else:
             return False
-
-    def update(
-        self, value_spec: dict[str, Any], where: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True
-    ) -> UpdateStatus:
-        """Update rows in this TableVersionPath.
-        Args:
-            value_spec: a list of (column, value) pairs specifying the columns to update and their new values.
-            where: a Predicate to filter rows to update.
-            cascade: if True, also update all computed columns that transitively depend on the updated columns,
-                including within views.
-        """
-        if self.is_snapshot():
-            raise excs.Error('Cannot update a snapshot')
-
-        from pixeltable.plan import Planner
-
-        update_spec = self._validate_update_spec(value_spec, allow_pk=False, allow_exprs=True)
-        if where is not None:
-            if not isinstance(where, exprs.Predicate):
-                raise excs.Error(f"'where' argument must be a Predicate, got {type(where)}")
-            analysis_info = Planner.analyze(self, where)
-            # for now we require that the updated rows can be identified via SQL, rather than via a Python filter
-            if analysis_info.filter is not None:
-                raise excs.Error(f'Filter {analysis_info.filter} not expressible in SQL')
-
-        with Env.get().engine.begin() as conn:
-            return self._update(conn, update_spec, where, cascade)
-
-    def batch_update(
-            self, batch: list[dict[Column, 'pixeltable.exprs.Expr']], rowids: list[tuple[int, ...]],
-            cascade: bool = True
-    ) -> UpdateStatus:
-        """Update rows in batch.
-        Args:
-            batch: one dict per row, each mapping Columns to LiteralExprs representing the new values
-            rowids: if not empty, one tuple per row, each containing the rowid values for the corresponding row in batch
-        """
-        # if we do lookups of rowids, we must have one for each row in the batch
-        assert len(rowids) == 0 or len(rowids) == len(batch)
-        result_status = UpdateStatus()
-        cols_with_excs: set[str] = set()
-        updated_cols: set[str] = set()
-        pk_cols = self.tbl_version.primary_key_columns()
-        use_rowids = len(rowids) > 0
-
-        with Env.get().engine.begin() as conn:
-            for i, row in enumerate(batch):
-                where_clause: Optional[exprs.Expr] = None
-                if use_rowids:
-                    # construct Where clause to match rowid
-                    num_rowid_cols = len(self.tbl_version.store_tbl.rowid_columns())
-                    for col_idx in range(num_rowid_cols):
-                        assert len(rowids[i]) == num_rowid_cols, f'len({rowids[i]}) != {num_rowid_cols}'
-                        clause = exprs.RowidRef(self.tbl_version, col_idx) == rowids[i][col_idx]
-                        if where_clause is None:
-                            where_clause = clause
-                        else:
-                            where_clause = where_clause & clause
-                else:
-                    # construct Where clause for primary key columns
-                    for col in pk_cols:
-                        assert col in row
-                        clause = exprs.ColumnRef(col) == row[col]
-                        if where_clause is None:
-                            where_clause = clause
-                        else:
-                            where_clause = where_clause & clause
-
-                update_targets = {col: row[col] for col in row if col not in pk_cols}
-                status = self._update(conn, update_targets, where_clause, cascade, show_progress=False)
-                result_status.num_rows += status.num_rows
-                result_status.num_excs += status.num_excs
-                result_status.num_computed_values += status.num_computed_values
-                cols_with_excs.update(status.cols_with_excs)
-                updated_cols.update(status.updated_cols)
-
-            result_status.cols_with_excs = list(cols_with_excs)
-            result_status.updated_cols = list(updated_cols)
-            return result_status
-
-    def _update(
-            self, conn: sql.engine.Connection, update_targets: dict[Column, 'pixeltable.exprs.Expr'],
-            where_clause: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True,
-            show_progress: bool = True
-    ) -> UpdateStatus:
-        from pixeltable.plan import Planner
-
-        plan, updated_cols, recomputed_cols = (
-            Planner.create_update_plan(self, update_targets, [], where_clause, cascade)
-        )
-        result = self.tbl_version.propagate_update(
-            plan, where_clause.sql_expr() if where_clause is not None else None, recomputed_cols,
-            base_versions=[], conn=conn, timestamp=time.time(), cascade=cascade, show_progress=show_progress)
-        result.updated_cols = updated_cols
-        return result
-
-    def _validate_update_spec(
-            self, value_spec: dict[str, Any], allow_pk: bool, allow_exprs: bool
-    ) -> dict[Column, 'pixeltable.exprs.Expr']:
-        update_targets: dict[Column, exprs.Expr] = {}
-        for col_name, val in value_spec.items():
-            if not isinstance(col_name, str):
-                raise excs.Error(f'Update specification: dict key must be column name, got {col_name!r}')
-            if col_name == _ROWID_COLUMN_NAME:
-                # ignore pseudo-column _rowid
-                continue
-            col = self.get_column(col_name, include_bases=False)
-            if col is None:
-                # TODO: return more informative error if this is trying to update a base column
-                raise excs.Error(f'Column {col_name} unknown')
-            if col.is_computed:
-                raise excs.Error(f'Column {col_name} is computed and cannot be updated')
-            if col.is_pk and not allow_pk:
-                raise excs.Error(f'Column {col_name} is a primary key column and cannot be updated')
-            if col.col_type.is_media_type():
-                raise excs.Error(f'Column {col_name} has type image/video/audio/document and cannot be updated')
-
-            # make sure that the value is compatible with the column type
-            try:
-                # check if this is a literal
-                value_expr = exprs.Literal(val, col_type=col.col_type)
-            except TypeError:
-                if not allow_exprs:
-                    raise excs.Error(
-                        f'Column {col_name}: value {val!r} is not a valid literal for this column '
-                        f'(expected {col.col_type})')
-                # it's not a literal, let's try to create an expr from it
-                value_expr = exprs.Expr.from_object(val)
-                if value_expr is None:
-                    raise excs.Error(f'Column {col_name}: value {val!r} is not a recognized literal or expression')
-                if not col.col_type.matches(value_expr.col_type):
-                    raise excs.Error((
-                        f'Type of value {val!r} ({value_expr.col_type}) is not compatible with the type of column '
-                        f'{col_name} ({col.col_type})'
-                    ))
-            update_targets[col] = value_expr
-
-        return update_targets
-
-    def delete(self, where: Optional['pixeltable.exprs.Predicate'] = None) -> UpdateStatus:
-        """Delete rows in this table.
-        Args:
-            where: a Predicate to filter rows to delete.
-        """
-        assert self.is_insertable()
-        from pixeltable.exprs import Predicate
-        from pixeltable.plan import Planner
-        if where is not None:
-            if not isinstance(where, Predicate):
-                raise excs.Error(f"'where' argument must be a Predicate, got {type(where)}")
-            analysis_info = Planner.analyze(self, where)
-            # for now we require that the updated rows can be identified via SQL, rather than via a Python filter
-            if analysis_info.filter is not None:
-                raise excs.Error(f'Filter {analysis_info.filter} not expressible in SQL')
-
-        analysis_info = Planner.analyze(self, where)
-        with Env.get().engine.begin() as conn:
-            num_rows = self.tbl_version.propagate_delete(analysis_info.sql_where_clause, base_versions=[], conn=conn, timestamp=time.time())
-
-        status = UpdateStatus(num_rows=num_rows)
-        return status
 
     def as_dict(self) -> dict:
         return {

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -12,7 +12,7 @@ import pixeltable.exceptions as excs
 from pixeltable import exprs
 from pixeltable.env import Env
 from .column import Column
-from .globals import POS_COLUMN_NAME, UpdateStatus
+from .globals import POS_COLUMN_NAME, _ROWID_COLUMN_NAME, UpdateStatus
 from .table_version import TableVersion
 
 _logger = logging.getLogger('pixeltable')
@@ -29,8 +29,6 @@ class TableVersionPath:
     TableVersionPath contains all metadata needed to execute queries and updates against a particular version of a
     table/view.
     """
-
-    __ROWID_COLUMN_NAME = '_rowid'
 
     def __init__(self, tbl_version: TableVersion, base: Optional[TableVersionPath] = None):
         assert tbl_version is not None
@@ -253,7 +251,7 @@ class TableVersionPath:
         for col_name, val in value_spec.items():
             if not isinstance(col_name, str):
                 raise excs.Error(f'Update specification: dict key must be column name, got {col_name!r}')
-            if col_name == self.__ROWID_COLUMN_NAME:
+            if col_name == _ROWID_COLUMN_NAME:
                 # ignore pseudo-column _rowid
                 continue
             col = self.get_column(col_name, include_bases=False)

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Optional, Union, Any
 from uuid import UUID
+
+import sqlalchemy as sql
 
 import pixeltable
 import pixeltable.exceptions as excs
@@ -13,6 +16,7 @@ from .globals import POS_COLUMN_NAME, UpdateStatus
 from .table_version import TableVersion
 
 _logger = logging.getLogger('pixeltable')
+
 
 class TableVersionPath:
     """
@@ -150,6 +154,13 @@ class TableVersionPath:
     def update(
         self, value_spec: dict[str, Any], where: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True
     ) -> UpdateStatus:
+        """Update rows in this TableVersionPath.
+        Args:
+            value_spec: a list of (column, value) pairs specifying the columns to update and their new values.
+            where: a Predicate to filter rows to update.
+            cascade: if True, also update all computed columns that transitively depend on the updated columns,
+                including within views.
+        """
         if self.is_snapshot():
             raise excs.Error('Cannot update a snapshot')
 
@@ -165,7 +176,75 @@ class TableVersionPath:
                 raise excs.Error(f'Filter {analysis_info.filter} not expressible in SQL')
 
         with Env.get().engine.begin() as conn:
-            return self.tbl_version._update(conn, update_spec, where, cascade)
+            return self._update(conn, update_spec, where, cascade)
+
+    def batch_update(
+            self, batch: list[dict[Column, 'pixeltable.exprs.Expr']], rowids: list[tuple[int, ...]],
+            cascade: bool = True
+    ) -> UpdateStatus:
+        """Update rows in batch.
+        Args:
+            batch: one dict per row, each mapping Columns to LiteralExprs representing the new values
+            rowids: if not empty, one tuple per row, each containing the rowid values for the corresponding row in batch
+        """
+        # if we do lookups of rowids, we must have one for each row in the batch
+        assert len(rowids) == 0 or len(rowids) == len(batch)
+        result_status = UpdateStatus()
+        cols_with_excs: set[str] = set()
+        updated_cols: set[str] = set()
+        pk_cols = self.tbl_version.primary_key_columns()
+        use_rowids = len(rowids) > 0
+
+        with Env.get().engine.begin() as conn:
+            for i, row in enumerate(batch):
+                where_clause: Optional[exprs.Expr] = None
+                if use_rowids:
+                    # construct Where clause to match rowid
+                    num_rowid_cols = len(self.tbl_version.store_tbl.rowid_columns())
+                    for col_idx in range(num_rowid_cols):
+                        assert len(rowids[i]) == num_rowid_cols, f'len({rowids[i]}) != {num_rowid_cols}'
+                        clause = exprs.RowidRef(self.tbl_version, col_idx) == rowids[i][col_idx]
+                        if where_clause is None:
+                            where_clause = clause
+                        else:
+                            where_clause = where_clause & clause
+                else:
+                    # construct Where clause for primary key columns
+                    for col in pk_cols:
+                        assert col in row
+                        clause = exprs.ColumnRef(col) == row[col]
+                        if where_clause is None:
+                            where_clause = clause
+                        else:
+                            where_clause = where_clause & clause
+
+                update_targets = {col: row[col] for col in row if col not in pk_cols}
+                status = self._update(conn, update_targets, where_clause, cascade, show_progress=False)
+                result_status.num_rows += status.num_rows
+                result_status.num_excs += status.num_excs
+                result_status.num_computed_values += status.num_computed_values
+                cols_with_excs.update(status.cols_with_excs)
+                updated_cols.update(status.updated_cols)
+
+            result_status.cols_with_excs = list(cols_with_excs)
+            result_status.updated_cols = list(updated_cols)
+            return result_status
+
+    def _update(
+            self, conn: sql.engine.Connection, update_targets: dict[Column, 'pixeltable.exprs.Expr'],
+            where_clause: Optional['pixeltable.exprs.Predicate'] = None, cascade: bool = True,
+            show_progress: bool = True
+    ) -> UpdateStatus:
+        from pixeltable.plan import Planner
+
+        plan, updated_cols, recomputed_cols = (
+            Planner.create_update_plan(self, update_targets, [], where_clause, cascade)
+        )
+        result = self.tbl_version._propagate_update(
+            plan, where_clause.sql_expr() if where_clause is not None else None, recomputed_cols,
+            base_versions=[], conn=conn, timestamp=time.time(), cascade=cascade, show_progress=show_progress)
+        result.updated_cols = updated_cols
+        return result
 
     def _validate_update_spec(
             self, value_spec: dict[str, Any], allow_pk: bool, allow_exprs: bool

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -1,29 +1,32 @@
 from __future__ import annotations
-import logging
-from typing import List, Optional, Type, Dict, Set, Any, Iterable
-from uuid import UUID
+
 import inspect
+import logging
+from typing import Optional, Type, Dict, Set, Any, Iterable, TYPE_CHECKING
+from uuid import UUID
 
 import sqlalchemy.orm as orm
 
+import pixeltable.catalog as catalog
+import pixeltable.exceptions as excs
+import pixeltable.func as func
+import pixeltable.metadata.schema as md_schema
+from pixeltable.env import Env
+from pixeltable.exceptions import Error
+from pixeltable.iterators import ComponentIterator
+from pixeltable.type_system import InvalidType, IntType
+from .catalog import Catalog
+from .column import Column
+from .globals import POS_COLUMN_NAME, UpdateStatus
 from .table import Table
 from .table_version import TableVersion
 from .table_version_path import TableVersionPath
-from .column import Column
-from .catalog import Catalog
-from .globals import POS_COLUMN_NAME, UpdateStatus
-from pixeltable.env import Env
-from pixeltable.iterators import ComponentIterator
-from pixeltable.exceptions import Error
-import pixeltable.func as func
-import pixeltable.type_system as ts
-import pixeltable.catalog as catalog
-import pixeltable.metadata.schema as md_schema
-from pixeltable.type_system import InvalidType, IntType
-import pixeltable.exceptions as excs
 
+if TYPE_CHECKING:
+    import pixeltable as pxt
 
 _logger = logging.getLogger('pixeltable')
+
 
 class View(Table):
     """A `Table` that presents a virtual view of another table (or view).
@@ -34,10 +37,11 @@ class View(Table):
     is simply a reference to a specific set of base versions.
     """
     def __init__(
-            self, id: UUID, dir_id: UUID, name: str, tbl_version_path: TableVersionPath, base: Table,
+            self, id: UUID, dir_id: UUID, name: str, tbl_version_path: TableVersionPath, base_id: UUID,
             snapshot_only: bool):
         super().__init__(id, dir_id, name, tbl_version_path)
-        self._base = base  # keep a reference to the base Table, so that we can keep track of its dependents
+        assert base_id in catalog.Catalog.get().tbl_dependents
+        self._base_id = base_id  # keep a reference to the base Table ID, so that we can keep track of its dependents
         self._snapshot_only = snapshot_only
 
     @classmethod
@@ -46,8 +50,8 @@ class View(Table):
 
     @classmethod
     def create(
-            cls, dir_id: UUID, name: str, base: Table, schema: Dict[str, Any],
-            predicate: 'exprs.Predicate', is_snapshot: bool, num_retained_versions: int, comment: str,
+            cls, dir_id: UUID, name: str, base: TableVersionPath, schema: Dict[str, Any],
+            predicate: 'pxt.exprs.Predicate', is_snapshot: bool, num_retained_versions: int, comment: str,
             iterator_cls: Optional[Type[ComponentIterator]], iterator_args: Optional[Dict]
     ) -> View:
         columns = cls._create_columns(schema)
@@ -55,8 +59,8 @@ class View(Table):
 
         # verify that filter can be evaluated in the context of the base
         if predicate is not None:
-            if not predicate.is_bound_by(base._tbl_version_path):
-                raise excs.Error(f'Filter cannot be computed in the context of the base {base._name}')
+            if not predicate.is_bound_by(base):
+                raise excs.Error(f'Filter cannot be computed in the context of the base {base.tbl_name()}')
             # create a copy that we can modify and store
             predicate = predicate.copy()
 
@@ -65,9 +69,9 @@ class View(Table):
             if not col.is_computed:
                 continue
             # make sure that the value can be computed in the context of the base
-            if col.value_expr is not None and not col.value_expr.is_bound_by(base._tbl_version_path):
+            if col.value_expr is not None and not col.value_expr.is_bound_by(base):
                 raise excs.Error(
-                    f'Column {col.name}: value expression cannot be computed in the context of the base {base._name}')
+                    f'Column {col.name}: value expression cannot be computed in the context of the base {base.tbl_name()}')
 
         if iterator_cls is not None:
             assert iterator_args is not None
@@ -114,7 +118,7 @@ class View(Table):
             iterator_args_expr = InlineDict(iterator_args) if iterator_args is not None else None
             iterator_class_fqn = f'{iterator_cls.__module__}.{iterator_cls.__name__}' if iterator_cls is not None \
                 else None
-            base_version_path = cls._get_snapshot_path(base._tbl_version_path) if is_snapshot else base._tbl_version_path
+            base_version_path = cls._get_snapshot_path(base) if is_snapshot else base
             base_versions = [
                 (tbl_version.id.hex, tbl_version.version if is_snapshot or tbl_version.is_snapshot else None)
                 for tbl_version in base_version_path.get_tbl_versions()
@@ -139,11 +143,11 @@ class View(Table):
                 session, dir_id, name, columns, num_retained_versions, comment, base_path=base_version_path, view_md=view_md)
             if tbl_version is None:
                 # this is purely a snapshot: we use the base's tbl version path
-                view = cls(id, dir_id, name, base_version_path, base, snapshot_only=True)
+                view = cls(id, dir_id, name, base_version_path, base.tbl_id(), snapshot_only=True)
                 _logger.info(f'created snapshot {name}')
             else:
                 view = cls(
-                    id, dir_id, name, TableVersionPath(tbl_version, base=base_version_path), base,
+                    id, dir_id, name, TableVersionPath(tbl_version, base=base_version_path), base.tbl_id(),
                     snapshot_only=False)
                 _logger.info(f'Created view `{name}`, id={tbl_version.id}')
 
@@ -156,7 +160,7 @@ class View(Table):
             session.commit()
             cat = Catalog.get()
             cat.tbl_dependents[view._id] = []
-            cat.tbl_dependents[base._id].append(view)
+            cat.tbl_dependents[base.tbl_id()].append(view)
             cat.tbls[view._id] = view
             return view
 
@@ -200,7 +204,7 @@ class View(Table):
             del cat.tbls[self._id]
         else:
             super()._drop()
-        cat.tbl_dependents[self._base._id].remove(self)
+        cat.tbl_dependents[self._base_id].remove(self)
         del cat.tbl_dependents[self._id]
 
     def insert(

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -710,13 +710,13 @@ class DataFrame:
 
     def update(self, value_spec: dict[str, Any], cascade: bool = True) -> UpdateStatus:
         self._validate_mutable('update')
-        return self.tbl.update(value_spec, where=self.where_clause, cascade=cascade)
+        return self.tbl.tbl_version.update(value_spec, where=self.where_clause, cascade=cascade)
 
     def delete(self) -> UpdateStatus:
         self._validate_mutable('delete')
         if not self.tbl.is_insertable():
             raise excs.Error(f'Cannot delete from view')
-        return self.tbl.delete(where=self.where_clause)
+        return self.tbl.tbl_version.delete(where=self.where_clause)
 
     def _validate_mutable(self, op_name: str) -> None:
         """Tests whether this `DataFrame` can be mutated (such as by an update operation)."""

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -595,7 +595,7 @@ class DataFrame:
                 raise excs.Error(f'Invalid name: {name}')
         base_list = [(expr, None) for expr in items] + [(expr, k) for (k, expr) in named_items.items()]
         if len(base_list) == 0:
-            raise excs.Error(f'Empty select list')
+            return self
 
         # analyze select list; wrap literals with the corresponding expressions
         select_list = []

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -717,12 +717,12 @@ class DataFrame:
         return self.tbl.delete(where=self.where_clause)
 
     def _validate_writable(self, op_name: str) -> None:
-        if self.select_list is not None:
-            raise excs.Error(f'Cannot use `{op_name}` after `select`')
-        if self.group_by_clause is not None:
+        if self.group_by_clause is not None or self.grouping_tbl is not None:
             raise excs.Error(f'Cannot use `{op_name}` after `group_by`')
         if self.order_by_clause is not None:
             raise excs.Error(f'Cannot use `{op_name}` after `order_by`')
+        if self.select_list is not None:
+            raise excs.Error(f'Cannot use `{op_name}` after `select`')
         if self.limit_val is not None:
             raise excs.Error(f'Cannot use `{op_name}` after `limit`')
 

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -721,11 +721,9 @@ class DataFrame:
             raise excs.Error(f'Cannot use `{op_name}` after `select`')
         if self.group_by_clause is not None:
             raise excs.Error(f'Cannot use `{op_name}` after `group_by`')
-        if self.grouping_tbl is not None:
-            raise excs.Error(f'Cannot use `{op_name}` with aggregate')
         if self.order_by_clause is not None:
             raise excs.Error(f'Cannot use `{op_name}` after `order_by`')
-        if self.limit is not None:
+        if self.limit_val is not None:
             raise excs.Error(f'Cannot use `{op_name}` after `limit`')
 
     def __getitem__(self, index: object) -> DataFrame:

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -124,7 +124,6 @@ def create_view(
     """
     if isinstance(base, catalog.Table):
         tbl_version_path = base._tbl_version_path
-        # assert base._name == tbl_version_path.tbl_name()
     elif isinstance(base, DataFrame):
         base._validate_writable('create_view')
         tbl_version_path = base.tbl

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -125,9 +125,13 @@ def create_view(
     if isinstance(base, catalog.Table):
         tbl_version_path = base._tbl_version_path
     elif isinstance(base, DataFrame):
-        base._validate_writable('create_view')
+        base._validate_mutable('create_view')
         tbl_version_path = base.tbl
-        filter = base.where_clause if filter is None else base.where_clause & filter
+        if base.where_clause is not None and filter is not None:
+            raise excs.Error(
+                'Cannot specify a `filter` directly if one is already declared in a `DataFrame.where` clause'
+            )
+        filter = base.where_clause
     else:
         raise excs.Error('`base` must be an instance of `Table` or `DataFrame`')
     assert isinstance(base, catalog.Table) or isinstance(base, DataFrame)

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -124,12 +124,13 @@ def create_view(
     """
     if isinstance(base, catalog.Table):
         tbl_version_path = base._tbl_version_path
+        # assert base._name == tbl_version_path.tbl_name()
     elif isinstance(base, DataFrame):
         base._validate_writable('create_view')
         tbl_version_path = base.tbl
         filter = base.where_clause if filter is None else base.where_clause & filter
     else:
-        raise excs.Error('`base`must be an instance of `Table` or `DataFrame`')
+        raise excs.Error('`base` must be an instance of `Table` or `DataFrame`')
     assert isinstance(base, catalog.Table) or isinstance(base, DataFrame)
     path = catalog.Path(path_str)
     try:

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -1,13 +1,13 @@
 import dataclasses
 import logging
-from typing import Any, Optional, Union, Type
+from typing import Any, Optional, Union
 
 import pandas as pd
 import sqlalchemy as sql
 from sqlalchemy.util.preloaded import orm
 
 import pixeltable.exceptions as excs
-from pixeltable import catalog, func
+from pixeltable import catalog, func, DataFrame
 from pixeltable.catalog import Catalog
 from pixeltable.env import Env
 from pixeltable.exprs import Predicate
@@ -78,7 +78,7 @@ def create_table(
 
 def create_view(
     path_str: str,
-    base: catalog.Table,
+    base: Union[catalog.Table, DataFrame],
     *,
     schema: Optional[dict[str, Any]] = None,
     filter: Optional[Predicate] = None,
@@ -92,7 +92,7 @@ def create_view(
 
     Args:
         path_str: Path to the view.
-        base: Table (ie, table or view or snapshot) to base the view on.
+        base: Table (i.e., table or view or snapshot) or DataFrame to base the view on.
         schema: dictionary mapping column names to column types, value expressions, or to column specifications.
         filter: Predicate to filter rows of the base table.
         is_snapshot: Whether the view is a snapshot.
@@ -122,7 +122,15 @@ def create_view(
         >>> snapshot_view = cl.create_view(
             'my_snapshot', base, schema={'col3': base.col2 + 1}, filter=base.col1 > 10, is_snapshot=True)
     """
-    assert isinstance(base, catalog.Table)
+    if isinstance(base, catalog.Table):
+        tbl_version_path = base._tbl_version_path
+    elif isinstance(base, DataFrame):
+        base._validate_writable('create_view')
+        tbl_version_path = base.tbl
+        filter = base.where_clause if filter is None else base.where_clause & filter
+    else:
+        raise excs.Error('`base`must be an instance of `Table` or `DataFrame`')
+    assert isinstance(base, catalog.Table) or isinstance(base, DataFrame)
     path = catalog.Path(path_str)
     try:
         Catalog.get().paths.check_is_valid(path, expected=None)
@@ -139,10 +147,11 @@ def create_view(
         iterator_class, iterator_args = None, None
     else:
         iterator_class, iterator_args = iterator
+
     view = catalog.View.create(
         dir._id,
         path.name,
-        base=base,
+        base=tbl_version_path,
         schema=schema,
         predicate=filter,
         is_snapshot=is_snapshot,

--- a/tests/io/test_hf_datasets.py
+++ b/tests/io/test_hf_datasets.py
@@ -57,7 +57,7 @@ class TestHfDatasets:
                 schema_override=rec.get('schema_override', None),
             )
             if isinstance(hf_dataset, datasets.Dataset):
-                self._assert_hf_dataset_equal(hf_dataset, tab._df(), split_column_name)
+                self._assert_hf_dataset_equal(hf_dataset, tab.select(), split_column_name)
             elif isinstance(hf_dataset, datasets.DatasetDict):
                 assert tab.count() == sum(hf_dataset.num_rows.values())
                 assert split_column_name in tab.column_names()

--- a/tests/io/test_hf_datasets.py
+++ b/tests/io/test_hf_datasets.py
@@ -57,7 +57,7 @@ class TestHfDatasets:
                 schema_override=rec.get('schema_override', None),
             )
             if isinstance(hf_dataset, datasets.Dataset):
-                self._assert_hf_dataset_equal(hf_dataset, tab.df(), split_column_name)
+                self._assert_hf_dataset_equal(hf_dataset, tab._df(), split_column_name)
             elif isinstance(hf_dataset, datasets.DatasetDict):
                 assert tab.count() == sum(hf_dataset.num_rows.values())
                 assert split_column_name in tab.column_names()

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -85,14 +85,14 @@ class TestPandas:
         t4 = import_excel('fin_sample', 'tests/data/datasets/Financial Sample.xlsx')
         assert t4.count() == 700
         assert t4.column_types()['Date'] == pxt.TimestampType()
-        entry = t4._df().limit(1).collect()[0]
+        entry = t4.limit(1).collect()[0]
         assert entry['Date'] == datetime.datetime(2014, 1, 1, 0, 0)
 
         t5 = import_excel('sale_data', 'tests/data/datasets/SaleData.xlsx')
         assert t5.count() == 45
         assert t5.column_types()['OrderDate'] == pxt.TimestampType(nullable=True)
         # Ensure valid mapping of 'NaT' -> None
-        assert t5._df().collect()[43]['OrderDate'] is None
+        assert t5.collect()[43]['OrderDate'] is None
 
     def test_pandas_errors(self, reset_db) -> None:
         from pixeltable.io import import_csv

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -85,14 +85,14 @@ class TestPandas:
         t4 = import_excel('fin_sample', 'tests/data/datasets/Financial Sample.xlsx')
         assert t4.count() == 700
         assert t4.column_types()['Date'] == pxt.TimestampType()
-        entry = t4.df().limit(1).collect()[0]
+        entry = t4._df().limit(1).collect()[0]
         assert entry['Date'] == datetime.datetime(2014, 1, 1, 0, 0)
 
         t5 = import_excel('sale_data', 'tests/data/datasets/SaleData.xlsx')
         assert t5.count() == 45
         assert t5.column_types()['OrderDate'] == pxt.TimestampType(nullable=True)
         # Ensure valid mapping of 'NaT' -> None
-        assert t5.df().collect()[43]['OrderDate'] is None
+        assert t5._df().collect()[43]['OrderDate'] is None
 
     def test_pandas_errors(self, reset_db) -> None:
         from pixeltable.io import import_csv

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -20,6 +20,10 @@ class TestDataFrame:
 
     def test_select_where(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
+        res1 = t.show(0)
+        res2 = t.select().show(0)
+        assert res1 == res2
+
         res1 = t[t.c1, t.c2, t.c3].show(0)
         res2 = t.select(t.c1, t.c2, t.c3).show(0)
         assert res1 == res2

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -292,6 +292,22 @@ class TestDataFrame:
             v2.select(pxt.functions.video.make_video(v2.pos, v2.frame)).group_by(t2).delete()
         assert 'Cannot use `delete` after `group_by`' in str(exc_info.value)
 
+        # delete from view
+        with pytest.raises(excs.Error) as exc_info:
+            v2.where(t.c2 < 10).delete()
+        assert 'Cannot delete from view' in str(exc_info.value)
+
+        # update snapshot
+        snap = pxt.create_view('test_snapshot', t, is_snapshot=True)
+        with pytest.raises(excs.Error) as exc_info:
+            snap.where(t.c2 < 10).update({'c3': 0.0})
+        assert 'Cannot update a snapshot' in str(exc_info.value)
+
+        # delete from snapshot
+        with pytest.raises(excs.Error) as exc_info:
+            snap.where(t.c2 < 10).delete()
+        assert 'Cannot delete from view' in str(exc_info.value)
+
     def test_to_pytorch_dataset(self, all_datatypes_tbl: catalog.Table) -> None:
         """ tests all types are handled correctly in this conversion
         """

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -583,7 +583,7 @@ class TestTable:
 
         t.insert([{'c1': 'this is a python\x00string'}])
         assert t.count() == 1
-        for tup in t._df().collect():
+        for tup in t.collect():
             assert tup['c1'] == 'this is a python string'
 
     def test_query(self, reset_db) -> None:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -583,7 +583,7 @@ class TestTable:
 
         t.insert([{'c1': 'this is a python\x00string'}])
         assert t.count() == 1
-        for tup in t.df().collect():
+        for tup in t._df().collect():
             assert tup['c1'] == 'this is a python string'
 
     def test_query(self, reset_db) -> None:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -110,6 +110,18 @@ class TestView:
         assert t.count() == 110
         check_view(t, v)
 
+        # check alternate view creation syntax (via a DataFrame)
+        v2 = pxt.create_view('test_view_alt', t.where(t.c2 < 10), schema=schema)
+        validate_update_status(v2.add_column(v3=v2.v1 * 2.0), expected_rows=10)
+        validate_update_status(v2.add_column(v4=v2.v2[0]), expected_rows=10)
+        check_view(t, v2)
+
+        # combination of filter + dataframe
+        v3 = pxt.create_view('test_view_alt2', t.where(t.c2 < 10), filter=t.c2 >= 8, schema=schema)
+        assert v3.count() == 4
+        validate_update_status(v3.add_column(v3=v3.v1 * 2.0), expected_rows=4)
+        validate_update_status(v3.add_column(v4=v3.v2[0]), expected_rows=4)
+
         # test delete view
         pxt.drop_table('test_view')
         with pytest.raises(excs.Error) as exc_info:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -138,6 +138,26 @@ class TestView:
             _ = pxt.create_view('lambda_view', t, schema={'v1': lambda c3: c3 * 2.0})
         assert 'computed with a callable' in str(exc_info.value).lower()
 
+    def test_from_dataframe(self, reset_db) -> None:
+        t = self.create_tbl()
+
+        # TODO(aaron-siegel): We actually do want to support this one
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.create_view('test_view', t.select(t.c2))
+        assert 'Cannot use `create_view` after `select`' in str(exc_info.value)
+
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.create_view('test_view', t.group_by(t.c2))
+        assert 'Cannot use `create_view` after `group_by`' in str(exc_info.value)
+
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.create_view('test_view', t.order_by(t.c2))
+        assert 'Cannot use `create_view` after `order_by`' in str(exc_info.value)
+
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.create_view('test_view', t.limit(10))
+        assert 'Cannot use `create_view` after `limit`' in str(exc_info.value)
+
     def test_parallel_views(self, reset_db) -> None:
         """Two views over the same base table, with non-overlapping filters"""
         t = self.create_tbl()
@@ -499,11 +519,11 @@ class TestView:
 
         with pytest.raises(excs.Error) as exc_info:
             v = pxt.create_view('test_view', s, schema={'v1': t.c3 * 2.0})
-        assert 'value expression cannot be computed in the context of the base test_snap' in str(exc_info.value)
+        assert 'value expression cannot be computed in the context of the base test_tbl' in str(exc_info.value)
 
         with pytest.raises(excs.Error) as exc_info:
             v = pxt.create_view('test_view', s, filter=t.c2 < 10)
-        assert 'filter cannot be computed in the context of the base test_snap' in str(exc_info.value).lower()
+        assert 'filter cannot be computed in the context of the base test_tbl' in str(exc_info.value).lower()
 
         # create view with filter and computed columns
         schema = {

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -116,12 +116,6 @@ class TestView:
         validate_update_status(v2.add_column(v4=v2.v2[0]), expected_rows=10)
         check_view(t, v2)
 
-        # combination of filter + dataframe
-        v3 = pxt.create_view('test_view_alt2', t.where(t.c2 < 10), filter=t.c2 >= 8, schema=schema)
-        assert v3.count() == 4
-        validate_update_status(v3.add_column(v3=v3.v1 * 2.0), expected_rows=4)
-        validate_update_status(v3.add_column(v4=v3.v2[0]), expected_rows=4)
-
         # test delete view
         pxt.drop_table('test_view')
         with pytest.raises(excs.Error) as exc_info:
@@ -157,6 +151,11 @@ class TestView:
         with pytest.raises(excs.Error) as exc_info:
             pxt.create_view('test_view', t.limit(10))
         assert 'Cannot use `create_view` after `limit`' in str(exc_info.value)
+
+        # combination of filter + dataframe
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.create_view('test_view', t.where(t.c2 < 10), filter=t.c2 >= 8)
+        assert 'Cannot specify a `filter` directly' in str(exc_info.value)
 
     def test_parallel_views(self, reset_db) -> None:
         """Two views over the same base table, with non-overlapping filters"""


### PR DESCRIPTION
- Allow updates and deletes from a DataFrame: `t.where(t.c1 < 10).delete()`
- Allow view creation from a DataFrame: `pxt.create_view('my_view', t.where(t.c1 < 10))`
- Allow empty select statement: `t.select()`
- Rename `t.df()` to `t._df()` (the user-facing way to do this is now `t.select()`)

Moves a bunch of update/delete logic from `Table` into `TableVersion`.

Reference doc: https://www.notion.so/pixeltable/Pixeltable-API-Suggestions-0cf550f777f245f2a82654125b9ba465