### PR TITLE
Type system performance improvements

### DIFF
--- a/pixeltable/io/globals.py
+++ b/pixeltable/io/globals.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Literal, Optional, Union
 
 import pixeltable as pxt
@@ -176,7 +175,6 @@ def import_rows(
     schema: dict[str, pxt.ColumnType] = {}
     cols_with_nones: set[str] = set()
 
-    t = datetime.now()
     for n, row in enumerate(rows):
         for col_name, value in row.items():
             if col_name in schema_overrides:
@@ -201,9 +199,6 @@ def import_rows(
                     schema[col_name] = supertype
             else:
                 cols_with_nones.add(col_name)
-    dur = datetime.now() - t
-    print(f'TIMING: {dur}')
-    assert False
 
     extraneous_keys = schema_overrides.keys() - schema.keys()
     if len(extraneous_keys) > 0:

--- a/pixeltable/io/globals.py
+++ b/pixeltable/io/globals.py
@@ -1,3 +1,4 @@
+from datetime import datetime, time
 from typing import Any, Literal, Optional, Union
 import urllib.request
 
@@ -176,6 +177,7 @@ def import_rows(
     schema: dict[str, pxt.ColumnType] = {}
     cols_with_nones: set[str] = set()
 
+    t = datetime.now()
     for n, row in enumerate(rows):
         for col_name, value in row.items():
             if col_name in schema_overrides:
@@ -200,6 +202,9 @@ def import_rows(
                     schema[col_name] = supertype
             else:
                 cols_with_nones.add(col_name)
+    dur = datetime.now() - t
+    print(f'TIMING: {dur}')
+    assert False
 
     extraneous_keys = schema_overrides.keys() - schema.keys()
     if len(extraneous_keys) > 0:

--- a/pixeltable/io/globals.py
+++ b/pixeltable/io/globals.py
@@ -1,6 +1,5 @@
-from datetime import datetime, time
+from datetime import datetime
 from typing import Any, Literal, Optional, Union
-import urllib.request
 
 import pixeltable as pxt
 import pixeltable.exceptions as excs
@@ -189,7 +188,7 @@ def import_rows(
             elif value is not None:
                 # If `key` is not in `schema_overrides`, then we infer its type from the data.
                 # The column type will always be nullable by default.
-                col_type = pxt.ColumnType.infer_literal_type(value).copy(nullable=True)
+                col_type = pxt.ColumnType.infer_literal_type(value, nullable=True)
                 if col_name not in schema:
                     schema[col_name] = col_type
                 else:

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -564,7 +564,7 @@ class JsonType(ColumnType):
         if isinstance(val, (list, tuple)):
             return all(cls.__is_valid_literal(v) for v in val)
         if isinstance(val, dict):
-            return all(isinstance(k, str) and cls.__is_valid_literal(v) for k, v in val.items())
+            return all(isinstance(k, (str, int)) and cls.__is_valid_literal(v) for k, v in val.items())
         return False
 
     def _create_literal(self, val: Any) -> Any:


### PR DESCRIPTION
On a sample dataset of ~500k rows, achieves a > 90% reduction in running time of the type inference logic in `import_rows()` on an M3 Max CPU, from 32.1 seconds to 2.56 seconds.

Most of the reduction (from 32 -> ~6 seconds) is achieved by eliminating the use of `deepcopy()` in `ColumnType.copy()`. The remainder is achieved by reducing object creation and dynamic evaluation in `ColumnType` and subclasses.

It is assumed that `ColumnType` instances are immutable. I believe that further optimizations are possible by making `ColumnType` instances formally immutable (as frozen dataclasses, say) and minimizing object creation. But those changes would be more invasive, and I'm pretty sure this is enough to get type inference off the critical performance path.

UPDATED: Optimized `JsonType._validate_literal`, reducing the time to 2.3 seconds (93% reduction vs. baseline)