### PR TITLE
Handle lists/dicts and other non-numpy datatypes in `import_pandas`

### DIFF
--- a/pixeltable/exprs/arithmetic_expr.py
+++ b/pixeltable/exprs/arithmetic_expr.py
@@ -22,7 +22,7 @@ class ArithmeticExpr(Expr):
             # we assume it's a float
             super().__init__(ts.FloatType())
         else:
-            super().__init__(ts.ColumnType.supertype(op1.col_type, op2.col_type))
+            super().__init__(op1.col_type.supertype(op2.col_type))
         self.operator = operator
         self.components = [op1, op2]
 

--- a/pixeltable/exprs/inline_array.py
+++ b/pixeltable/exprs/inline_array.py
@@ -51,9 +51,9 @@ class InlineArray(Expr):
             # try to infer the element type
             for idx, val in self.elements:
                 if idx is not None:
-                    inferred_element_type = ts.ColumnType.supertype(inferred_element_type, self.components[idx].col_type)
+                    inferred_element_type = inferred_element_type.supertype(self.components[idx].col_type)
                 else:
-                    inferred_element_type = ts.ColumnType.supertype(inferred_element_type, ts.ColumnType.infer_literal_type(val))
+                    inferred_element_type = inferred_element_type.supertype(ts.ColumnType.infer_literal_type(val))
                 if inferred_element_type is None:
                     break
 

