### PR TITLE
Reformatting code cells to fit display width

### DIFF
--- a/docs/release/tutorials/audio-transcriptions.ipynb
+++ b/docs/release/tutorials/audio-transcriptions.ipynb
@@ -121,7 +121,9 @@
     "# Create a table to store our videos and workflow\n",
     "video_table = pxt.create_table(\n",
     "    'transcription_demo.video_table',\n",
-    "    {'video': pxt.VideoType()})\n",
+    "    {'video': pxt.VideoType()}\n",
+    ")\n",
+    "\n",
     "video_table"
    ]
   },
@@ -494,9 +496,10 @@
    "source": [
     "from pixeltable.functions import whisper\n",
     "\n",
-    "video_table['transcription'] = \\\n",
-    "    whisper.transcribe(\n",
-    "        audio=video_table.audio, model='base.en')\n",
+    "video_table['transcription'] = whisper.transcribe(\n",
+    "    audio=video_table.audio, model='base.en'\n",
+    ")\n",
+    "\n",
     "video_table.select(\n",
     "    video_table.video,\n",
     "    video_table.transcription.text\n",
@@ -532,7 +535,8 @@
     "    video_table,\n",
     "    iterator=StringSplitter.create(\n",
     "        text=video_table.transcription.text,\n",
-    "        separators='sentence')\n",
+    "        separators='sentence'\n",
+    "    )\n",
     ")"
    ]
   },
@@ -747,13 +751,13 @@
    "source": [
     "sim = sentences_view.text.similarity('What is happiness?')\n",
     "\n",
-    "sentences_view\\\n",
-    ".order_by(sim, asc=False)\\\n",
-    ".limit(10)\\\n",
-    ".select(\n",
-    "    sentences_view.text, similarity=sim\n",
-    ")\\\n",
-    ".collect()"
+    "(\n",
+    "    sentences_view\n",
+    "    .order_by(sim, asc=False)\n",
+    "    .limit(10)\n",
+    "    .select(sentences_view.text,similarity=sim)\n",
+    "    .collect()\n",
+    ")"
    ]
   },
   {
@@ -1008,11 +1012,13 @@
    "source": [
     "sim = sentences_view.text.similarity('What is happiness?')\n",
     "\n",
-    "sentences_view\\\n",
-    ".order_by(sim, asc=False)\\\n",
-    ".limit(20)\\\n",
-    ".select(sentences_view.text, similarity=sim)\\\n",
-    ".collect()"
+    "(\n",
+    "    sentences_view\n",
+    "    .order_by(sim, asc=False)\n",
+    "    .limit(20)\n",
+    "    .select(sentences_view.text, similarity=sim)\n",
+    "    .collect()\n",
+    ")"
    ]
   },
   {
@@ -1076,9 +1082,9 @@
    "source": [
     "from pixeltable.functions import openai\n",
     "\n",
-    "video_table['transcription_from_api'] = \\\n",
-    "    openai.transcriptions(\n",
-    "        video_table.audio, model='whisper-1')"
+    "video_table['transcription_from_api'] = openai.transcriptions(\n",
+    "    video_table.audio, model='whisper-1'\n",
+    ")"
    ]
   },
   {

--- a/docs/release/tutorials/audio-transcriptions.ipynb
+++ b/docs/release/tutorials/audio-transcriptions.ipynb
@@ -119,7 +119,9 @@
     "pxt.create_dir('transcription_demo')\n",
     "\n",
     "# Create a table to store our videos and workflow\n",
-    "video_table = pxt.create_table('transcription_demo.video_table', {'video': pxt.VideoType()})\n",
+    "video_table = pxt.create_table(\n",
+    "    'transcription_demo.video_table',\n",
+    "    {'video': pxt.VideoType()})\n",
     "video_table"
    ]
   },
