### PR TITLE
Code cleanup: Lowercase Dict/List/Set/Tuple/Type

### DIFF
--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Iterable, List, Optional, overload
+from typing import Any, Iterable, Optional, overload
 from uuid import UUID
 
 import sqlalchemy.orm as orm
@@ -36,7 +36,7 @@ class InsertableTable(Table):
     @classmethod
     def _create(
         cls, dir_id: UUID, name: str, schema: dict[str, ts.ColumnType], df: Optional[pxt.DataFrame],
-        primary_key: List[str], num_retained_versions: int, comment: str, media_validation: MediaValidation
+        primary_key: list[str], num_retained_versions: int, comment: str, media_validation: MediaValidation
     ) -> InsertableTable:
         columns = cls._create_columns(schema)
         cls._verify_schema(columns)
@@ -79,7 +79,7 @@ class InsertableTable(Table):
 
     @overload
     def insert(
-            self, rows: Iterable[Dict[str, Any]], /, *, print_stats: bool = False, fail_on_exception: bool = True
+            self, rows: Iterable[dict[str, Any]], /, *, print_stats: bool = False, fail_on_exception: bool = True
     ) -> UpdateStatus: ...
 
     @overload
@@ -121,7 +121,7 @@ class InsertableTable(Table):
         FileCache.get().emit_eviction_warnings()
         return status
 
-    def _validate_input_rows(self, rows: List[Dict[str, Any]]) -> None:
+    def _validate_input_rows(self, rows: list[dict[str, Any]]) -> None:
         """Verify that the input rows match the table schema"""
         valid_col_names = set(self._schema.keys())
         reqd_col_names = set(self._tbl_version_path.tbl_version.get_required_col_names())

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -6,7 +6,7 @@ import json
 import logging
 from pathlib import Path
 from typing import _GenericAlias  # type: ignore[attr-defined]
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, Optional, Set, Sequence, Tuple, Type, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, Optional, Sequence, Union, overload
 from uuid import UUID
 
 import pandas as pd
@@ -508,7 +508,7 @@ class Table(SchemaObject):
 
     @classmethod
     def _verify_column(
-            cls, col: Column, existing_column_names: Set[str], existing_query_names: Optional[Set[str]] = None
+            cls, col: Column, existing_column_names: set[str], existing_query_names: Optional[set[str]] = None
     ) -> None:
         """Check integrity of user-supplied Column and supply defaults"""
         if is_system_column_name(col.name):
@@ -529,7 +529,7 @@ class Table(SchemaObject):
     @classmethod
     def _verify_schema(cls, schema: list[Column]) -> None:
         """Check integrity of user-supplied schema and set defaults"""
-        column_names: Set[str] = set()
+        column_names: set[str] = set()
         for col in schema:
             cls._verify_column(col, column_names)
             column_names.add(col.name)
@@ -710,7 +710,7 @@ class Table(SchemaObject):
 
     def _drop_index(
             self, *, column_name: Optional[str] = None, idx_name: Optional[str] = None,
-            _idx_class: Optional[Type[index.IndexBase]] = None
+            _idx_class: Optional[type[index.IndexBase]] = None
     ) -> None:
         if self._tbl_version_path.is_snapshot():
             raise excs.Error('Cannot drop an index from a snapshot')
@@ -867,7 +867,7 @@ class Table(SchemaObject):
 
         # pseudo-column _rowid: contains the rowid of the row to update and can be used instead of the primary key
         has_rowid = _ROWID_COLUMN_NAME in rows[0]
-        rowids: list[Tuple[int, ...]] = []
+        rowids: list[tuple[int, ...]] = []
         if len(pk_col_names) == 0 and not has_rowid:
             raise excs.Error('Table must have primary key for batch update')
 

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -8,7 +8,7 @@ import logging
 import mimetypes
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, Iterator, List, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Hashable, Iterator, Optional, Sequence, Union
 
 import pandas as pd
 import pandas.io.formats.style
@@ -77,7 +77,7 @@ class DataFrameResultSet:
     def to_pandas(self) -> pd.DataFrame:
         return pd.DataFrame.from_records(self._rows, columns=self._col_names)
 
-    def _row_to_dict(self, row_idx: int) -> Dict[str, Any]:
+    def _row_to_dict(self, row_idx: int) -> dict[str, Any]:
         return {self._col_names[i]: self._rows[row_idx][i] for i in range(len(self._col_names))}
 
     def __getitem__(self, index: Any) -> Any:
