### PR TITLE
Add UUID Type to Pixeltable Type System

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Any, Dict, List, Optional
+import uuid
 
 import numpy as np
 import PIL.Image
@@ -7,7 +8,7 @@ import PIL.Image
 import pixeltable as pxt
 from pixeltable.type_system import (ArrayType, BoolType, ColumnType, FloatType,
                                     ImageType, IntType, InvalidType, JsonType,
-                                    StringType, TimestampType)
+                                    StringType, TimestampType, UuidType)
 
 
 class TestTypes:
@@ -22,6 +23,7 @@ class TestTypes:
             (np.ndarray((1, 2, 3), dtype=np.int64), ArrayType((1, 2, 3), dtype=IntType())),
             ({'a': 1, 'b': '2'}, pxt.JsonType()),
             (['3', 4], pxt.JsonType()),
+            (uuid.uuid4(), UuidType()),
         ]
         for val, expected_type in test_cases:
             assert ColumnType.infer_literal_type(val) == expected_type, val


### PR DESCRIPTION
### PR Summary: Add UUID Type to Pixeltable Type System

**Description:**

This pull request introduces a new `UuidType` to the Pixeltable type system to provide native support for UUIDs.

**Changes:**

1. **New UUID Type:**
 
   - [x]  Added a new `UuidType` class extending `ColumnType` to manage UUID values.
     - [x] Implemented the `to_sa_type()` method to map the UUID type to SQLAlchemy's `sql.UUID()`.
     - [x] Implemented the `_validate_literal()` method to ensure the value is an instance of `uuid.UUID`.
     - [x] Implemented the `_create_literal()` method to support creating UUIDs from strings, bytes, or integers.

2. **Type Enum Update:**
   - [x] Updated the `ColumnType.Type` enum to include a new `UUID` type.

3. **Type Factory Method Update:**
   - [x] Updated the `make_type` method in `ColumnType` to handle the new `UUID` type by returning an instance of `UuidType`.

4. **Test:**
   - [x] Added a unit test to `test_types.py` to ensure that `UuidType` behaves as expected.