@@ -492,8 +494,13 @@
    "source": [
     "from pixeltable.functions import whisper\n",
     "\n",
-    "video_table['transcription'] = whisper.transcribe(audio=video_table.audio, model='base.en')\n",
-    "video_table.select(video_table.video, video_table.transcription.text).show()"
+    "video_table['transcription'] = \\\n",
+    "    whisper.transcribe(\n",
+    "        audio=video_table.audio, model='base.en')\n",
+    "video_table.select(\n",
+    "    video_table.video,\n",
+    "    video_table.transcription.text\n",
+    ").show()"
    ]
   },
   {
@@ -523,7 +530,9 @@
     "sentences_view = pxt.create_view(\n",
     "    'transcription_demo.sentences_view',\n",
     "    video_table,\n",
-    "    iterator=StringSplitter.create(text=video_table.transcription.text, separators='sentence')\n",
+    "    iterator=StringSplitter.create(\n",
+    "        text=video_table.transcription.text,\n",
+    "        separators='sentence')\n",
     ")"
    ]
   },
@@ -605,7 +614,10 @@
     }
    ],
    "source": [
-    "sentences_view.select(sentences_view.pos, sentences_view.text).show(8)"
+    "sentences_view.select(\n",
+    "    sentences_view.pos,\n",
+    "    sentences_view.text\n",
+    ").show(8)"
    ]
   },
   {
@@ -734,7 +746,14 @@
    ],
    "source": [
     "sim = sentences_view.text.similarity('What is happiness?')\n",
-    "sentences_view.select(sentences_view.text, similarity=sim).order_by(sim, asc=False).limit(10).collect()"
+    "\n",
+    "sentences_view\\\n",
+    ".order_by(sim, asc=False)\\\n",
+    ".limit(10)\\\n",
+    ".select(\n",
+    "    sentences_view.text, similarity=sim\n",
+    ")\\\n",
+    ".collect()"
    ]
   },
   {
@@ -849,7 +868,11 @@
     }
    ],
    "source": [
-    "video_table.select(video_table.video, video_table.metadata, video_table.transcription.text).show()"
+    "video_table.select(\n",
+    "    video_table.video,\n",
+    "    video_table.metadata,\n",
+    "    video_table.transcription.text\n",
+    ").show()"
    ]
   },
   {
@@ -984,7 +1007,12 @@
    ],
    "source": [
     "sim = sentences_view.text.similarity('What is happiness?')\n",
-    "sentences_view.select(sentences_view.text, similarity=sim).order_by(sim, asc=False).limit(20).collect()"
+    "\n",
+    "sentences_view\\\n",
+    ".order_by(sim, asc=False)\\\n",
+    ".limit(20)\\\n",
+    ".select(sentences_view.text, similarity=sim)\\\n",
+    ".collect()"
    ]
   },
   {
@@ -1048,7 +1076,9 @@
    "source": [
     "from pixeltable.functions import openai\n",
     "\n",
-    "video_table['transcription_from_api'] = openai.transcriptions(video_table.audio, model='whisper-1')"
+    "video_table['transcription_from_api'] = \\\n",
+    "    openai.transcriptions(\n",
+    "        video_table.audio, model='whisper-1')"
    ]
   },
   {
@@ -1130,7 +1160,11 @@
     }
    ],
    "source": [
-    "video_table.select(video_table.video, video_table.transcription.text, video_table.transcription_from_api.text).show()"
+    "video_table.select(\n",
+    "    video_table.video,\n",
+    "    video_table.transcription.text,\n",
+    "    video_table.transcription_from_api.text\n",
+    ").show()"
    ]
   },
   {
@@ -1179,7 +1213,10 @@
     }
    ],
    "source": [
-    "video_table.select(video_table.transcription, video_table.transcription_from_api).show(1)"
+    "video_table.select(\n",
+    "    video_table.transcription,\n",
+    "    video_table.transcription_from_api\n",
+    ").show(1)"
    ]
   }
  ],
