### PR TITLE
Quality-of-life scripts for Pixeltable postgres admin

### DIFF
--- a/scripts/drop-pxt-db.sh
+++ b/scripts/drop-pxt-db.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+POSTGRES_BIN_PATH=$(python -c 'import pgserver; import sys; sys.stdout.write(str(pgserver._commands.POSTGRES_BIN_PATH))')
+if [ -z "$PIXELTABLE_HOME" ]; then
+    PIXELTABLE_HOME=~/.pixeltable
+fi
+PIXELTABLE_URL="postgresql://postgres:@/postgres?host=$PIXELTABLE_HOME/pgdata"
+
+
+echo "THIS COMMAND WILL DELETE EVERYTHING IN YOUR PIXELTABLE DATABASE AT: $PIXELTABLE_HOME/pgdata"
+read -p "Type \"delete\" if you're sure: "
+
+if [[ "$REPLY" != "delete" ]]; then
+    exit 0
+fi
+
+echo "Deleting!"
+
+PG_DISCONNECT="SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND datname = 'pixeltable';"
+PG_DROP="DROP DATABASE pixeltable;"
+
+"$POSTGRES_BIN_PATH/psql" "$PIXELTABLE_URL" -U postgres -c "$PG_DISCONNECT"
+"$POSTGRES_BIN_PATH/psql" "$PIXELTABLE_URL" -U postgres -c "$PG_DROP"

--- a/scripts/postgres.sh
+++ b/scripts/postgres.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+# Run this script inside your conda environment to open a postgres connection to your Pixeltable DB.
+
+POSTGRES_BIN_PATH=$(python -c 'import pgserver; import sys; sys.stdout.write(str(pgserver._commands.POSTGRES_BIN_PATH))')
+if [ -z "$PIXELTABLE_HOME" ]; then
+    PIXELTABLE_HOME=~/.pixeltable
+fi
+PIXELTABLE_URL="postgresql://postgres:@/postgres?host=$PIXELTABLE_HOME/pgdata"
+"$POSTGRES_BIN_PATH/psql" "$PIXELTABLE_URL" -U postgres


### PR DESCRIPTION
Two useful maintenance scripts:
- `postgres.sh` opens a `psql` connection to $PIXELTABLE_HOME using the pgserver-installed postgres binaries
- `drop-pxt-db.sh` force-drops the `pixeltable` postgres database