### PR TITLE
Migrate to pixeltable-pgserver fork

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,9 @@ jobs:
     - name: Install type-checking and linting tools
       run: |
         python -m pip install --upgrade pip
-        python -m pip install mypy sqlalchemy[mypy] pylint ruff
-        python -m pip install mkdocs mkdocs-material mkdocstrings-python black
+        python -m pip install mypy 'sqlalchemy[mypy]' pylint ruff
+        # TODO We should really be using poetry for this
+        python -m pip install mkdocs==1.6.0 mkdocstrings==0.25.1 mkdocs-material==9.5.23 mkdocstrings-python==1.10.2 griffe==0.45.0 black
         python -m pip install -e .
     # These steps will check ONLY the files that are affected by the PR.
     # For the time being, failures will be ignored (report-only).

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, Dict, Any, List, TYPE_CHECKING
 
-import pgserver
+import pixeltable_pgserver
 import sqlalchemy as sql
 import yaml
 from tqdm import TqdmWarning
@@ -60,7 +60,7 @@ class Env:
         self._sa_engine: Optional[sql.engine.base.Engine] = None
         self._pgdata_dir: Optional[Path] = None
         self._db_name: Optional[str] = None
-        self._db_server: Optional[pgserver.PostgresServer] = None
+        self._db_server: Optional[pixeltable_pgserver.PostgresServer] = None
         self._db_url: Optional[str] = None
 
         # info about installed packages that are utilized by some parts of the code;
@@ -266,8 +266,8 @@ class Env:
         self._db_name = os.environ.get('PIXELTABLE_DB', 'pixeltable')
         self._pgdata_dir = Path(os.environ.get('PIXELTABLE_PGDATA', str(self._home / 'pgdata')))
 
-        # in pgserver.get_server(): cleanup_mode=None will leave db on for debugging purposes
-        self._db_server = pgserver.get_server(self._pgdata_dir, cleanup_mode=None)
+        # in pixeltable_pgserver.get_server(): cleanup_mode=None will leave db on for debugging purposes
+        self._db_server = pixeltable_pgserver.get_server(self._pgdata_dir, cleanup_mode=None)
         self._db_url = self._db_server.get_uri(database=self._db_name)
 
         if reinit_db:

--- a/pixeltable/tool/create_test_db_dump.py
+++ b/pixeltable/tool/create_test_db_dump.py
@@ -6,7 +6,7 @@ import pathlib
 import subprocess
 from typing import Any
 
-import pgserver
+import pixeltable_pgserver
 import toml
 
 import pixeltable as pxt
@@ -41,7 +41,7 @@ class Dumper:
         md_version = metadata.VERSION
         dump_file = self.output_dir / f'pixeltable-v{md_version:03d}-test.dump.gz'
         _logger.info(f'Creating database dump at: {dump_file}')
-        pg_package_dir = os.path.dirname(pgserver.__file__)
+        pg_package_dir = os.path.dirname(pixeltable_pgserver.__file__)
         pg_dump_binary = f'{pg_package_dir}/pginstall/bin/pg_dump'
         _logger.info(f'Using pg_dump binary at: {pg_dump_binary}')
         with open(dump_file, 'wb') as dump:

--- a/poetry.lock
+++ b/poetry.lock
@@ -4527,40 +4527,6 @@ files = [
 ptyprocess = ">=0.5"
 
 [[package]]
-name = "pgserver"
-version = "0.1.4"
-description = "Self-contained postgres server for your python applications"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "pgserver-0.1.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:79041d91d4d28e3a6a75dd472ee395e2da036ffd7f77cd826052697532291646"},
-    {file = "pgserver-0.1.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2aa7897ab2894a460cfc430959f9640e27659fc8b8802f82b3f58632ae181218"},
-    {file = "pgserver-0.1.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb0e711e257dbfa2681d78c0bd789dd81753bc28c207889dcefa8f80706f3fed"},
-    {file = "pgserver-0.1.4-cp310-cp310-win_amd64.whl", hash = "sha256:7be9cd117184aea1eaf9118b4c052c318dc13bb93d3cd9336329ad5b8d1729b1"},
-    {file = "pgserver-0.1.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:854fa9394d495b3a332c954b63d4356b56d29220530e6d2aae146821bf87e05a"},
-    {file = "pgserver-0.1.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cc5a64f40749c0e9752cd63784e63dfcf1f3e5ecd2279b6b59f7c64fb520fb4"},
-    {file = "pgserver-0.1.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d595789b47624a3d963aa9aa6359da9be31beb7e61f1a45541953242068b8813"},
-    {file = "pgserver-0.1.4-cp311-cp311-win_amd64.whl", hash = "sha256:fb755fe493c479fcad1a1e9923fcc1f09d15cd2fb168e563c003b29f14a80545"},
-    {file = "pgserver-0.1.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:dc34f88561b18bc08edd98a84528f99a3720fe713a4e39a4a6210a4d009fe465"},
-    {file = "pgserver-0.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:780fa89f26a960cca0215caf471e70848dd8597bd8ceaeba7faf42170278980c"},
-    {file = "pgserver-0.1.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a5d07c61d51f2abfef4ef61e2ef5cd014b994f7e09de8d3c140d2cf370e84a8"},
-    {file = "pgserver-0.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:406e9355334e40754160a33d93f18a848720a38cd0b68da50be2ea272c89ed2d"},
-    {file = "pgserver-0.1.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:206e58be4f01db433df882c6d781ea1058d604f9c23acfc6ce3401ba717bc6ad"},
-    {file = "pgserver-0.1.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2b902adff9dbfa65eac0405b914bd16a9d0b04e7710a02e4a172997b436135f4"},
-    {file = "pgserver-0.1.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9b7cf6f1611506654a7e948d99f8fb20895321474187401587d3fee1067e298"},
-    {file = "pgserver-0.1.4-cp39-cp39-win_amd64.whl", hash = "sha256:a515926064743131f76c9cd2268b5d69f160371b89e7d9cc377102aa4087ae2d"},
-]
-
-[package.dependencies]
-fasteners = ">=0.19"
-platformdirs = ">=4.0.0"
-psutil = ">=5.9.0"
-
-[package.extras]
-dev = ["sysv-ipc"]
-test = ["psycopg2-binary", "pytest", "sqlalchemy (>=2)", "sqlalchemy-utils"]
-
-[[package]]
 name = "pgvector"
 version = "0.2.4"
 description = "pgvector support for Python"
@@ -4669,6 +4635,48 @@ mic = ["olefile"]
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 typing = ["typing-extensions"]
 xmp = ["defusedxml"]
+
+[[package]]
+name = "pixeltable-pgserver"
+version = "0.2.4"
+description = "Embedded Postgres Server for Pixeltable"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pixeltable_pgserver-0.2.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b63312f394f82f98bee5658e09371d5015af2b013bcf4ff837d1d3892299fec"},
+    {file = "pixeltable_pgserver-0.2.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c00a280375396c27ef1410ec97e2894764e3502575dda1ee22178575cd466cbb"},
+    {file = "pixeltable_pgserver-0.2.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f870b4dfeedf2817d3036d40a0c9626a3986cfeb5f4bec76bd47aa9a60b3cbb0"},
+    {file = "pixeltable_pgserver-0.2.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:828cf7f58c31947a06b43e08e60b01e72b3801e122013293cd401440ad9d3ef3"},
+    {file = "pixeltable_pgserver-0.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:d06be8834e4f7b995a229abf41fc428b0870e7af50351fe372204fb6052d10f1"},
+    {file = "pixeltable_pgserver-0.2.4-cp310-cp310-win_arm64.whl", hash = "sha256:782d824a5a34bfcb47e3462682a5632f12f8aba1998b013e5ed914003de1cbf1"},
+    {file = "pixeltable_pgserver-0.2.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:19ab3fbce02ca3de7d2c8f85619baf45b06ba81089500a46fd59396d5c5fd8a9"},
+    {file = "pixeltable_pgserver-0.2.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72b3efa2075720e04b91a56ced6d7577c80f64d874cd6965fdf10f79b09020a5"},
+    {file = "pixeltable_pgserver-0.2.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45380a3dbc1d739453a78ad23305a1055474cb71b059abde55c29a968cc02209"},
+    {file = "pixeltable_pgserver-0.2.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40a11ea270b551e8b7ec6c31caec9b00fba7a9debf76b8b4082328cc5261afdb"},
+    {file = "pixeltable_pgserver-0.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:3213ecf86db0a6a2807c4ce56cf96c249b077efd1edafb312fe650ea24eab597"},
+    {file = "pixeltable_pgserver-0.2.4-cp311-cp311-win_arm64.whl", hash = "sha256:7a6a0a2cb132c525e654d3a4768193774e8661f90d8b32027d692d84ec84add6"},
+    {file = "pixeltable_pgserver-0.2.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:bf31189173c722b2b4b29e5c702cfa4f3a55e65a803e7be057010fe75a54a43d"},
+    {file = "pixeltable_pgserver-0.2.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e9b5f4dc90fce71f9592f72fff75cd5ea7ee1dc88c2a8d0a52314afb541366"},
+    {file = "pixeltable_pgserver-0.2.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b146e344adf4fb5c4f037f7d756cbb3c848b2f7b71bcfbd2e1f84c8b30398e86"},
+    {file = "pixeltable_pgserver-0.2.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78f12601fca2a7c95a0876f225eb403da273406b4018518e4295f5d33e594f2d"},
+    {file = "pixeltable_pgserver-0.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:73bcd419153ba4f0fbb49a9cae3c6def0d92ebd5f49598616aae9948eda1d636"},
+    {file = "pixeltable_pgserver-0.2.4-cp312-cp312-win_arm64.whl", hash = "sha256:bb8e64d05c3e72d92e957b15deaf78de7452d00ffb435feb1e6b8096bc6a1147"},
+    {file = "pixeltable_pgserver-0.2.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:954b0a5f03de1b12af73b6b4d3706d4162ac59cc7eb2caffae2090e123c43e41"},
+    {file = "pixeltable_pgserver-0.2.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f9a5e55bba2189e312f3f21ef97cdbd6321e405d40c01948f457a0ebc171ed8a"},
+    {file = "pixeltable_pgserver-0.2.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:def2dbb183c2925734d491a09fee0990eb48d947a3b96bb514fc71260cbe9c59"},
+    {file = "pixeltable_pgserver-0.2.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0064529b6dac3d1d0c579f7c2b753453172b8cacd81484e30455e19a37b8656a"},
+    {file = "pixeltable_pgserver-0.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:81fd33ebcdc3e602cb7af7eeef9be637c2e006478dc0152460dd7cfcaf9c7ab8"},
+    {file = "pixeltable_pgserver-0.2.4-cp39-cp39-win_arm64.whl", hash = "sha256:0b7df60973aaf5773df6c4344dc063cdeb34acfc79a617ae946e063db6e746ec"},
+]
+
+[package.dependencies]
+fasteners = ">=0.19"
+platformdirs = ">=4.0.0"
+psutil = ">=5.9.0"
+
+[package.extras]
+dev = ["sysv-ipc"]
+test = ["psycopg2-binary", "pytest", "sqlalchemy (>=2)", "sqlalchemy-utils"]
 
 [[package]]
 name = "platformdirs"
