### PR TITLE
Break out documents dependencies into an extras package

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-22.04, macos-12, windows-2022]
         python-version: ["3.9", "3.12"]
         test-category: ["py"]
-        poetry-options: ["--with dev"]
+        poetry-options: ["--extras documents --with dev"]
         # Add some additional matrix configurations that are run only on linux, to test
         # additional scenarios/compatibilities that are unlikely to be platform-sensitive.
         include:
@@ -33,22 +33,22 @@ jobs:
           - os: ubuntu-22.04
             python-version: "3.10"
             test-category: "py"
-            poetry-options: "--with dev"
+            poetry-options: "--extras documents --with dev"
           # Python 3.11
           - os: ubuntu-22.04
             python-version: "3.11"
             test-category: "py"
-            poetry-options: "--with dev"
+            poetry-options: "--extras documents --with dev"
           # Minimal installation of pixeltable (without --with dev)
           - os: ubuntu-22.04
             python-version: "3.9"
             test-category: "py"
-            poetry-options: ""
+            poetry-options: ""  # Minimal installation
           # Notebook tests
           - os: ubuntu-22.04
             python-version: "3.9"
             test-category: "ipynb"
-            poetry-options: "--with dev"
+            poetry-options: "--extras documents --with dev"
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ YOLOX_OK := $(shell python -c "import sys; sys.stdout.write(str(sys.version_info
 
 .make-install/deps: poetry.lock
 	@echo "Installing dependencies from poetry ..."
-	@poetry install --with dev
+	@poetry install --extras documents --with dev
 	@touch .make-install/deps
 
 .make-install/others:

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -435,7 +435,10 @@ class Env:
         check('yolox')
         check('whisperx')
         check('boto3')
+        check('bs4')
+        check('ftfy')
         check('fitz')  # pymupdf
+        check('mistune')
         check('pyarrow')
         check('spacy')  # TODO: deal with en-core-web-sm
         if self.is_installed_package('spacy'):

--- a/pixeltable/iterators/document.py
+++ b/pixeltable/iterators/document.py
@@ -3,8 +3,6 @@ import enum
 import logging
 from typing import Dict, Any, List, Tuple, Optional, Iterable, Iterator
 
-import ftfy
-
 from pixeltable.env import Env
 from pixeltable.exceptions import Error
 from pixeltable.type_system import ColumnType, DocumentType, StringType, IntType, JsonType
@@ -118,6 +116,9 @@ class DocumentSplitter(ComponentIterator):
                  `'title'`, `'heading'` (HTML and Markdown), `'sourceline'` (HTML), `'page'` (PDF), `'bounding_box'`
                  (PDF). The input may be a comma-separated string, e.g., `'title,heading,sourceline'`.
         """
+        Env.get().require_package('ftfy')
+        import ftfy
+
         if html_skip_tags is None:
             html_skip_tags = ['nav']
         self._doc_handle = get_document_handle(document)
@@ -251,6 +252,8 @@ class DocumentSplitter(ComponentIterator):
                 headings[el.name] = el.get_text().strip()
 
         def emit() -> None:
+            import ftfy
+
             nonlocal accumulated_text, headings, sourceline
             if len(accumulated_text) > 0:
                 md = DocumentSectionMetadata(sourceline=sourceline, heading=headings.copy())
@@ -310,6 +313,8 @@ class DocumentSplitter(ComponentIterator):
             headings[level] = text
 
         def emit() -> None:
+            import ftfy
+
             nonlocal accumulated_text, headings
             if len(accumulated_text) > 0:
                 metadata = DocumentSectionMetadata(sourceline=0, heading=headings.copy())
@@ -356,6 +361,8 @@ class DocumentSplitter(ComponentIterator):
         accumulated_text = []  # invariant: all elements are ftfy clean and non-empty
 
         def _add_cleaned_text(raw_text: str) -> None:
+            import ftfy
+
             fixed = ftfy.fix_text(raw_text)
             if fixed:
                 accumulated_text.append(fixed)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2136,7 +2136,7 @@ tqdm = ["tqdm"]
 name = "ftfy"
 version = "6.2.0"
 description = "Fixes mojibake and other problems with Unicode, after the fact"
-optional = false
+optional = true
 python-versions = ">=3.8,<4"
 files = [
     {file = "ftfy-6.2.0-py3-none-any.whl", hash = "sha256:f94a2c34b76e07475720e3096f5ca80911d152406fbde66fdb45c4d0c9150026"},
@@ -5951,7 +5951,7 @@ extra = ["pygments (>=2.12)"]
 name = "pymupdf"
 version = "1.24.2"
 description = "A high performance Python library for data extraction, analysis, conversion & manipulation of PDF (and other) documents."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "PyMuPDF-1.24.2-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:5faed2bbdfbea80db1bbaa5944888f27a672f2e10e16e61f7d4ff73429a00506"},
@@ -5994,7 +5994,7 @@ PyMuPDFb = "1.24.1"
 name = "pymupdfb"
 version = "1.24.1"
 description = "MuPDF shared libraries for PyMuPDF."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "PyMuPDFb-1.24.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:37179e363bf69ce9be637937c5469957b96968341dabe3ce8f4b690a82e9ad92"},
@@ -9042,7 +9042,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+documents = ["ftfy", "mistune", "pymupdf"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "a3abb3ddb6892eef276ebdc6823d2b0db1650860dfc40bd4cf75636c78f99d07"
+content-hash = "e727c1fac8af2db21e459cb0416c096f4b5bc01e5d71926b2e8c44c2ddf20641"

--- a/poetry.lock
+++ b/poetry.lock
@@ -9045,4 +9045,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "aa132ae5a2b506da304e962a533016d8ea2aa9c252361e3c3fa6aab02ff6b0c0"
+content-hash = "a3abb3ddb6892eef276ebdc6823d2b0db1650860dfc40bd4cf75636c78f99d07"

--- a/poetry.lock
+++ b/poetry.lock
@@ -9043,9 +9043,9 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
-documents = ["ftfy", "mistune", "pymupdf"]
+documents = ["beautifulsoup4", "ftfy", "mistune", "pymupdf"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "e727c1fac8af2db21e459cb0416c096f4b5bc01e5d71926b2e8c44c2ddf20641"
+content-hash = "219244b51b69da9d92f1345049baa56f13251fbb56df50a09f0ec1ae195899ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,13 @@ requests = "^2.31.0"
 pyyaml = "^6.0.1"
 jinja2 = "^3.1.3"
 tenacity = "^8.2"
-mistune = "^3.0.2"
-pymupdf = "^1.24.1"
-ftfy = "^6.2.0"
+mistune = { version = "^3.0.2", optional = true }
+pymupdf = { version = "^1.24.1", optional = true }
+ftfy = { version = "^6.2.0", optional = true }
 pixeltable-pgserver = "==0.2.7"
+
+[tool.poetry.extras]
+documents = ["mistune", "pymupdf", "ftfy"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,18 +30,18 @@ psutil = "^5.9.5"
 sqlalchemy = {extras = ["mypy"], version = "^2.0.23"}
 pgvector = "^0.2.1"
 av = ">=10.0.0"
-beautifulsoup4 = "^4.0.0"
 requests = "^2.31.0"
 pyyaml = "^6.0.1"
 jinja2 = "^3.1.3"
 tenacity = "^8.2"
+beautifulsoup4 = { version = "^4.0.0", optional = true }
 mistune = { version = "^3.0.2", optional = true }
 pymupdf = { version = "^1.24.1", optional = true }
 ftfy = { version = "^6.2.0", optional = true }
 pixeltable-pgserver = "==0.2.7"
 
 [tool.poetry.extras]
-documents = ["mistune", "pymupdf", "ftfy"]
+documents = ["beautifulsoup4", "mistune", "pymupdf", "ftfy"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-setuptools = "69.1.1"  # setuptools >= 69.2 has known issues with Github Actions
 numpy = ">=1.25"
 pandas = ">=2.0,<3.0"
 pillow = ">=9.3.0"

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, Dict
 
 import PIL.Image
-import bs4
 import numpy as np
 import pytest
 
@@ -197,6 +196,9 @@ class TestDataFrame:
         assert res[next(iter(res.schema.keys()))] == [1.0] * 10
 
     def test_html_media_url(self, reset_db) -> None:
+        skip_test_if_not_installed('bs4')
+        import bs4
+
         tab = pxt.create_table('test_html_repr', {'video': pxt.VideoType(),
                                                   'audio': pxt.AudioType(),
                                                   'doc': pxt.DocumentType()})

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -8,15 +8,11 @@ import pytest
 
 import pixeltable as pxt
 from pixeltable.iterators.document import DocumentSplitter
-from .utils import (
-    get_audio_files,
-    get_documents,
-    get_image_files,
-    get_video_files,
-    skip_test_if_not_installed,
-)
 from pixeltable.type_system import DocumentType
 from pixeltable.utils.documents import get_document_handle
+
+from .utils import get_audio_files, get_documents, get_image_files, get_video_files, skip_test_if_not_installed
+
 
 def _check_pdf_metadata(rec, sep1):
     if sep1 in ['page', 'paragraph', 'sentence']:
@@ -48,6 +44,7 @@ class TestDocument:
         return [get_video_files()[0], get_audio_files()[0], get_image_files()[0]]
 
     def test_insert(self, reset_db) -> None:
+        skip_test_if_not_installed('bs4')
         file_paths = self.valid_doc_paths()
         doc_t = pxt.create_table('docs', {'doc': DocumentType()})
         status = doc_t.insert({'doc': p} for p in file_paths)
@@ -62,6 +59,7 @@ class TestDocument:
         assert status.num_excs >= len(file_paths)
 
     def test_get_document_handle(self) -> None:
+        skip_test_if_not_installed('bs4')
         file_paths = self.valid_doc_paths()
         for path in file_paths:
             extension = path.split('.')[-1].lower()
@@ -85,6 +83,8 @@ class TestDocument:
     def test_invalid_arguments(self, reset_db) -> None:
         """ Test input parsing provides useful error messages
         """
+        skip_test_if_not_installed('bs4')
+
         example_file = [p for p in self.valid_doc_paths() if p.endswith('.pdf')][0]
 
         # test invalid separators, or combinations of separators
@@ -121,8 +121,8 @@ class TestDocument:
 
     def test_doc_splitter(self, reset_db) -> None:
         skip_test_if_not_installed('tiktoken')
-        skip_test_if_not_installed('fitz')
         skip_test_if_not_installed('spacy')
+        skip_test_if_not_installed('bs4')
 
         file_paths = self.valid_doc_paths()
         doc_t = pxt.create_table('docs', {'doc': DocumentType()})

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -392,6 +392,7 @@ class TestTable:
         self.check_bad_media(rows, AudioType(nullable=True))
 
     def test_validate_docs(self, reset_db) -> None:
+        skip_test_if_not_installed('bs4')
         valid_doc_paths = get_documents()
         invalid_doc_paths = [get_video_files()[0], get_audio_files()[0], get_image_files()[0]]
         doc_paths = valid_doc_paths + invalid_doc_paths


### PR DESCRIPTION
Creates a new `pixeltable[documents]` extras package for the documents
dependencies: `beautifulsoup4`, `pymupdf`, `mistune`, and `ftfy`.

Fixes spurious warnings when doing `pip install pixeltable` in colab.