@@ -1199,7 +1236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/release/tutorials/object-detection-in-videos.ipynb
+++ b/docs/release/tutorials/object-detection-in-videos.ipynb
@@ -66,11 +66,15 @@
    "source": [
     "import pixeltable as pxt\n",
     "\n",
-    "pxt.drop_dir('video_tutorial', force=True)  # Ensure a clean slate for the demo\n",
+    "# Ensure a clean slate for the demo\n",
+    "pxt.drop_dir('video_tutorial', force=True)\n",
     "pxt.create_dir('video_tutorial')\n",
     "\n",
     "# Create the `videos` table\n",
-    "videos_table = pxt.create_table('video_tutorial.videos', {'video': pxt.VideoType()})"
+    "videos_table = pxt.create_table(\n",
+    "    'video_tutorial.videos',\n",
+    "    {'video': pxt.VideoType()}\n",
+    ")"
    ]
   },
   {
@@ -238,7 +242,11 @@
     }
    ],
    "source": [
-    "videos_table.insert([{'video': 'https://raw.github.com/pixeltable/pixeltable/release/docs/source/data/bangkok.mp4'}])"
+    "videos_table.insert([\n",
+    "    {\n",
+    "        'video': 'https://raw.github.com/pixeltable/pixeltable/release/docs/source/data/bangkok.mp4'\n",
+    "    }\n",
+    "])"
    ]
   },
   {
@@ -376,7 +384,12 @@
     }
    ],
    "source": [
-    "frames_view.select(frames_view.pos, frames_view.frame, frames_view.frame.width, frames_view.frame.height).show(5)"
+    "frames_view.select(\n",
+    "    frames_view.pos,\n",
+    "    frames_view.frame,\n",
+    "    frames_view.frame.width,\n",
+    "    frames_view.frame.height\n",
+    ").show(5)"
    ]
   },
   {
@@ -473,9 +486,13 @@
     }
    ],
    "source": [
-    "# Show the results of applying the `yolox_tiny` model to the first few frames in the table.\n",
+    "# Show the results of applying the `yolox_tiny` model\n",
+    "# to the first few frames in the table.\n",
     "\n",
-    "frames_view.select(frames_view.frame, yolox(frames_view.frame, model_id='yolox_tiny')).show(3)"
+    "frames_view.select(\n",
+    "    frames_view.frame,\n",
+    "    yolox(frames_view.frame, model_id='yolox_tiny')\n",
+    ").show(3)"
    ]
   },
   {
@@ -504,11 +521,14 @@
     }
    ],
    "source": [
-    "# Create a computed column to compute detections using the `yolox_tiny` model.\n",
-    "# We'll adjust the confidence threshold down a bit (the default is 0.5) to pick up even more\n",
-    "# bounding boxes.\n",
+    "# Create a computed column to compute detections using the `yolox_tiny`\n",
+    "# model.\n",
+    "# We'll adjust the confidence threshold down a bit (the default is 0.5)\n",
+    "# to pick up even more bounding boxes.\n",
     "\n",
-    "frames_view['detect_yolox_tiny'] = yolox(frames_view.frame, model_id='yolox_tiny', threshold=0.25)"
+    "frames_view['detect_yolox_tiny'] = yolox(\n",
+    "    frames_view.frame, model_id='yolox_tiny', threshold=0.25\n",
+    ")"
    ]
   },
   {
@@ -672,7 +692,10 @@
     }
    ],
    "source": [
-    "frames_view.select(frames_view.frame, frames_view.detect_yolox_tiny).show(3)"
+    "frames_view.select(\n",
+    "    frames_view.frame,\n",
+    "    frames_view.detect_yolox_tiny\n",
+    ").show(3)"
    ]
   },
   {
@@ -694,11 +717,14 @@
     "import PIL.ImageDraw\n",
     "\n",
     "@pxt.udf\n",
-    "def draw_boxes(img: PIL.Image.Image, boxes: list[list[float]]) -> PIL.Image.Image:\n",
+    "def draw_boxes(\n",
+    "    img: PIL.Image.Image, boxes: list[list[float]]\n",
+    ") -> PIL.Image.Image:\n",
     "    result = img.copy()  # Create a copy of `img`\n",
     "    d = PIL.ImageDraw.Draw(result)\n",
     "    for box in boxes:\n",
-    "        d.rectangle(box, width=3)  # Draw bounding box rectangles on the copied image\n",
+    "        # Draw bounding box rectangles on the copied image\n",
+    "        d.rectangle(box, width=3)\n",
     "    return result"
    ]
   },
