### PR TITLE
Fix circularity in DB migration for schema version 19 -> 20

### DIFF
--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -4,6 +4,7 @@ import os
 import platform
 import subprocess
 import sys
+from datetime import datetime
 
 import pixeltable_pgserver
 import pytest
@@ -11,7 +12,7 @@ import sqlalchemy.orm as orm
 
 import pixeltable as pxt
 from pixeltable.env import Env
-from pixeltable.exprs import FunctionCall
+from pixeltable.exprs import FunctionCall, Literal
 from pixeltable.func import CallableFunction
 from pixeltable.metadata import VERSION, SystemInfo
 from pixeltable.metadata.notes import VERSION_NOTES
@@ -135,6 +136,15 @@ class TestMigration:
         # Test that stored batched functions are properly loaded as batched
         expr = v['view_test_udf_batched'].col.value_expr
         assert isinstance(expr, FunctionCall) and isinstance(expr.fn, CallableFunction) and expr.fn.is_batched
+
+        # Test that timestamp literals are properly stored as aware datetimes
+        expr = v['view_timestamp_const_1'].col.value_expr
+        assert isinstance(expr, Literal) and isinstance(expr.val, datetime) and expr.val.tzinfo is not None
+
+        # Test that timestamp columns are properly converted to aware columns (TIMESTAMPTZ in Postgres)
+        ts1 = v.select(v.c5).head(1)[0]['c5']
+        assert isinstance(ts1, datetime)
+        assert ts1.tzinfo is not None  # ensure timestamps are aware
 
     @classmethod
     def _run_v17_tests(cls) -> None:


### PR DESCRIPTION
PR #250 introduced an issue where database migration could enter an infinite loop in certain situations, because it was trying to use the catalog to drive the migration before the catalog had been fully loaded. This issue was not caught in testing because the unit tests uses a different catalog initialization mechanism (`reload_catalog()`).

This fix changes the migration script to rely only on literal metadata, and not on the Catalog, to drive the migration.

TESTING DONE: Manually create a v19 Pixeltable database and test the upgrade on that installation. Verify that the migration tests still pass with the new migration script.

PRODUCTION IMPACT: None. (PR #250 has not gone into production yet.)

FOLLOW-UP WORK: Consider adding additional tests that run the DB migrations on fresh Pixeltable instances in separate Python processes.