### PR TITLE
Test infrastructure improvements

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Ensure pytest is installed
         # This is necessary for running the tests without --with dev
         if: ${{ matrix.poetry-options == '' }}
-        run: pip install pytest coverage
+        run: pip install pytest pytest-xdist pytest-rerunfailures coverage
       - name: Run the unit tests
         if: ${{ matrix.test-category == 'py' }}
         # Run the tests with the 'expensive' marker only once, on ubuntu-22.04 with Python 3.9. The other tests

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test: pytest typecheck docstest
 	@echo "All tests passed!"
 
 .PHONY: fulltest
-fulltest: pytestall nbtest typecheck docstest
+fulltest: fullpytest nbtest typecheck docstest
 	@echo "All tests passed!"
 
 .PHONY: pytest

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,19 @@ help:
 	@echo "Targets:"
 	@echo "  install       Install the development environment"
 	@echo "  test          Run pytest, typecheck, and docstest"
+	@echo "  fulltest      Run pytest, nbtest, typecheck, and docstest, including expensive tests"
+	@echo "  release       Create a pypi release and post to github"
+	@echo "  release-docs  Build and deploy API documentation (must be run from home repo, not a fork)"
+	@echo ""
+	@echo "Individual test targets:"
+	@echo "  clean         Remove generated files and temp files"
 	@echo "  pytest        Run pytest"
+	@echo "  fullpytest    Run pytest, including expensive tests"
 	@echo "  typecheck     Run mypy"
 	@echo "  docstest      Run mkdocs build --strict"
 	@echo "  nbtest        Run notebook tests"
 	@echo "  lint          Run linting tools against changed files"
 	@echo "  format        Format changed files with ruff (updates .py files in place)"
-	@echo "  release       Create a pypi release and post to github"
-	@echo "  release-docs  Build and deploy API documentation"
-	@echo "  clean         Remove generated files and temp files"
 
 .PHONY: setup-install
 setup-install:
@@ -67,10 +71,19 @@ install: setup-install .make-install/poetry .make-install/deps .make-install/oth
 test: pytest typecheck docstest
 	@echo "All tests passed!"
 
+.PHONY: fulltest
+fulltest: pytestall nbtest typecheck docstest
+	@echo "All tests passed!"
+
 .PHONY: pytest
 pytest: install
 	@echo "Running pytest ..."
-	@ulimit -n 4000; pytest -v
+	@ulimit -n 4000; pytest -v -n auto --dist loadgroup --maxprocesses 6 tests
+
+.PHONY: fullpytest
+fullpytest: install
+	@echo "Running pytest, including expensive tests ..."
+	@ulimit -n 4000; pytest -v -m '' -n auto --dist loadgroup --maxprocesses 6 tests
 
 NB_CELL_TIMEOUT := 3600
 # We ensure the TQDM progress bar is updated exactly once per cell execution, by setting the refresh rate equal
@@ -85,10 +98,12 @@ nbtest: install
 
 .PHONY: typecheck
 typecheck: install
+	@echo "Running mypy ..."
 	@mypy pixeltable
 
 .PHONY: docstest
 docstest: install
+	@echo "Running mkdocs build --strict ..."
 	@mkdocs build --strict
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  install       Install the development environment"
-	@echo "  test          Run pytest"
-	@echo "  nbtest        Run notebook tests"
+	@echo "  test          Run pytest, typecheck, and docstest"
+	@echo "  pytest        Run pytest"
 	@echo "  typecheck     Run mypy"
+	@echo "  docstest      Run mkdocs build --strict"
+	@echo "  nbtest        Run notebook tests"
 	@echo "  lint          Run linting tools against changed files"
 	@echo "  format        Format changed files with ruff (updates .py files in place)"
 	@echo "  release       Create a pypi release and post to github"
