### PR TITLE
Update macos-12 to macos-13 in github actions configs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
           - "label_studio_sdk"
         include:
           # Test the basic pixeltable installation on other platforms.
-          - os: macos-12
+          - os: macos-13
             python-version: "3.9"
             package-configs: ""
           - os: macos-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,11 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         # Test with Python 3.9 and 3.12 (minimum and maximum supported versions) on every platform.
-        # After a PR, test only the basic (free) platforms: ubuntu-22.04, macos-12, macos-latest, windows-2022.
+        # After a PR, test only the basic (free) platforms: ubuntu-22.04, macos-13, macos-latest, windows-2022.
         # On other event types (push and workflow_dispatch), test also ubuntu-arm64 and ubuntu-x64-t4.
         os: ${{ github.event_name == 'pull_request'
-                && fromJSON('["ubuntu-22.04", "macos-12", "windows-2022"]')
-                || fromJSON('["ubuntu-22.04", "macos-12", "windows-2022", "ubuntu-arm64", "ubuntu-x64-t4"]') }}
+                && fromJSON('["ubuntu-22.04", "macos-13", "windows-2022"]')
+                || fromJSON('["ubuntu-22.04", "macos-13", "windows-2022", "ubuntu-arm64", "ubuntu-x64-t4"]') }}
         python-version: ["3.9", "3.12"]
         test-category: ["py"]
         poetry-options: ["--with dev"]


### PR DESCRIPTION
Github Actions is deprecating macos-12. This updates to use macos-13 instead.