@@ -752,7 +778,13 @@
     }
    ],
    "source": [
-    "frames_view.select(frames_view.frame, draw_boxes(frames_view.frame, frames_view.detect_yolox_tiny.bboxes)).show(1)"
+    "frames_view.select(\n",
+    "    frames_view.frame,\n",
+    "    draw_boxes(\n",
+    "        frames_view.frame,\n",
+    "        frames_view.detect_yolox_tiny.bboxes\n",
+    "    )\n",
+    ").show(1)"
    ]
   },
   {
@@ -810,9 +842,15 @@
     }
    ],
    "source": [
-    "frames_view.select(pxt.functions.video.make_video(\n",
-    "    frames_view.pos, draw_boxes(frames_view.frame, frames_view.detect_yolox_tiny.bboxes)\n",
-    ")).group_by(videos_table).show(1)"
+    "frames_view.group_by(videos_table).select(\n",
+    "    pxt.functions.video.make_video(\n",
+    "        frames_view.pos,\n",
+    "        draw_boxes(\n",
+    "            frames_view.frame,\n",
+    "            frames_view.detect_yolox_tiny.bboxes\n",
+    "        )\n",
+    "    )\n",
+    ").show(1)"
    ]
   },
   {
@@ -849,7 +887,9 @@
    "source": [
     "# Here we use the larger `yolox_m` (medium) model.\n",
     "\n",
-    "frames_view['detect_yolox_m'] = yolox(frames_view.frame, model_id='yolox_m', threshold=0.25)"
+    "frames_view['detect_yolox_m'] = yolox(\n",
+    "    frames_view.frame, model_id='yolox_m', threshold=0.25\n",
+    ")"
    ]
   },
   {
@@ -906,11 +946,22 @@
     }
    ],
    "source": [
-    "frames_view.select(pxt.functions.video.make_video(\n",
-    "    frames_view.pos, draw_boxes(frames_view.frame, frames_view.detect_yolox_tiny.bboxes)\n",
-    "), pxt.functions.video.make_video(\n",
-    "    frames_view.pos, draw_boxes(frames_view.frame, frames_view.detect_yolox_m.bboxes)\n",
-    ")).group_by(videos_table).show(1)"
+    "frames_view.group_by(videos_table).select(\n",
+    "    pxt.functions.video.make_video(\n",
+    "        frames_view.pos,\n",
+    "        draw_boxes(\n",
+    "            frames_view.frame,\n",
+    "            frames_view.detect_yolox_tiny.bboxes\n",
+    "        )\n",
+    "    ),\n",
+    "    pxt.functions.video.make_video(\n",
+    "        frames_view.pos,\n",
+    "        draw_boxes(\n",
+    "            frames_view.frame,\n",
+    "            frames_view.detect_yolox_m.bboxes\n",
+    "        )\n",
+    "    )\n",
+    ").show(1)"
    ]
   },
   {
@@ -941,7 +992,9 @@
     }
    ],
    "source": [
-    "frames_view['detect_yolox_x'] = yolox(frames_view.frame, model_id='yolox_x', threshold=0.25)"
+    "frames_view['detect_yolox_x'] = yolox(\n",
+    "    frames_view.frame, model_id='yolox_x', threshold=0.25\n",
+    ")"
    ]
   },
   {
@@ -1168,7 +1221,10 @@
     }
    ],
    "source": [
-    "frames_view.select(frames_view.eval_yolox_tiny, frames_view.eval_yolox_m).show(1)"
+    "frames_view.select(\n",
+    "    frames_view.eval_yolox_tiny,\n",
+    "    frames_view.eval_yolox_m\n",
+    ").show(1)"
    ]
   },
   {
@@ -1217,7 +1273,10 @@
     }
    ],
    "source": [
-    "frames_view.select(mean_ap(frames_view.eval_yolox_tiny), mean_ap(frames_view.eval_yolox_m)).show()"
+    "frames_view.select(\n",
+    "    mean_ap(frames_view.eval_yolox_tiny),\n",
+    "    mean_ap(frames_view.eval_yolox_m)\n",
+    ").show()"
    ]
   },
   {
@@ -1245,7 +1304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/release/tutorials/rag-demo.ipynb
+++ b/docs/release/tutorials/rag-demo.ipynb
@@ -90,7 +90,8 @@
     "import numpy as np\n",
     "import pixeltable as pxt\n",
     "\n",
-    "pxt.drop_dir('rag_demo', force=True)  # Ensure a clean slate for the demo\n",
+    "# Ensure a clean slate for the demo\n",
+    "pxt.drop_dir('rag_demo', force=True)\n",
     "pxt.create_dir('rag_demo')"
    ]
   },