--- a/pixeltable/io/globals.py
+++ b/pixeltable/io/globals.py
@@ -191,7 +191,7 @@ def import_rows(
                 if col_name not in schema:
                     schema[col_name] = col_type
                 else:
-                    supertype = pxt.ColumnType.supertype(schema[col_name], col_type)
+                    supertype = schema[col_name].supertype(col_type)
                     if supertype is None:
                         raise excs.Error(
                             f'Could not infer type of column `{col_name}`; the value in row {n} does not match preceding type {schema[col_name]}: {value!r}\n'

--- a/pixeltable/io/pandas.py
+++ b/pixeltable/io/pandas.py
@@ -1,7 +1,9 @@
+import datetime
 from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
+import PIL.Image
 
 import pixeltable as pxt
 import pixeltable.exceptions as excs
@@ -140,21 +142,64 @@ def __np_dtype_to_pxt_type(np_dtype: np.dtype, data_col: pd.Series, nullable: bo
     """
     if np.issubdtype(np_dtype, np.integer):
         return pxt.IntType(nullable=nullable)
+
     if np.issubdtype(np_dtype, np.floating):
         return pxt.FloatType(nullable=nullable)
+
     if np.issubdtype(np_dtype, np.bool_):
         return pxt.BoolType(nullable=nullable)
-    if np_dtype == np.object_ or np.issubdtype(np_dtype, np.character):
-        has_nan = any(isinstance(val, float) and np.isnan(val) for val in data_col)
-        if has_nan and not nullable:
-            raise excs.Error(f'Primary key column `{data_col.name}` cannot contain null values.')
+
+    if np.issubdtype(np_dtype, np.character):
         return pxt.StringType(nullable=nullable)
+
     if np.issubdtype(np_dtype, np.datetime64):
         has_nat = any(pd.isnull(val) for val in data_col)
         if has_nat and not nullable:
             raise excs.Error(f'Primary key column `{data_col.name}` cannot contain null values.')
         return pxt.TimestampType(nullable=nullable)
-    raise excs.Error(f'Unsupported dtype: {np_dtype}')
+
+    if np_dtype == np.object_:
+        # The `object_` dtype can mean all sorts of things; see if we can infer the Pixeltable type.
+        has_nan = any(isinstance(val, float) and np.isnan(val) for val in data_col)
+        if has_nan and not nullable:
+            raise excs.Error(f'Primary key column `{data_col.name}` cannot contain null values.')
+        data_col = data_col.dropna()  # Now drop any NaN values for type inference
+
+        # JsonType?
+        # TODO We should also allow int, float, str, and bool here, but we first need to allow
+        # Pixeltable to accept those types in a JsonType column.
+        if all(isinstance(val, (list, dict)) for val in data_col):
+            return pxt.JsonType(nullable=nullable)
+        # ImageType?
+        if all(isinstance(val, PIL.Image.Image) for val in data_col):
+            return pxt.ImageType(nullable=nullable)
+        # TimestampType? (This can happen if there are aware datatimes in the Pandas DataFrame)
+        if all(isinstance(val, datetime.datetime) for val in data_col):
+            return pxt.TimestampType(nullable=nullable)
+        # ArrayType?
+        array_type = __infer_array_type_from_col(data_col)
+        if array_type is not None:
+            return array_type.copy(nullable=nullable)
+        # As a last resort, stringify the objects.
+        # TODO Should we throw an exception instead?
+        return pxt.StringType(nullable=nullable)
+
+    raise excs.Error(f'Could not infer Pixeltable type of column: {data_col.name} (dtype: {np_dtype})')
+
+
+def __infer_array_type_from_col(col: pd.Series) -> Optional[pxt.ArrayType]:
+    array_type: Optional[pxt.ArrayType] = None
+    for val in col:
+        if not isinstance(val, np.ndarray):
+            return None
+        this_type = pxt.ArrayType.from_literal(val)
+        if array_type is None:
+            array_type = this_type
+        else:
+            array_type = pxt.ArrayType._supertype(array_type, this_type)
+            if array_type is None:
+                return None
+    return array_type
 
 
 def __df_row_to_pxt_row(row: tuple[Any, ...], schema: dict[str, pxt.ColumnType]) -> dict[str, Any]:

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -9,7 +9,7 @@ import urllib.parse
 import urllib.request
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Optional, Tuple, Dict, Callable, List, Union, Sequence, Mapping
+from typing import Any, Iterable, Optional, Tuple, Dict, Callable, List, Union, Sequence, Mapping
 
 import PIL.Image
 import av
@@ -191,35 +191,22 @@ class ColumnType:
                 return False
         return True
 
-    @classmethod
-    def supertype(cls, type1: ColumnType, type2: ColumnType) -> Optional[ColumnType]:
-        if type1 == type2:
-            return type1
+    def supertype(self, other: ColumnType) -> Optional[ColumnType]:
+        if self == other:
+            return self
 
-        if type1.is_invalid_type():
-            return type2
-        if type2.is_invalid_type():
-            return type1
+        if self.is_invalid_type():
+            return other
+        if other.is_invalid_type():
+            return self
 
-        if type1.is_scalar_type() and type2.is_scalar_type():
-            t = cls.Type.supertype(type1._type, type2._type, cls.common_supertypes)
+        if self.is_scalar_type() and other.is_scalar_type():
+            t = self.Type.supertype(self._type, other._type, self.common_supertypes)
             if t is not None:
-                return cls.make_type(t).copy(nullable=(type1.nullable or type2.nullable))
+                return self.make_type(t).copy(nullable=(self.nullable or other.nullable))
             return None
 
-        if type1._type == type2._type:
-            return cls._supertype(type1, type2)
-
         return None
-
-    @classmethod
-    @abc.abstractmethod
-    def _supertype(cls, type1: ColumnType, type2: ColumnType) -> Optional[ColumnType]:
-        """
-        Class-specific implementation of determining the supertype. type1 and type2 are from the same subclass of
-        ColumnType.
-        """
-        pass
 
     @classmethod
     def infer_literal_type(cls, val: Any) -> Optional[ColumnType]:
@@ -248,6 +235,19 @@ class ColumnType:
             except TypeError:
                 return None
         return None
+
+    @classmethod
+    def infer_common_type(cls, vals: Iterable[Any]) -> Optional[ColumnType]:
+        inferred_type: Optional[ColumnType] = None
+        for val in vals:
+            val_type = cls.infer_literal_type(val)
+            if inferred_type is None:
+                inferred_type = val_type
+            else:
+                inferred_type = inferred_type.supertype(val_type)
+                if inferred_type is None:
+                    return None
+        return inferred_type
 
     @classmethod
     def from_python_type(cls, t: type) -> Optional[ColumnType]:
@@ -562,30 +562,27 @@ class JsonType(ColumnType):
 
 
 class ArrayType(ColumnType):
-    def __init__(
-            self, shape: Tuple[Union[int, None], ...], dtype: ColumnType, nullable: bool = False):
+    def __init__(self, shape: Tuple[Union[int, None], ...], dtype: ColumnType, nullable: bool = False):
         super().__init__(self.Type.ARRAY, nullable=nullable)
         self.shape = shape
         assert dtype.is_int_type() or dtype.is_float_type() or dtype.is_bool_type() or dtype.is_string_type()
         self.dtype = dtype._type
 
-    @classmethod
-    def _supertype(cls, type1: ArrayType, type2: ArrayType) -> Optional[ArrayType]:
-        if len(type1.shape) != len(type2.shape):
+    def supertype(self, other: ColumnType) -> Optional[ArrayType]:
+        if not isinstance(other, ArrayType):
             return None
-        base_type = cls.Type.supertype(type1.dtype, type2.dtype, cls.common_supertypes)
+        if len(self.shape) != len(other.shape):
+            return None
+        base_type = self.Type.supertype(self.dtype, other.dtype, self.common_supertypes)
         if base_type is None:
             return None
-        shape = [n1 if n1 == n2 else None for n1, n2 in zip(type1.shape, type2.shape)]
-        return ArrayType(tuple(shape), cls.make_type(base_type), nullable=(type1.nullable or type2.nullable))
+        shape = [n1 if n1 == n2 else None for n1, n2 in zip(self.shape, other.shape)]
+        return ArrayType(tuple(shape), self.make_type(base_type), nullable=(self.nullable or other.nullable))
 
     def _as_dict(self) -> Dict:
         result = super()._as_dict()
         result.update(shape=list(self.shape), dtype=self.dtype.value)
         return result
-
-    def __repr__(self) -> str:
-        return f'{self._type.name.lower()}({self.shape}, dtype={self.dtype.name}, nullable={self.nullable})'
 
     def __str__(self) -> str:
         return f'{self._type.name.lower()}({self.shape}, dtype={self.dtype.name})'
@@ -700,10 +697,19 @@ class ImageType(ColumnType):
     def _is_supertype_of(self, other: ImageType) -> bool:
         if self.mode is not None and self.mode != other.mode:
             return False
-        if self.width is None and self.height is None:
-            return True
-        if self.width != other.width and self.height != other.height:
+        if self.width is not None and self.width != other.width:
             return False
+        if self.height is not None and self.height != other.height:
+            return False
+        return True
+
+    def supertype(self, other: ColumnType) -> Optional[ImageType]:
+        if not isinstance(other, ImageType):
+            return None
+        width = self.width if self.width == other.width else None
+        height = self.height if self.height == other.height else None
+        mode = self.mode if self.mode == other.mode else None
+        return ImageType(width=width, height=height, mode=mode, nullable=(self.nullable or other.nullable))
 
     @property
     def size(self) -> Optional[Tuple[int, int]]:

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -1,11 +1,13 @@
 import datetime
 
-import pandas as pd
 import numpy as np
+import pandas as pd
+import PIL.Image
 import pytest
 
 import pixeltable as pxt
 import pixeltable.exceptions as excs
+
 from ..utils import skip_test_if_not_installed
 
 
@@ -22,6 +24,8 @@ class TestPandas:
             'json_col_2': [{'a': 1}, {'b': 2}],
             'array_col_1': [np.ndarray((1, 2), dtype=int), np.ndarray((3, 2), dtype=int)],
             'array_col_2': [np.ndarray((1, 2), dtype=int), np.ndarray((3, 4), dtype=int)],
+            'array_col_3': [np.ndarray((1, 2), dtype=np.float32), np.ndarray((3, 4), dtype=np.float32)],
+            'image_col': [PIL.Image.new('RGB', (100, 100)), PIL.Image.new('L', (100, 200))],
         })
         t = pxt.io.import_pandas('test_types', df)
         assert(t.column_types() == {
@@ -35,6 +39,8 @@ class TestPandas:
             'json_col_2': pxt.JsonType(nullable=True),
             'array_col_1': pxt.ArrayType(shape=(None, 2), dtype=pxt.IntType(), nullable=True),
             'array_col_2': pxt.ArrayType(shape=(None, None), dtype=pxt.IntType(), nullable=True),
+            'array_col_3': pxt.ArrayType(shape=(None, None), dtype=pxt.FloatType(), nullable=True),
+            'image_col': pxt.ImageType(width=100, nullable=True),
         })
 
     def test_pandas_csv(self, reset_db) -> None:

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pandas as pd
 import numpy as np
 import pytest
 
@@ -9,6 +10,33 @@ from ..utils import skip_test_if_not_installed
 
 
 class TestPandas:
+    def test_pandas_types(self, reset_db) -> None:
+        df = pd.DataFrame({
+            'int_col': [1, 2],
+            'float_col': [1.0, 2.0],
+            'bool_col': [True, False],
+            'str_col': ['a', 'b'],
+            'dt_col': [datetime.datetime(2024, 1, 1), datetime.datetime(2024, 1, 2)],
+            'aware_dt_col': [datetime.datetime(2024, 1, 1), datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)],
+            'json_col_1': [[1, 2], [3, 4]],
+            'json_col_2': [{'a': 1}, {'b': 2}],
+            'array_col_1': [np.ndarray((1, 2), dtype=int), np.ndarray((3, 2), dtype=int)],
+            'array_col_2': [np.ndarray((1, 2), dtype=int), np.ndarray((3, 4), dtype=int)],
+        })
+        t = pxt.io.import_pandas('test_types', df)
+        assert(t.column_types() == {
+            'int_col': pxt.IntType(nullable=True),
+            'float_col': pxt.FloatType(nullable=True),
+            'bool_col': pxt.BoolType(nullable=True),
+            'str_col': pxt.StringType(nullable=True),
+            'dt_col': pxt.TimestampType(nullable=True),
+            'aware_dt_col': pxt.TimestampType(nullable=True),
+            'json_col_1': pxt.JsonType(nullable=True),
+            'json_col_2': pxt.JsonType(nullable=True),
+            'array_col_1': pxt.ArrayType(shape=(None, 2), dtype=pxt.IntType(), nullable=True),
+            'array_col_2': pxt.ArrayType(shape=(None, None), dtype=pxt.IntType(), nullable=True),
+        })
+
     def test_pandas_csv(self, reset_db) -> None:
         from pixeltable.io import import_csv
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -74,12 +74,23 @@ class TestTypes:
             (IntType(), FloatType(), FloatType()),
             (BoolType(), IntType(), IntType()),
             (BoolType(), FloatType(), FloatType()),
+            (IntType(), StringType(), None),
+            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((3, 2, 1), dtype=IntType()), ArrayType((None, 2, None), dtype=IntType())),
+            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((1, 2), dtype=IntType()), None),
+            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((3, 2, 1), dtype=FloatType()), ArrayType((None, 2, None), dtype=FloatType())),
+            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((3, 2, 1), dtype=StringType()), None),
+            (ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=200, mode='RGB')),
+            (ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=200, mode='RGBA'), ImageType(height=100, width=200, mode=None)),
+            (ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=300, mode='RGB'), ImageType(height=100, width=None, mode='RGB')),
+            (ImageType(height=100, width=200, mode='RGB'), ImageType(height=300, width=200, mode='RGB'), ImageType(height=None, width=200, mode='RGB')),
+            (ImageType(height=100, width=200, mode='RGB'), ImageType(height=300, width=400, mode='RGBA'), ImageType()),
+            (ImageType(height=100, width=200, mode='RGB'), ImageType(), ImageType()),
         ]
         for t1, t2, expected in test_cases:
             for n1 in [True, False]:
                 for n2 in [True, False]:
                     t1n = t1.copy(nullable=n1)
                     t2n = t2.copy(nullable=n2)
-                    expectedn = expected.copy(nullable=(n1 or n2))
-                    assert ColumnType.supertype(t1n, t2n) == expectedn
-                    assert ColumnType.supertype(t2n, t1n) == expectedn
+                    expectedn = None if expected is None else expected.copy(nullable=(n1 or n2))
+                    assert t1n.supertype(t2n) == expectedn
+                    assert t2n.supertype(t1n) == expectedn


### PR DESCRIPTION
Enhances `import_pandas` to properly interpret lists, dicts, images, and arrays, if they appear within a Pandas `DataFrame` with type `np.object_`.

Also refactors `ColumnType.supertype()` and fixes several type system bugs.