@@ -8394,4 +8402,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "973bb2cedc8f3b0750d146fa30c4945c95140f6925aa167a28a512df1e80acec"
+content-hash = "a75779728f7c8a7915312998a42bef8f2f64d361ee510fbf700b9e3735795149"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ requests = "^2.31.0"
 pyyaml = "^6.0.1"
 jinja2 = "^3.1.3"
 tenacity = "^8.2"
-pgserver = "==0.1.4"
 mistune = "^3.0.2"
 pymupdf = "^1.24.1"
 ftfy = "^6.2.0"
+pixeltable-pgserver = "==0.2.4"
 
 [tool.poetry.group.dev]
 optional = true

--- a/scripts/drop-pxt-db.sh
+++ b/scripts/drop-pxt-db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-POSTGRES_BIN_PATH=$(python -c 'import pgserver; import sys; sys.stdout.write(str(pgserver._commands.POSTGRES_BIN_PATH))')
+POSTGRES_BIN_PATH=$(python -c 'import pixeltable_pgserver; import sys; sys.stdout.write(str(pixeltable_pgserver._commands.POSTGRES_BIN_PATH))')
 if [ -z "$PIXELTABLE_HOME" ]; then
     PIXELTABLE_HOME=~/.pixeltable
 fi

--- a/scripts/postgres.sh
+++ b/scripts/postgres.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # Run this script inside your conda environment to open a postgres connection to your Pixeltable DB.
 
-POSTGRES_BIN_PATH=$(python -c 'import pgserver; import sys; sys.stdout.write(str(pgserver._commands.POSTGRES_BIN_PATH))')
+POSTGRES_BIN_PATH=$(python -c 'import pixeltable_pgserver; import sys; sys.stdout.write(str(pixeltable_pgserver._commands.POSTGRES_BIN_PATH))')
 if [ -z "$PIXELTABLE_HOME" ]; then
     PIXELTABLE_HOME=~/.pixeltable
 fi

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -5,7 +5,7 @@ import platform
 import subprocess
 import sys
 
-import pgserver
+import pixeltable_pgserver
 import pytest
 import sqlalchemy.orm as orm
 
@@ -30,7 +30,7 @@ class TestMigration:
         import toml
 
         env = Env.get()
-        pg_package_dir = os.path.dirname(pgserver.__file__)
+        pg_package_dir = os.path.dirname(pixeltable_pgserver.__file__)
         pg_restore_binary = f'{pg_package_dir}/pginstall/bin/pg_restore'
         _logger.info(f'Using pg_restore binary at: {pg_restore_binary}')
         dump_files = glob.glob('tests/data/dbdumps/*.dump.gz')


### PR DESCRIPTION
Includes a few improvements:
- Wheels for Linux and Windows ARM deployments
- Enable readline in postgres build (quality-of-life improvement for postgres admin of the pixeltable db)