### PR TITLE
UDF quality-of-life improvements

### DIFF
--- a/pixeltable/func/function_registry.py
+++ b/pixeltable/func/function_registry.py
@@ -66,6 +66,8 @@ class FunctionRegistry:
     #             self.module_fns[fn_path] = obj
 
     def register_function(self, fqn: str, fn: Function) -> None:
+        if fqn in self.module_fns:
+            raise excs.Error(f'A UDF with that name already exists: {fqn}')
         self.module_fns[fqn] = fn
 
     def list_functions(self) -> List[Function]:

--- a/pixeltable/tool/doc_plugins/griffe.py
+++ b/pixeltable/tool/doc_plugins/griffe.py
@@ -41,6 +41,9 @@ class PxtGriffeExtension(Extension):
         # Convert the parameter types to Pixeltable type references
         for griffe_param in func.parameters:
             assert isinstance(griffe_param.annotation, griffe.expressions.Expr)
+            if griffe_param.name not in udf.signature.parameters:
+                logger.warning(f'Parameter `{griffe_param.name}` not found in signature for UDF: {udf.display_name}')
+                continue
             pxt_param = udf.signature.parameters[griffe_param.name]
             griffe_param.annotation = self.__column_type_to_display_str(pxt_param.col_type)
 

--- a/tests/module_with_duplicate_udf.py
+++ b/tests/module_with_duplicate_udf.py
@@ -1,0 +1,9 @@
+from pixeltable import udf
+
+@udf
+def duplicate_udf(n: int) -> int:
+    return n + 1
+
+@udf
+def duplicate_udf(n: int) -> int:
+    return n + 2

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -439,6 +439,10 @@ class TestFunction:
                 return pxt.StringType()
         assert '`wrong_param` that is not in the signature' in str(exc_info.value).lower()
 
+        with pytest.raises(excs.Error) as exc_info:
+            from .module_with_duplicate_udf import duplicate_udf
+        assert 'A UDF with that name already exists: tests.module_with_duplicate_udf.duplicate_udf' in str(exc_info.value)
+
     def test_udf_docstring(self) -> None:
         assert self.func.__doc__ == "A UDF."
         assert self.agg.__doc__ == "An aggregator."


### PR DESCRIPTION
UDF quality-of-life improvements:
- Better error handling of extraneous arguments in Pixeltable UDF docstrings
- Reject `@udf` decorator on functions with identical fqn's