@@ -293,7 +294,11 @@
     }
    ],
    "source": [
-    "documents_t = pxt.create_table('rag_demo.documents', {'document': pxt.DocumentType()})\n",
+    "documents_t = pxt.create_table(\n",
+    "    'rag_demo.documents',\n",
+    "    {'document': pxt.DocumentType()}\n",
+    ")\n",
+    "\n",
     "documents_t"
    ]
   },
@@ -426,7 +431,9 @@
     "    documents_t,\n",
     "    iterator=DocumentSplitter.create(\n",
     "        document=documents_t.document,\n",
-    "        separators='token_limit', limit=300)\n",
+    "        separators='token_limit',\n",
+    "        limit=300\n",
+    "    )\n",
     ")"
    ]
   },
@@ -1180,10 +1187,11 @@
     "query_text = \"What is the expected EPS for Nvidia in Q1 2026?\"\n",
     "sim = chunks_t.text.similarity(query_text)\n",
     "nvidia_eps_query = (\n",
-    "    chunks_t.order_by(sim, asc=False)\n",
-    "        .select(similarity=sim, text=chunks_t.text)\n",
-    "        .limit(5)\n",
-    "    )\n",
+    "    chunks_t\n",
+    "    .order_by(sim, asc=False)\n",
+    "    .select(similarity=sim, text=chunks_t.text)\n",
+    "    .limit(5)\n",
+    ")\n",
     "nvidia_eps_query.collect()"
    ]
   },
@@ -1362,10 +1370,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define a UDF to create an LLM prompt given a top-k list of context chunks and a question.\n",
+    "# Define a UDF to create an LLM prompt given a top-k list of\n",
+    "# context chunks and a question.\n",
     "@pxt.udf\n",
     "def create_prompt(top_k_list: list[dict], question: str) -> str:\n",
-    "    concat_top_k = '\\n\\n'.join(elt['text'] for elt in reversed(top_k_list))\n",
+    "    concat_top_k = '\\n\\n'.join(\n",
+    "        elt['text'] for elt in reversed(top_k_list)\n",
+    "    )\n",
     "    return f'''\n",
     "    PASSAGES:\n",
     "\n",