@@ -111,22 +111,22 @@ class DataFrameResultSet:
 #     def __init__(self, tbl: catalog.TableVersion):
 #         self.tbl = tbl
 #         # output of the SQL scan stage
-#         self.sql_scan_output_exprs: List[exprs.Expr] = []
+#         self.sql_scan_output_exprs: list[exprs.Expr] = []
 #         # output of the agg stage
-#         self.agg_output_exprs: List[exprs.Expr] = []
+#         self.agg_output_exprs: list[exprs.Expr] = []
 #         # Where clause of the Select stmt of the SQL scan stage
 #         self.sql_where_clause: Optional[sql.ClauseElement] = None
 #         # filter predicate applied to input rows of the SQL scan stage
 #         self.filter: Optional[exprs.Predicate] = None
 #         self.similarity_clause: Optional[exprs.ImageSimilarityPredicate] = None
-#         self.agg_fn_calls: List[exprs.FunctionCall] = []  # derived from unique_exprs
+#         self.agg_fn_calls: list[exprs.FunctionCall] = []  # derived from unique_exprs
 #         self.has_frame_col: bool = False  # True if we're referencing the frame col
 #
 #         self.evaluator: Optional[exprs.Evaluator] = None
-#         self.sql_scan_eval_ctx: List[exprs.Expr] = []  # needed to materialize output of SQL scan stage
-#         self.agg_eval_ctx: List[exprs.Expr] = []  # needed to materialize output of agg stage
-#         self.filter_eval_ctx: List[exprs.Expr] = []
-#         self.group_by_eval_ctx: List[exprs.Expr] = []
+#         self.sql_scan_eval_ctx: list[exprs.Expr] = []  # needed to materialize output of SQL scan stage
+#         self.agg_eval_ctx: list[exprs.Expr] = []  # needed to materialize output of agg stage
+#         self.filter_eval_ctx: list[exprs.Expr] = []
+#         self.group_by_eval_ctx: list[exprs.Expr] = []
 #
 #     def finalize_exec(self) -> None:
 #         """
@@ -142,11 +142,11 @@ class DataFrame:
     def __init__(
         self,
         tbl: catalog.TableVersionPath,
-        select_list: Optional[List[Tuple[exprs.Expr, Optional[str]]]] = None,
+        select_list: Optional[list[tuple[exprs.Expr, Optional[str]]]] = None,
         where_clause: Optional[exprs.Expr] = None,
-        group_by_clause: Optional[List[exprs.Expr]] = None,
+        group_by_clause: Optional[list[exprs.Expr]] = None,
         grouping_tbl: Optional[catalog.TableVersion] = None,
-        order_by_clause: Optional[List[Tuple[exprs.Expr, bool]]] = None,  # List[(expr, asc)]
+        order_by_clause: Optional[list[tuple[exprs.Expr, bool]]] = None,  # list[(expr, asc)]
         limit: Optional[int] = None,
     ):
         self.tbl = tbl
@@ -174,7 +174,7 @@ class DataFrame:
     @classmethod
     def _select_list_check_rep(
         cls,
-        select_list: Optional[List[Tuple[exprs.Expr, Optional[str]]]],
+        select_list: Optional[list[tuple[exprs.Expr, Optional[str]]]],
     ) -> None:
         """Validate basic select list types."""
         if select_list is None:  # basic check for valid select list
@@ -411,8 +411,8 @@ class DataFrame:
 
     def _description(self) -> pd.DataFrame:
         """see DataFrame.describe()"""
-        heading_vals: List[str] = []
-        info_vals: List[str] = []
+        heading_vals: list[str] = []
+        info_vals: list[str] = []
         if self.select_list is not None:
             assert len(self.select_list) > 0
             heading_vals.append('Select')
@@ -497,7 +497,7 @@ class DataFrame:
 
         # check user provided names do not conflict among themselves
         # or with auto-generated ones
-        seen: Set[str] = set()
+        seen: set[str] = set()
         _, names = DataFrame._normalize_select_list(self.tbl, select_list)
         for name in names:
             if name in seen:
@@ -540,7 +540,7 @@ class DataFrame:
         if self.group_by_clause is not None:
             raise excs.Error(f'Group-by already specified')
         grouping_tbl: Optional[catalog.TableVersion] = None
-        group_by_clause: Optional[List[exprs.Expr]] = None
+        group_by_clause: Optional[list[exprs.Expr]] = None
         for item in grouping_items:
             if isinstance(item, catalog.Table):
                 if len(grouping_items) > 1:
