### PR TITLE
Partial fix for duplicate progress bars (temporary hack)

### DIFF
--- a/pixeltable/exec/expr_eval_node.py
+++ b/pixeltable/exec/expr_eval_node.py
@@ -50,9 +50,9 @@ class ExprEvalNode(ExecNode):
 
     def _open(self) -> None:
         warnings.simplefilter("ignore", category=TqdmWarning)
-        # This is a temporary hack. When indexable strings were introduced via new (anonymous) computed columns,
-        # it resulted in frivolous progress bars appearing on every insertion. This simply special-cases
-        # `str_filter` expressions to suppress the corresponding progress bar.
+        # This is a temporary hack. When B-tree indices on string columns were implemented (via computed columns
+        # that invoke the `BtreeIndex.str_filter` udf), it resulted in frivolous progress bars appearing on every
+        # insertion. This special-cases the `str_filter` call to suppress the corresponding progress bar.
         # TODO(aaron-siegel) Remove this hack once we clean up progress bars more generally.
         is_str_filter_node = all(
             isinstance(expr, exprs.FunctionCall) and expr.fn.name == 'str_filter' for expr in self.output_exprs


### PR DESCRIPTION
This is a temporary solution to fix the duplicate progress bars on insertions. The duplicates were introduced when indexable strings were added to Pixeltable via system/anonymous computed columns, resulting in a frivolous progress bar showing up on every insertion and crossing wires with the insertion console messages.

This is not a complete or long-term solution and is intended to hold us over until we revamp progress bars more generally (which is on the roadmap for open source v1).