### PR TITLE
initial-contributing-guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,5 +13,5 @@ https://github.com/pixeltable/pixeltable/blob/main/LICENSE
 
 
 ### Dev Dependencies
-We currently use [Poetry](https://python-poetry.org/) to manage our dependencies [ packaged, and dev ].  To contributin, you will need the 'dev' dependencies, those are defined in the 'dev' group in poetry.  You can install the dev dependencies by running `poetry install --with dev`
+We currently use [Poetry](https://python-poetry.org/) to manage our dependencies [ packaged, and dev ].  To contribute/develop, you will need the 'dev' dependencies, those are defined in the 'dev' group in poetry.  You can install the dev dependencies by running `poetry install --with dev`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+Recommendations and requirements for how to best contribute to Pixeltable. We strive to obey these as best as possible. As always, thanks for contributing--we hope these guidelines make it easier and shed some light on our approach and processes. If you believe there should be a change or exception to these rules please bring it up for discussion.
+
+### Key branches
+- `main` has the latest stable changes
+
+### Pull requests
+- Submit pull requests against the `master` branch
+- Try not to pollute your pull request with unintended changes--keep them simple and small
+
+### License
+By contributing your code, you agree to license your contribution under the terms of the APLv2:
+https://github.com/pixeltable/pixeltable/blob/main/LICENSE
+
+
+### Dev Dependencies
+We currently use [Poetry](https://python-poetry.org/) to manage our dependencies [ packaged, and dev ].  For contributing, you'll be developing.  You can install dev dependencies by running `poetry install --with dev`
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,5 +13,5 @@ https://github.com/pixeltable/pixeltable/blob/main/LICENSE
 
 
 ### Dev Dependencies
-We currently use [Poetry](https://python-poetry.org/) to manage our dependencies [ packaged, and dev ].  For contributing, you'll be developing.  You can install dev dependencies by running `poetry install --with dev`
+We currently use [Poetry](https://python-poetry.org/) to manage our dependencies [ packaged, and dev ].  To contributin, you will need the 'dev' dependencies, those are defined in the 'dev' group in poetry.  You can install the dev dependencies by running `poetry install --with dev`
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ Today's solutions for AI app development require extensive custom coding and inf
 ## 🐛 Contributions & Feedback
 
 Are you experiencing issues or bugs with Pixeltable? File an [Issue](https://github.com/pixeltable/pixeltable/issues).
-</br>Do you want to contribute? Feel free to open a [PR](https://github.com/pixeltable/pixeltable/pulls).
+</br>Do you want to contribute? Feel free to open a [PR](https://github.com/pixeltable/pixeltable/pulls), or see the [Contribution Guide](CONTRIBUTING.md).
+
 
 ## :classical_building: License
 


### PR DESCRIPTION
Initial contributing docs.

Esp. for place to document community conventions.

And, to highlight important/core tools.

Largely modeled from foundation of Parquet community doc, given I see there is potential community overlap.  