### PR TITLE
Set up Nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,77 @@
+name: Run pytest
+
+on:
+  schedule:
+    - cron: "19 2 * * 1,3,5"  # Monday, Wednesday, Friday at 02:19 UTC
+  workflow_dispatch:
+
+env:
+  # in a PR, the secrets will be empty
+  FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+  OPENCV_VIDEOIO_DEBUG: 1
+
+jobs:
+  pytest:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test the earliest and latest supported Python versions on every supported platform.
+        os: [ubuntu-22.04]
+        python-version: ["3.9", "3.12"]
+        package-configs:
+          - ""
+          - "torch transformers sentence-transformers"
+          - "openai together fireworks"
+          - "datasets boto3 openpyxl pyarrow tiktoken fitz spacy"
+          - "label_studio_sdk"
+        include:
+          - os: macos-12
+            python-version: "3.9"
+            package-configs: ""
+          - os: windows-2022
+            python-version: "3.9"
+            package-configs: ""
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}  # Needed for conda to work
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Delete unnecessary files
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /opt/hostedtoolcache
+          df -h
+      - name: Install conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: latest
+          activate-environment: pxt
+          python-version: ${{ matrix.python-version }}
+          use-only-tar-bz2: true  # Needed to use conda with cache action
+      - name: Show conda info
+        run: conda info
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pixeltable ${{ matrix.package-configs }}
+          python -m pip install pytest
+      - name: Run the unit tests
+        run: |
+          pytest -v -m '' tests
+      - name: Print utilization info
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          df -h
+          du -h -d3 /home/runner
+          du -h -d3 /home/runner/.cache
+      - name: Print utilization info
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+        run: df -h

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Run pytest
+name: Nightly CI
 
 on:
   schedule:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,9 +22,9 @@ jobs:
         python-version: ["3.9", "3.12"]
         package-configs:
           - ""
-          - "torch transformers sentence-transformers"
+          - "torch torchvision transformers sentence-transformers pyarrow"
           - "openai together fireworks"
-          - "datasets boto3 openpyxl pyarrow tiktoken fitz spacy https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl"
+          - "datasets boto3 openpyxl tiktoken pymupdf spacy https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl"
           - "label_studio_sdk"
         include:
           - os: macos-12

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           - ""
           - "torch transformers sentence-transformers"
           - "openai together fireworks"
-          - "datasets boto3 openpyxl pyarrow tiktoken fitz spacy"
+          - "datasets boto3 openpyxl pyarrow tiktoken fitz spacy https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl"
           - "label_studio_sdk"
         include:
           - os: macos-12

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -425,6 +425,7 @@ class Env:
             else:
                 self._installed_packages[package] = None
 
+        check('toml')
         check('datasets')
         check('torch')
         check('torchvision')

