### PR TITLE
Allow @query to be redefined if in __main__ (notebook) scope

### DIFF
--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -909,7 +909,7 @@ class Table(SchemaObject):
             query_name = py_fn.__name__
             if query_name in self._schema.keys():
                 raise excs.Error(f'Query name {query_name!r} conflicts with existing column')
-            if query_name in self._queries:
+            if query_name in self._queries and function_path is not None:
                 raise excs.Error(f'Duplicate query name: {query_name!r}')
             import pixeltable.func as func
             query_fn = func.QueryTemplateFunction.create(


### PR DESCRIPTION
It's a 1-line change. I don't see an easy way to test it, unfortunately; we'd have to simulate notebook scope somehow (maybe we can file that away as a future problem)