@@ -618,7 +618,7 @@ class DataFrame:
     def __getitem__(self, index: Union[exprs.Expr, Sequence[exprs.Expr]]) -> DataFrame:
         """
         Allowed:
-        - [List[Expr]]/[Tuple[Expr]]: setting the select list
+        - [list[Expr]]/[tuple[Expr]]: setting the select list
         - [Expr]: setting a single-col select list
         """
         if isinstance(index, exprs.Expr):
@@ -627,7 +627,7 @@ class DataFrame:
             return self.select(*index)
         raise TypeError(f'Invalid index type: {type(index)}')
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         """
         Returns:
             Dictionary representing this dataframe.
@@ -649,7 +649,7 @@ class DataFrame:
         return d
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> 'DataFrame':
+    def from_dict(cls, d: dict[str, Any]) -> 'DataFrame':
         tbl = catalog.TableVersionPath.from_dict(d['tbl'])
         select_list = [(exprs.Expr.from_dict(e), name) for e, name in d['select_list']] \
             if d['select_list'] is not None else None

--- a/pixeltable/exec/data_row_batch.py
+++ b/pixeltable/exec/data_row_batch.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Iterator, Optional
+from typing import Iterator, Optional
 import logging
 
 import pixeltable.exprs as exprs
@@ -53,8 +53,8 @@ class DataRowBatch:
         return self.rows[index]
 
     def flush_imgs(
-            self, idx_range: Optional[slice] = None, stored_img_info: Optional[List[exprs.ColumnSlotIdx]] = None,
-            flushed_slot_idxs: Optional[List[int]] = None
+            self, idx_range: Optional[slice] = None, stored_img_info: Optional[list[exprs.ColumnSlotIdx]] = None,
+            flushed_slot_idxs: Optional[list[int]] = None
     ) -> None:
         """Flushes images in the given range of rows."""
         assert self.tbl is not None

--- a/pixeltable/exec/exec_context.py
+++ b/pixeltable/exec/exec_context.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional
 
 import sqlalchemy as sql
 
@@ -8,7 +8,7 @@ class ExecContext:
     """Class for execution runtime constants"""
     def __init__(
             self, row_builder: exprs.RowBuilder, *, show_pbar: bool = False, batch_size: int = 0,
-            pk_clause: Optional[List[sql.ClauseElement]] = None, num_computed_exprs: int = 0,
+            pk_clause: Optional[list[sql.ClauseElement]] = None, num_computed_exprs: int = 0,
             ignore_errors: bool = False
     ):
         self.show_pbar = show_pbar

--- a/pixeltable/exec/exec_node.py
+++ b/pixeltable/exec/exec_node.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, Iterable, Iterator, List, Optional
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional
 
 import pixeltable.exprs as exprs
 
@@ -43,7 +43,7 @@ class ExecNode(abc.ABC):
         if self.input is not None:
             self.input.set_ctx(ctx)
 
-    def set_stored_img_cols(self, stored_img_cols: List[exprs.ColumnSlotIdx]) -> None:
+    def set_stored_img_cols(self, stored_img_cols: list[exprs.ColumnSlotIdx]) -> None:
         self.stored_img_cols = stored_img_cols
         # propagate batch size to the source
         if self.input is not None:

--- a/pixeltable/func/aggregate_function.py
+++ b/pixeltable/func/aggregate_function.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import pixeltable.exceptions as excs
 import pixeltable.type_system as ts
@@ -36,8 +36,8 @@ class AggregateFunction(Function):
     RESERVED_PARAMS = {ORDER_BY_PARAM, GROUP_BY_PARAM}
 
     def __init__(
-            self, aggregator_class: Type[Aggregator], self_path: str,
-            init_types: List[ts.ColumnType], update_types: List[ts.ColumnType], value_type: ts.ColumnType,
+            self, aggregator_class: type[Aggregator], self_path: str,
+            init_types: list[ts.ColumnType], update_types: list[ts.ColumnType], value_type: ts.ColumnType,
             requires_order_by: bool, allows_std_agg: bool, allows_window: bool):
         self.agg_cls = aggregator_class
         self.requires_order_by = requires_order_by
@@ -128,7 +128,7 @@ class AggregateFunction(Function):
             order_by_clause=[order_by_clause] if order_by_clause is not None else [],
             group_by_clause=[group_by_clause] if group_by_clause is not None else [])
 
-    def validate_call(self, bound_args: Dict[str, Any]) -> None:
+    def validate_call(self, bound_args: dict[str, Any]) -> None:
         # check that init parameters are not Exprs
         # TODO: do this in the planner (check that init parameters are either constants or only refer to grouping exprs)
         import pixeltable.exprs as exprs
@@ -146,10 +146,10 @@ class AggregateFunction(Function):
 def uda(
         *,
         value_type: ts.ColumnType,
-        update_types: List[ts.ColumnType],
-        init_types: Optional[List[ts.ColumnType]] = None,
+        update_types: list[ts.ColumnType],
+        init_types: Optional[list[ts.ColumnType]] = None,
         requires_order_by: bool = False, allows_std_agg: bool = True, allows_window: bool = False,
-) -> Callable[[Type[Aggregator]], AggregateFunction]:
+) -> Callable[[type[Aggregator]], AggregateFunction]:
     """Decorator for user-defined aggregate functions.
 
     The decorated class must inherit from Aggregator and implement the following methods:
@@ -171,7 +171,7 @@ def uda(
     if init_types is None:
         init_types = []
 
-    def decorator(cls: Type[Aggregator]) -> AggregateFunction:
+    def decorator(cls: type[Aggregator]) -> AggregateFunction:
         # validate type parameters
         num_init_params = len(inspect.signature(cls.__init__).parameters) - 1
         if num_init_params > 0:

--- a/pixeltable/func/expr_template_function.py
+++ b/pixeltable/func/expr_template_function.py
@@ -1,10 +1,11 @@
 import inspect
-from typing import Dict, Optional, Any
+from typing import Any, Optional
 
 import pixeltable
 import pixeltable.exceptions as excs
+
 from .function import Function
-from .signature import Signature, Parameter
+from .signature import Signature
 
 
 class ExprTemplateFunction(Function):
@@ -22,7 +23,7 @@ class ExprTemplateFunction(Function):
         self.param_exprs_by_name = {p.name: p for p in self.param_exprs}
 
         # verify default values
-        self.defaults: Dict[str, exprs.Literal] = {}  # key: param name, value: default value converted to a Literal
+        self.defaults: dict[str, exprs.Literal] = {}  # key: param name, value: default value converted to a Literal
         for param in signature.parameters.values():
             if param.default is inspect.Parameter.empty:
                 continue
@@ -77,7 +78,7 @@ class ExprTemplateFunction(Function):
     def name(self) -> str:
         return self.self_name
 
-    def _as_dict(self) -> Dict:
+    def _as_dict(self) -> dict:
         if self.self_path is not None:
             return super()._as_dict()
         return {
@@ -87,7 +88,7 @@ class ExprTemplateFunction(Function):
         }
 
     @classmethod
-    def _from_dict(cls, d: Dict) -> Function:
+    def _from_dict(cls, d: dict) -> Function:
         if 'expr' not in d:
             return super()._from_dict(d)
         assert 'signature' in d and 'name' in d

--- a/pixeltable/func/udf.py
+++ b/pixeltable/func/udf.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import List, Callable, Optional, overload, Any
+from typing import Any, Callable, Optional, overload
 
 import pixeltable.exceptions as excs
 import pixeltable.type_system as ts
+
 from .callable_function import CallableFunction
 from .expr_template_function import ExprTemplateFunction
 from .function import Function
@@ -22,7 +23,7 @@ def udf(decorated_fn: Callable) -> Function: ...
 def udf(
         *,
         return_type: Optional[ts.ColumnType] = None,
-        param_types: Optional[List[ts.ColumnType]] = None,
+        param_types: Optional[list[ts.ColumnType]] = None,
         batch_size: Optional[int] = None,
         substitute_fn: Optional[Callable] = None,
         is_method: bool = False,
@@ -79,7 +80,7 @@ def udf(*args, **kwargs):
 def make_function(
     decorated_fn: Callable,
     return_type: Optional[ts.ColumnType] = None,
-    param_types: Optional[List[ts.ColumnType]] = None,
+    param_types: Optional[list[ts.ColumnType]] = None,
     batch_size: Optional[int] = None,
     substitute_fn: Optional[Callable] = None,
     is_method: bool = False,
@@ -158,10 +159,10 @@ def make_function(
 def expr_udf(py_fn: Callable) -> ExprTemplateFunction: ...
 
 @overload
-def expr_udf(*, param_types: Optional[List[ts.ColumnType]] = None) -> Callable[[Callable], ExprTemplateFunction]: ...
+def expr_udf(*, param_types: Optional[list[ts.ColumnType]] = None) -> Callable[[Callable], ExprTemplateFunction]: ...
 
 def expr_udf(*args: Any, **kwargs: Any) -> Any:
-    def make_expr_template(py_fn: Callable, param_types: Optional[List[ts.ColumnType]]) -> ExprTemplateFunction:
+    def make_expr_template(py_fn: Callable, param_types: Optional[list[ts.ColumnType]]) -> ExprTemplateFunction:
         if py_fn.__module__ != '__main__' and py_fn.__name__.isidentifier():
             # this is a named function in a module
             function_path = f'{py_fn.__module__}.{py_fn.__qualname__}'

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional, Sequence, cast
+from typing import Any, Iterable, Optional, Sequence
 from uuid import UUID
 
 import sqlalchemy as sql

--- a/pixeltable/utils/coco.py
+++ b/pixeltable/utils/coco.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any
 
 import PIL
 
@@ -22,7 +22,7 @@ Required format:
 }
 """
 
-def _verify_input_dict(input_dict: Dict[str, Any]) -> None:
+def _verify_input_dict(input_dict: dict[str, Any]) -> None:
     """Verify that input_dict is a valid input dict for write_coco_dataset()"""
     if not isinstance(input_dict, dict):
         raise excs.Error(f'Expected dict, got {input_dict}{format_msg}')
@@ -61,11 +61,11 @@ def write_coco_dataset(df: pxt.DataFrame, dest_path: Path) -> Path:
     images_dir = dest_path / 'images'
     images_dir.mkdir()
 
-    images: List[Dict[str, Any]] = []
+    images: list[dict[str, Any]] = []
     img_id = -1
-    annotations: List[Dict[str, Any]] = []
+    annotations: list[dict[str, Any]] = []
     ann_id = -1
-    categories: Set[Any] = set()
+    categories: set[Any] = set()
     for input_row in df._exec():
         if input_dict_slot_idx == -1:
             input_dict_expr = df._select_list_exprs[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import pathlib
-from typing import List
 
 import pytest
 from filelock import FileLock
@@ -88,7 +87,7 @@ def test_tbl(reset_db) -> catalog.Table:
     return create_test_tbl()
 
 @pytest.fixture(scope='function')
-def test_tbl_exprs(test_tbl: catalog.Table) -> List[exprs.Expr]:
+def test_tbl_exprs(test_tbl: catalog.Table) -> list[exprs.Expr]:
     t = test_tbl
     return [
         t.c1,
@@ -132,7 +131,7 @@ def img_tbl(reset_db) -> catalog.Table:
     return create_img_tbl('test_img_tbl')
 
 @pytest.fixture(scope='function')
-def img_tbl_exprs(indexed_img_tbl: catalog.Table) -> List[exprs.Expr]:
+def img_tbl_exprs(indexed_img_tbl: catalog.Table) -> list[exprs.Expr]:
     t = indexed_img_tbl
     return [
         t.img.width,

--- a/tests/test_component_view.py
+++ b/tests/test_component_view.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -23,14 +23,14 @@ class ConstantImgIterator(ComponentIterator):
         self.pos_frame = 0.0
 
     @classmethod
-    def input_schema(cls) -> Dict[str, pxt.ColumnType]:
+    def input_schema(cls) -> dict[str, pxt.ColumnType]:
         return {
             'video': pxt.VideoType(nullable=False),
             'fps': pxt.FloatType()
         }
 
     @classmethod
-    def output_schema(cls, *args: Any, **kwargs: Any) -> Tuple[Dict[str, pxt.ColumnType], List[str]]:
+    def output_schema(cls, *args: Any, **kwargs: Any) -> tuple[dict[str, pxt.ColumnType], list[str]]:
         return {
             'frame_idx': pxt.IntType(),
             'pos_msec': pxt.FloatType(),
@@ -38,7 +38,7 @@ class ConstantImgIterator(ComponentIterator):
             'frame': pxt.ImageType(),
         }, ['frame']
 
-    def __next__(self) -> Dict[str, Any]:
+    def __next__(self) -> dict[str, Any]:
         while True:
             if self.next_frame_idx == self.num_frames:
                 raise StopIteration


### PR DESCRIPTION
We've been systematically lowercasing type references in accordance with Python 3.9+ conventions. There are only a few such cases remaining in the repo; we might as well clean them up now (and reduce the risk of related future merge conflicts).