--- a/pixeltable/functions/image.py
+++ b/pixeltable/functions/image.py
@@ -144,7 +144,7 @@ def resize(self: PIL.Image.Image, size: tuple[int, int]) -> PIL.Image.Image:
     Equivalent to
     [`PIL.Image.Image.resize()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.resize)
     """
-    return self.resize(size)
+    return self.resize(tuple(size))
 
 
 @resize.conditional_return_type

--- a/pixeltable/io/parquet.py
+++ b/pixeltable/io/parquet.py
@@ -19,12 +19,14 @@ from pixeltable.utils.transactional_directory import transactional_directory
 if typing.TYPE_CHECKING:
     import pixeltable as pxt
     import pyarrow as pa
+    from pyarrow import parquet
 
 _logger = logging.getLogger(__name__)
 
 
 def _write_batch(value_batch: Dict[str, deque], schema: pa.Schema, output_path: Path) -> None:
     import pyarrow as pa
+    from pyarrow import parquet
 
     pydict = {}
     for field in schema:
@@ -35,7 +37,7 @@ def _write_batch(value_batch: Dict[str, deque], schema: pa.Schema, output_path: 
             pydict[field.name] = value_batch[field.name]
 
     tab = pa.Table.from_pydict(pydict, schema=schema)
-    pa.parquet.write_table(tab, output_path)
+    parquet.write_table(tab, output_path)
 
 
 def save_parquet(df: pxt.DataFrame, dest_path: Path, partition_size_bytes: int = 100_000_000) -> None:
@@ -128,11 +130,11 @@ def save_parquet(df: pxt.DataFrame, dest_path: Path, partition_size_bytes: int =
 
 def parquet_schema_to_pixeltable_schema(parquet_path: str) -> Dict[str, Optional[ts.ColumnType]]:
     """Generate a default pixeltable schema for the given parquet file. Returns None for unknown types."""
-    import pyarrow as pa
+    from pyarrow import parquet
     from pixeltable.utils.arrow import to_pixeltable_schema
 
     input_path = Path(parquet_path).expanduser()
-    parquet_dataset = pa.parquet.ParquetDataset(input_path)
+    parquet_dataset = parquet.ParquetDataset(input_path)
     return to_pixeltable_schema(parquet_dataset.schema)
 
 
@@ -157,11 +159,11 @@ def import_parquet(
         The newly created table. The table will have loaded the data from the Parquet file(s).
     """
     import pixeltable as pxt
-    import pyarrow as pa
+    from pyarrow import parquet
     from pixeltable.utils.arrow import iter_tuples
 
     input_path = Path(parquet_path).expanduser()
-    parquet_dataset = pa.parquet.ParquetDataset(input_path)
+    parquet_dataset = parquet.ParquetDataset(input_path)
 
     schema = parquet_schema_to_pixeltable_schema(parquet_path)
     if schema_override is None:

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -1,13 +1,15 @@
 import pathlib
 
 import pixeltable as pxt
-from ..utils import skip_test_if_not_installed, make_test_arrow_table
+
+from ..utils import make_test_arrow_table, skip_test_if_not_installed
 
 
 class TestParquet:
     def test_import_parquet(self, reset_db, tmp_path: pathlib.Path) -> None:
         skip_test_if_not_installed('pyarrow')
         import pyarrow as pa
+        from pyarrow import parquet
         from pixeltable.utils.arrow import iter_tuples
 
         parquet_dir = tmp_path / 'test_data'
@@ -18,7 +20,7 @@ class TestParquet:
         assert 'test_parquet' in pxt.list_tables()
         assert tab is not None
         num_elts = tab.count()
-        arrow_tab: pa.Table = pa.parquet.read_table(str(parquet_dir))
+        arrow_tab: pa.Table = parquet.read_table(str(parquet_dir))
         assert num_elts == arrow_tab.num_rows
         assert set(tab.column_names()) == set(arrow_tab.column_names)
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -328,6 +328,7 @@ class TestDataFrame:
         """ tests all types are handled correctly in this conversion
         """
         skip_test_if_not_installed('torch')
+        skip_test_if_not_installed('pyarrow')
         import torch
 
         t = all_datatypes_tbl
@@ -358,6 +359,8 @@ class TestDataFrame:
         """ tests the image_format parameter is honored
         """
         skip_test_if_not_installed('torch')
+        skip_test_if_not_installed('torchvision')
+        skip_test_if_not_installed('pyarrow')
         import torch
         import torchvision.transforms as T
 
@@ -474,6 +477,7 @@ class TestDataFrame:
             3. changing the select list invalidates the cached version
         """
         skip_test_if_not_installed('torch')
+        skip_test_if_not_installed('pyarrow')
         t = all_datatypes_tbl
 
         t.drop_column('c_video') # null value video column triggers internal assertions in DataRow

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -27,6 +27,7 @@ class TestMigration:
     @pytest.mark.skipif(sys.version_info >= (3, 11), reason='Does not run on Python 3.11+ (due to pickling issue)')
     def test_db_migration(self, init_env) -> None:
         skip_test_if_not_installed('transformers')
+        skip_test_if_not_installed('toml')
         import toml
 
         env = Env.get()

--- a/tests/tool/test_db_dump_tool.py
+++ b/tests/tool/test_db_dump_tool.py
@@ -7,4 +7,5 @@ class TestDbDumpTool:
 
     def test_db_dump_tool(self) -> None:
         skip_test_if_not_installed('label_studio_sdk')
+        skip_test_if_not_installed('toml')
         subprocess.run('python pixeltable/tool/create_test_db_dump.py'.split(' '), check=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,10 +6,10 @@ import random
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import PIL.Image
 import more_itertools
 import numpy as np
 import pandas as pd
+import PIL.Image
 import pytest
 
 import pixeltable as pxt
@@ -20,18 +20,8 @@ from pixeltable.dataframe import DataFrameResultSet
 from pixeltable.env import Env
 from pixeltable.functions.huggingface import clip_image, clip_text, sentence_transformer
 from pixeltable.io import SyncStatus
-from pixeltable.type_system import (
-    ArrayType,
-    BoolType,
-    ColumnType,
-    FloatType,
-    ImageType,
-    IntType,
-    JsonType,
-    StringType,
-    TimestampType,
-    VideoType,
-)
+from pixeltable.type_system import (ArrayType, BoolType, ColumnType, FloatType, ImageType, IntType, JsonType,
+                                    StringType, TimestampType, VideoType)
 
 
 def make_default_type(t: ColumnType.Type) -> ColumnType:
@@ -394,6 +384,7 @@ def validate_sync_status(
 
 def make_test_arrow_table(output_path: Path) -> None:
     import pyarrow as pa
+    from pyarrow import parquet
 
     value_dict = {
         'c_id': [1, 2, 3, 4, 5],
@@ -449,7 +440,7 @@ def make_test_arrow_table(output_path: Path) -> None:
     )
 
     test_table = pa.Table.from_pydict(value_dict, schema=schema)
-    pa.parquet.write_table(test_table, str(output_path / 'test.parquet'))
+    parquet.write_table(test_table, str(output_path / 'test.parquet'))
 
 
 def assert_img_eq(img1: PIL.Image.Image, img2: PIL.Image.Image) -> None:


### PR DESCRIPTION
Sets up a nightly (actually, thrice-weekly) CI workflow that `pip install`s Pixeltable along with various combinations of optional dependencies and ensures that the tests run.

This isn't intended to detect regressions due to code changes, but rather, regressions that happen due to something else changing in the environment (e.g., a third party releasing a new version of a library that gets preferentially `pip install`ed but is backward-incompatible).

I've already found (and fixed) a couple bugs this way:
- `img.resize()` is broken with the latest Pillow release
- import errors when using torch/transformers with pyarrow