@@ -1398,7 +1409,9 @@
     }
    ],
    "source": [
-    "queries_t['prompt'] = create_prompt(queries_t.question_context, queries_t.Question)"
+    "queries_t['prompt'] = create_prompt(\n",
+    "    queries_t.question_context, queries_t.Question\n",
+    ")"
    ]
   },
   {
@@ -1560,12 +1573,20 @@
     "\n",
     "# Assemble the prompt and instructions into OpenAI's message format\n",
     "messages = [\n",
-    "    {'role': 'system', 'content': 'Please read the following passages and answer the question based on their contents.'},\n",
-    "    {'role': 'user', 'content': queries_t.prompt}\n",
+    "    {\n",
+    "        'role': 'system',\n",
+    "        'content': 'Please read the following passages and answer the question based on their contents.'\n",
+    "    },\n",
+    "    {\n",
+    "        'role': 'user',\n",
+    "        'content': queries_t.prompt\n",
+    "    }\n",
     "]\n",
     "\n",
     "# Add a computed column that calls OpenAI\n",
-    "queries_t['response'] = openai.chat_completions(model='gpt-4o-mini', messages=messages)"
+    "queries_t['response'] = openai.chat_completions(\n",
+    "    model='gpt-4o-mini', messages=messages\n",
+    ")"
    ]
   },
   {
@@ -2167,7 +2188,13 @@
     }
    ],
    "source": [
-    "questions = list(queries_t.select(queries_t.S__No_, queries_t.Question, queries_t.correct_answer).collect())\n",
+    "questions = list(\n",
+    "    queries_t.select(\n",
+    "        queries_t.S__No_,\n",
+    "        queries_t.Question,\n",
+    "        queries_t.correct_answer\n",
+    "    ).collect()\n",
+    ")\n",
     "queries_t.delete()\n",
     "queries_t.insert(questions)"
    ]
@@ -2294,7 +2321,11 @@
     }
    ],
    "source": [
-    "queries_t.select(queries_t.Question, queries_t.correct_answer, queries_t.answer).show()"
+    "queries_t.select(\n",
+    "    queries_t.Question,\n",
+    "    queries_t.correct_answer,\n",
+    "    queries_t.answer\n",
+    ").show()"
    ]
   }
  ],
@@ -2314,7 +2345,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/release/tutorials/rag-operations.ipynb
+++ b/docs/release/tutorials/rag-operations.ipynb
@@ -45,8 +45,9 @@
    "source": [
     "import pixeltable as pxt\n",
     "\n",
+    "# Ensure a clean slate for the demo\n",
+    "pxt.drop_dir('rag_ops_demo', force=True)\n",
     "# Create the Pixeltable workspace\n",
-    "pxt.drop_dir('rag_ops_demo', force=True)  # Ensure a clean slate for the demo\n",
     "pxt.create_dir('rag_ops_demo')"
    ]
   },
@@ -75,7 +76,10 @@
     }
    ],
    "source": [
-    "docs = pxt.create_table('rag_ops_demo.docs', {'source_doc': pxt.DocumentType()})"
+    "docs = pxt.create_table(\n",
+    "    'rag_ops_demo.docs',\n",
+    "    {'source_doc': pxt.DocumentType()}\n",
+    ")"
    ]
   },
   {
@@ -318,7 +322,7 @@
     }
    ],
    "source": [
-    "docs.insert(source_doc='https://en.wikipedia.org/wiki/Marc_Chagall')"
+    "docs.insert([{'source_doc': 'https://en.wikipedia.org/wiki/Marc_Chagall'}])"
    ]
   },
   {
@@ -1207,7 +1211,9 @@
    "source": [
     "from pixeltable.functions.huggingface import sentence_transformer\n",
     "\n",
-    "chunks['minilm_embed'] =sentence_transformer(chunks.text, model_id='paraphrase-MiniLM-L6-v2')"
+    "chunks['minilm_embed'] = sentence_transformer(\n",
+    "    chunks.text, model_id='paraphrase-MiniLM-L6-v2'\n",
+    ")"
    ]
   },
   {
@@ -1451,7 +1457,9 @@
    "source": [
     "from pixeltable.functions.huggingface import clip_text\n",
     "\n",
-    "chunks['clip_embed'] = clip_text(chunks.text, model_id='openai/clip-vit-base-patch32')"
+    "chunks['clip_embed'] = clip_text(\n",
+    "    chunks.text, model_id='openai/clip-vit-base-patch32'\n",
+    ")"
    ]
   },
   {
@@ -1684,7 +1692,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A lot of the code cells are shown with their right side cut off due to the overly-narrow notebook display on readme.io.