### PR TITLE
Ensure FunctionCall return types have correct nullability

### DIFF
--- a/tests/functions/test_huggingface.py
+++ b/tests/functions/test_huggingface.py
@@ -52,7 +52,7 @@ class TestHuggingface:
             assert t._schema[col_name].is_array_type()
             list_col_name = f'embed_list{idx}'
             t[list_col_name] = sentence_transformer_list(t.input_list, model_id=model_id, normalize_embeddings=True)
-            assert t._schema[list_col_name] == pxt.JsonType()
+            assert t._schema[list_col_name] == pxt.JsonType(nullable=True)
 
         def verify_row(row: dict[str, Any]) -> None:
             for idx, (_, d) in enumerate(zip(model_ids, num_dims)):
@@ -85,10 +85,10 @@ class TestHuggingface:
         for idx, model_id in enumerate(model_ids):
             col_name = f'embed{idx}'
             t[col_name] = cross_encoder(t.input, t.input, model_id=model_id)
-            assert t._schema[col_name] == pxt.FloatType()
+            assert t._schema[col_name] == pxt.FloatType(nullable=True)
             list_col_name = f'embed_list{idx}'
             t[list_col_name] = cross_encoder_list(t.input, t.input_list, model_id=model_id)
-            assert t._schema[list_col_name] == pxt.JsonType()
+            assert t._schema[list_col_name] == pxt.JsonType(nullable=True)
 
         def verify_row(row: dict[str, Any]) -> None:
             for i in range(len(model_ids)):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1408,6 +1408,34 @@ class TestTable:
         result = t.where(t.add3.errortype != None).select(t.c2, t.add3, t.add3.errortype, t.add3.errormsg).show()
         assert len(result) == 10
 
+    def test_computed_column_types(self, reset_db) -> None:
+        t = pxt.create_table(
+            'test',
+            {
+                'c1': pxt.Int,
+                'c1_r': pxt.Required[pxt.Int],
+                'c2': pxt.String,
+                'c2_r': pxt.Required[pxt.String],
+            }
+        )
+
+        # Ensure that arithmetic and (non-nullable) function call expressions inherit nullability from their arguments
+        t.add_column(arith=t.c1 + 1)
+        t.add_column(arith_r=t.c1_r + 1)
+        t.add_column(func=t.c2.upper())
+        t.add_column(func_r=t.c2_r.upper())
+
+        assert t.get_metadata()['schema'] == {
+            'c1': pxt.IntType(nullable=True),
+            'c1_r': pxt.IntType(nullable=False),
+            'c2': pxt.StringType(nullable=True),
+            'c2_r': pxt.StringType(nullable=False),
+            'arith': pxt.IntType(nullable=True),
+            'arith_r': pxt.IntType(nullable=False),
+            'func': pxt.StringType(nullable=True),
+            'func_r': pxt.StringType(nullable=False),
+        }
+
     def test_describe(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
         fn = lambda c2: np.full((3, 4), c2)


### PR DESCRIPTION
Ensures that a `FunctionCall` will have nullable return type if any of its non-nullable parameters have a nullable input. This conforms to Pixeltable's behavior of defaulting to `None` any time a `FunctionCall` sees such an input.

Previously, the column type was reported as non-nullable but `None`s were being generated, an inconsistency.