@@ -41,6 +43,7 @@ YOLOX_OK := $(shell python -c "import sys; sys.stdout.write(str(sys.version_info
 
 .make-install/deps: poetry.lock
 	@echo "Installing dependencies from poetry ..."
+	@export CMAKE_ARGS='-DLLAVA_BUILD=OFF'
 	@poetry install --with dev
 	@touch .make-install/deps
 
@@ -61,7 +64,11 @@ endif
 install: setup-install .make-install/poetry .make-install/deps .make-install/others
 
 .PHONY: test
-test: install
+test: pytest typecheck docstest
+	@echo "All tests passed!"
+
+.PHONY: pytest
+pytest: install
 	@echo "Running pytest ..."
 	@ulimit -n 4000; pytest -v
 
@@ -79,6 +86,10 @@ nbtest: install
 .PHONY: typecheck
 typecheck: install
 	@mypy pixeltable
+
+.PHONY: docstest
+docstest: install
+	@mkdocs build --strict
 
 .PHONY: lint
 lint: install

--- a/poetry.lock
+++ b/poetry.lock
@@ -5341,9 +5341,9 @@ files = [
 numpy = [
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.21.0", markers = "python_version == \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
-    {version = ">=1.19.3", markers = "platform_system == \"Linux\" and platform_machine == \"aarch64\" and python_version >= \"3.8\" and python_version < \"3.10\" or python_version > \"3.9\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_system != \"Darwin\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
     {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\" and python_version < \"3.11\""},
     {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.19.3", markers = "platform_system == \"Linux\" and platform_machine == \"aarch64\" and python_version >= \"3.8\" and python_version < \"3.10\" or python_version > \"3.9\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_system != \"Darwin\" and python_version < \"3.10\" or python_version >= \"3.9\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
     {version = ">=1.23.5", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 
@@ -6898,6 +6898,21 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "14.0"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-rerunfailures-14.0.tar.gz", hash = "sha256:4a400bcbcd3c7a4ad151ab8afac123d90eca3abe27f98725dc4d9702887d2e92"},
+    {file = "pytest_rerunfailures-14.0-py3-none-any.whl", hash = "sha256:4197bdd2eaeffdbf50b5ea6e7236f47ff0e44d1def8dae08e409f536d84e7b32"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=7.2"
 
 [[package]]
 name = "pytest-xdist"
@@ -10350,4 +10365,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "fe093ef335ceb9ca791682c505fb6f91272e7a1485ee5997220a0888b7ee54fa"
+content-hash = "22bdf7911905ed9d0ea718fd49a523021305ed5366ba519aa968f11c601e4c91"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ optional = true
 # pytest-related
 pytest = "^7.2.1"
 pytest-xdist = { extras = ["psutil"], version = "^3.3.1" }
+pytest-rerunfailures = "^14.0.0"
 coverage = "^7.4"
 # type checking
 mypy = "^1.11.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def init_env(tmp_path_factory, worker_id) -> None:
     # Set the relevant env vars for the test db.
     # We use a single shared pgserver instance, running in the "true" home directory ($PIXELTABLE_HOME/pgdata).
     # Each worker gets its own test db in this instance, along with its own home directory for everything else
-    # (file cache, media cache, etc).
+    # (file cache, media store, etc).
     shared_home = pathlib.Path(os.environ.get('PIXELTABLE_HOME', str(pathlib.Path.home() / '.pixeltable')))
     home_dir = str(tmp_path_factory.mktemp('base') / '.pixeltable')
     os.environ['PIXELTABLE_HOME'] = home_dir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,13 @@ import pathlib
 from typing import List
 
 import pytest
+from filelock import FileLock
 
 import pixeltable as pxt
 import pixeltable.catalog as catalog
 import pixeltable.functions as pxtf
 from pixeltable import exprs
+from pixeltable.env import Env
 from pixeltable.exprs import RELATIVE_PATH_ROOT as R
 from pixeltable.metadata import SystemInfo, create_system_info
 from pixeltable.metadata.schema import Dir, Function, Table, TableSchemaVersion, TableVersion
@@ -19,23 +21,28 @@ from .utils import create_all_datatypes_tbl, create_img_tbl, create_test_tbl, re
 
 
 @pytest.fixture(scope='session')
-def init_env(tmp_path_factory) -> None:
-    from pixeltable.env import Env
-
-    # set the relevant env vars for the test db
+def init_env(tmp_path_factory, worker_id) -> None:
+    # Set the relevant env vars for the test db.
+    # We use a single shared pgserver instance, running in the "true" home directory ($PIXELTABLE_HOME/pgdata).
+    # Each worker gets its own test db in this instance, along with its own home directory for everything else
+    # (file cache, media cache, etc).
     shared_home = pathlib.Path(os.environ.get('PIXELTABLE_HOME', str(pathlib.Path.home() / '.pixeltable')))
     home_dir = str(tmp_path_factory.mktemp('base') / '.pixeltable')
     os.environ['PIXELTABLE_HOME'] = home_dir
     os.environ['PIXELTABLE_CONFIG'] = str(shared_home / 'config.toml')
-    test_db = 'test'
-    os.environ['PIXELTABLE_DB'] = test_db
+    os.environ['PIXELTABLE_DB'] = f'test_{worker_id}'
     os.environ['PIXELTABLE_PGDATA'] = str(shared_home / 'pgdata')
 
-    # ensure this home dir exits
+    # Ensure the shared home directory exists.
     shared_home.mkdir(parents=True, exist_ok=True)
-    # this also runs create_all()
+
+    # Initialize Pixeltable. If using multiple workers, they need to be initialized synchronously to ensure we
+    # don't have several processes trying to initialize pgserver in parallel.
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    with FileLock(str(root_tmp_dir / 'pxt-init.lock')):
+        pxt.init()
+
     Env.get().configure_logging(level=logging.DEBUG, to_stdout=True)
-    # leave db in place for debugging purposes
 
 
 @pytest.fixture(scope='function')

--- a/tests/functions/test_fireworks.py
+++ b/tests/functions/test_fireworks.py
@@ -6,6 +6,7 @@ from ..utils import skip_test_if_not_installed, validate_update_status
 
 
 @pytest.mark.remote_api
+@pytest.mark.flaky(reruns=3, reruns_delay=8)
 class TestFireworks:
     def test_fireworks(self, reset_db) -> None:
         skip_test_if_not_installed('fireworks')

--- a/tests/io/test_hf_datasets.py
+++ b/tests/io/test_hf_datasets.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     sysconfig.get_platform() == 'linux-aarch64',
     reason='libsndfile.so is missing on Linux ARM instances in CI'
 )
+@pytest.mark.flaky(reruns=3, only_rerun='HfHubHTTPError')
 class TestHfDatasets:
     def test_import_hf_dataset(self, reset_db, tmp_path: pathlib.Path) -> None:
         skip_test_if_not_installed('datasets')

--- a/tests/io/test_label_studio.py
+++ b/tests/io/test_label_studio.py
@@ -84,6 +84,7 @@ class TestLabelStudio:
     </View>
     """
 
+    @pytest.mark.xdist_group('label_studio')
     def test_label_studio_project(self, ls_image_table: pxt.InsertableTable) -> None:
         skip_test_if_not_installed('label_studio_sdk')
         t = ls_image_table
@@ -135,6 +136,7 @@ class TestLabelStudio:
 
     # Run the basic sync test four ways: with 'post' and 'file' import methods, and with
     # a stored and non-stored media column, in all combinations.
+    @pytest.mark.xdist_group('label_studio')
     @pytest.mark.parametrize(
         'media_import_method,sync_col',
         [('post', 'image_col'), ('file', 'image_col'), ('url', 'image_col'),
@@ -152,6 +154,7 @@ class TestLabelStudio:
         self.__test_label_studio_sync(ls_image_table, self.test_config_image, media_import_method, sync_col, 'image')
 
     # TODO(aaron-siegel): 'file' is not working for videos or audio yet.
+    @pytest.mark.xdist_group('label_studio')
     @pytest.mark.parametrize('media_import_method', ['post', 'url'])
     def test_label_studio_sync_videos(
             self,
@@ -161,6 +164,7 @@ class TestLabelStudio:
         skip_test_if_not_installed('label_studio_sdk')
         self.__test_label_studio_sync(ls_video_table, self.test_config_video, media_import_method, 'video_col', 'video')
 
+    @pytest.mark.xdist_group('label_studio')
     @pytest.mark.parametrize('media_import_method', ['post', 'url'])
     def test_label_studio_sync_audio(
             self,
@@ -274,6 +278,7 @@ class TestLabelStudio:
     def __is_expected_url(cls, url: str) -> bool:
         return url.startswith('file://') or url.startswith('https://') or url.startswith('s3://')
 
+    @pytest.mark.xdist_group('label_studio')
     def test_label_studio_sync_preannotations(self, ls_image_table: pxt.InsertableTable) -> None:
         skip_test_if_not_installed('label_studio_sdk')
         skip_test_if_not_installed('transformers')
@@ -315,6 +320,7 @@ class TestLabelStudio:
         # 'person' should be present ('knife' sometimes is too, but it's nondeterministic)
         assert 'person' in found_labels
 
+    @pytest.mark.xdist_group('label_studio')
     def test_label_studio_sync_to_base_table(self, ls_image_table: pxt.InsertableTable) -> None:
         skip_test_if_not_installed('label_studio_sdk')
         from pixeltable.io.label_studio import LabelStudioProject
@@ -353,6 +359,7 @@ class TestLabelStudio:
         assert len(annotations) == 5
         assert all(annotations[i][0]['result'][0]['image_class'] == 'Dog' for i in range(5)), annotations
 
+    @pytest.mark.xdist_group('label_studio')
     def test_label_studio_sync_complex(self, ls_video_table: pxt.InsertableTable) -> None:
         # Test a more complex label studio project, with multiple images and other fields
         skip_test_if_not_installed('label_studio_sdk')
@@ -403,6 +410,7 @@ class TestLabelStudio:
         sync_status = v.sync()  # Should have no further effect
         validate_sync_status(sync_status, 0, 0, 0, 0, 0)
 
+    @pytest.mark.xdist_group('label_studio')
     def test_label_studio_sync_errors(self, ls_image_table: pxt.InsertableTable) -> None:
         skip_test_if_not_installed('label_studio_sdk')
         from pixeltable.io.label_studio import LabelStudioProject


### PR DESCRIPTION
Several improvements to our test infra:

1. `make test` now runs `mypy` and `mkdocs build --strict` in addition to `pytest`. It was too easy to forget to run these checks locally and then get burned in CI. To run pytest only, use `make pytest`.

2. Use `pytest-xdist` to parallelize test execution. `make test` now enables this by default. Tests in CI will still run on a single process. I've limited parallelism to 6 concurrent processes for now (above this, there seems to be no benefit, and the tests actually take longer due to increased initialization costs). The time to run `make pytest` is reduced by about 2/3, from ~326 seconds to ~112 seconds on my machine.

    You can ensure that a particular subset of tests runs on the same worker with (for example) `@pytest.mark.xdist_group('label_studio')`.

3. Use `pytest-rerunfailures` to allow flaky tests to rerun multiple times. Some tests depend on downloading data or models from remote servers, which can be unreliable; it's especially annoying when they fail in CI. Flaky tests can now be marked with:

    `@pytest.mark.flaky(reruns=3)`

    which will cause them to run `n` times before failing. To rerun only on specific exceptions, use (for example):

    `@pytest.mark.flaky(reruns=3, only_rerun='HfHubHTTPError')`