### PR TITLE
PXT-334 - Add columns property to the table handle

### DIFF
--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -125,7 +125,7 @@ class Table(SchemaObject):
     def __getattr__(self, name: str) -> 'pxt.exprs.ColumnRef':
         """Return a ColumnRef for the given name.
         """
-        return getattr(self._tbl_version_path, name)
+        return self._tbl_version_path.get_column_ref(name)
 
     @overload
     def __getitem__(self, name: str) -> 'pxt.exprs.ColumnRef': ...

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -218,6 +218,12 @@ class Table(SchemaObject):
         return self._df().count()
 
     @property
+    def columns(self) -> list[str]:
+        """Return the names of the columns in this table. """
+        cols = self._tbl_version_path.columns()
+        return [c.name for c in cols]
+
+    @property
     def _schema(self) -> dict[str, ts.ColumnType]:
         """Return the schema (column names and column types) of this table."""
         return {c.name: c.col_type for c in self._tbl_version_path.columns()}

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -81,13 +81,13 @@ class TableVersionPath:
             return None
         return self.base.find_tbl_version(id)
 
-    def __getattr__(self, col_name: str) -> exprs.ColumnRef:
+    def get_column_ref(self, col_name: str) -> exprs.ColumnRef:
         """Return a ColumnRef for the given column name."""
         from pixeltable.exprs import ColumnRef
         if col_name not in self.tbl_version.cols_by_name:
             if self.base is None:
                 raise AttributeError(f'Column {col_name} unknown')
-            return getattr(self.base, col_name)
+            return self.base.get_column_ref(col_name)
         col = self.tbl_version.cols_by_name[col_name]
         return ColumnRef(col)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -115,7 +115,6 @@ class TestTable:
         assert "'insert' is a reserved name in pixeltable" in str(exc_info.value).lower()
 
     def test_columns(self, reset_db) -> None:  # noqa: PLR6301
-        pxt.create_dir('dir1')
         schema = {
             'c1': pxt.String,
             'c2': pxt.Int,
@@ -123,8 +122,7 @@ class TestTable:
             'c4': pxt.Timestamp,
         }
         t = pxt.create_table('test', schema)
-        colList = t.columns
-        assert colList == ['c1', 'c2', 'c3', 'c4']
+        assert t.columns == ['c1', 'c2', 'c3', 'c4']
 
     def test_names(self, reset_db) -> None:
         pxt.create_dir('dir')
@@ -1146,7 +1144,7 @@ class TestTable:
 
         # test loading from store
         reload_catalog()
-		# RESOLVE: comparing t == t? should this be t'?
+        # RESOLVE: comparing t == t? should we be using a different handle t' here?
         t = pxt.get_table('test')
         assert len(t._tbl_version_path.columns()) == len(t.columns)
         for i in range(len(t._tbl_version_path.columns())):
@@ -1248,9 +1246,10 @@ class TestTable:
         reload_catalog()
         t2 = pxt.get_table(t._name)
         assert len(t.columns) == len(t2.columns)
-        for i in range(len(t.columns)):
-            if t.columns[i] is not None:
-                assert t.columns[i] == t2.columns[i]
+        assert len(t._tbl_version_path.columns()) == len(t2._tbl_version_path.columns())
+        for i in range(len(t._tbl_version_path.columns())):
+            if t._tbl_version_path.columns()[i].value_expr is not None:
+                assert t._tbl_version_path.columns()[i].value_expr.equals(t2._tbl_version_path.columns()[i].value_expr)
 
         # make sure we can still insert data and that computed cols are still set correctly
         t2.insert(rows)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1145,11 +1145,13 @@ class TestTable:
         # test loading from store
         reload_catalog()
         t2 = pxt.get_table('test')
-        assert len(t2._tbl_version_path.columns()) == len(t2.columns)
-        assert len(t._tbl_version_path.columns()) == len(t2._tbl_version_path.columns())
-        for i in range(len(t._tbl_version_path.columns())):
-            if t._tbl_version_path.columns()[i].value_expr is not None:
-                assert t._tbl_version_path.columns()[i].value_expr.equals(t2._tbl_version_path.columns()[i].value_expr)
+        t2_columns = t2._tbl_version_path.columns()
+        assert len(t2_columns) == len(t2.columns)
+        t_columns = t._tbl_version_path.columns()
+        assert len(t_columns) == len(t2_columns)
+        for i in range(len(t_columns)):
+            if t_columns[i].value_expr is not None:
+                assert t_columns[i].value_expr.equals(t2_columns[i].value_expr)
 
         # make sure we can still insert data and that computed cols are still set correctly
         status = t.insert(rows)
@@ -1246,10 +1248,12 @@ class TestTable:
         reload_catalog()
         t2 = pxt.get_table(t._name)
         assert len(t.columns) == len(t2.columns)
-        assert len(t._tbl_version_path.columns()) == len(t2._tbl_version_path.columns())
-        for i in range(len(t._tbl_version_path.columns())):
-            if t._tbl_version_path.columns()[i].value_expr is not None:
-                assert t._tbl_version_path.columns()[i].value_expr.equals(t2._tbl_version_path.columns()[i].value_expr)
+        t_columns = t._tbl_version_path.columns()
+        t2_columns = t2._tbl_version_path.columns()
+        assert len(t_columns) == len(t2_columns)
+        for i in range(len(t_columns)):
+            if t_columns[i].value_expr is not None:
+                assert t_columns[i].value_expr.equals(t2_columns[i].value_expr)
 
         # make sure we can still insert data and that computed cols are still set correctly
         t2.insert(rows)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1144,12 +1144,12 @@ class TestTable:
 
         # test loading from store
         reload_catalog()
-        # RESOLVE: comparing t == t? should we be using a different handle t' here?
-        t = pxt.get_table('test')
-        assert len(t._tbl_version_path.columns()) == len(t.columns)
+        t2 = pxt.get_table('test')
+        assert len(t2._tbl_version_path.columns()) == len(t2.columns)
+        assert len(t._tbl_version_path.columns()) == len(t2._tbl_version_path.columns())
         for i in range(len(t._tbl_version_path.columns())):
             if t._tbl_version_path.columns()[i].value_expr is not None:
-                assert t._tbl_version_path.columns()[i].value_expr.equals(t._tbl_version_path.columns()[i].value_expr)
+                assert t._tbl_version_path.columns()[i].value_expr.equals(t2._tbl_version_path.columns()[i].value_expr)
 
         # make sure we can still insert data and that computed cols are still set correctly
         status = t.insert(rows)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -114,6 +114,18 @@ class TestTable:
             _ = pxt.create_table('test', {'insert': pxt.Int})
         assert "'insert' is a reserved name in pixeltable" in str(exc_info.value).lower()
 
+    def test_columns(self, reset_db) -> None:  # noqa: PLR6301
+        pxt.create_dir('dir1')
+        schema = {
+            'c1': pxt.String,
+            'c2': pxt.Int,
+            'c3': pxt.Float,
+            'c4': pxt.Timestamp,
+        }
+        t = pxt.create_table('test', schema)
+        colList = t.columns
+        assert colList == ['c1', 'c2', 'c3', 'c4']
+
     def test_names(self, reset_db) -> None:
         pxt.create_dir('dir')
         pxt.create_dir('dir.subdir')
@@ -1134,11 +1146,12 @@ class TestTable:
 
         # test loading from store
         reload_catalog()
+		# RESOLVE: comparing t == t? should this be t'?
         t = pxt.get_table('test')
-        assert len(t.columns()) == len(t.columns())
-        for i in range(len(t.columns())):
-            if t.columns()[i].value_expr is not None:
-                assert t.columns()[i].value_expr.equals(t.columns()[i].value_expr)
+        assert len(t._tbl_version_path.columns()) == len(t.columns)
+        for i in range(len(t._tbl_version_path.columns())):
+            if t._tbl_version_path.columns()[i].value_expr is not None:
+                assert t._tbl_version_path.columns()[i].value_expr.equals(t._tbl_version_path.columns()[i].value_expr)
 
         # make sure we can still insert data and that computed cols are still set correctly
         status = t.insert(rows)
@@ -1234,10 +1247,10 @@ class TestTable:
         # test loading from store
         reload_catalog()
         t2 = pxt.get_table(t._name)
-        assert len(t.columns()) == len(t2.columns())
-        for i in range(len(t.columns())):
-            if t.columns()[i].value_expr is not None:
-                assert t.columns()[i].value_expr.equals(t2.columns()[i].value_expr)
+        assert len(t.columns) == len(t2.columns)
+        for i in range(len(t.columns)):
+            if t.columns[i] is not None:
+                assert t.columns[i] == t2.columns[i]
 
         # make sure we can still insert data and that computed cols are still set correctly
         t2.insert(rows)
@@ -1315,12 +1328,12 @@ class TestTable:
 
     def test_add_column(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
-        num_orig_cols = len(t.columns())
+        num_orig_cols = len(t.columns)
         t.add_column(add1=pxt.Int)
         # Make sure that `name` and `id` are allowed, i.e., not reserved as system names
         t.add_column(name=pxt.String)
         t.add_column(id=pxt.String)
-        assert len(t.columns()) == num_orig_cols + 3
+        assert len(t.columns) == num_orig_cols + 3
 
         with pytest.raises(excs.Error) as exc_info:
             _ = t.add_column(add2=pxt.Required[pxt.Int])
@@ -1370,26 +1383,26 @@ class TestTable:
         # make sure this is still true after reloading the metadata
         reload_catalog()
         t = pxt.get_table(t._name)
-        assert len(t.columns()) == num_orig_cols + 3
+        assert len(t.columns) == num_orig_cols + 3
 
         # revert() works
         t.revert()
         t.revert()
         t.revert()
-        assert len(t.columns()) == num_orig_cols
+        assert len(t.columns) == num_orig_cols
 
         # make sure this is still true after reloading the metadata once more
         reload_catalog()
         t = pxt.get_table(t._name)
-        assert len(t.columns()) == num_orig_cols
+        assert len(t.columns) == num_orig_cols
 
     def test_add_column_setitem(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
-        num_orig_cols = len(t.columns())
+        num_orig_cols = len(t.columns)
         t['add1'] = pxt.Int
-        assert len(t.columns()) == num_orig_cols + 1
+        assert len(t.columns) == num_orig_cols + 1
         t['computed1'] = t.c2 + 1
-        assert len(t.columns()) == num_orig_cols + 2
+        assert len(t.columns) == num_orig_cols + 2
 
         with pytest.raises(excs.Error) as exc_info:
             _ = t['pos'] = pxt.String
@@ -1419,23 +1432,23 @@ class TestTable:
         # make sure this is still true after reloading the metadata
         reload_catalog()
         t = pxt.get_table(t._name)
-        assert len(t.columns()) == num_orig_cols + 2
+        assert len(t.columns) == num_orig_cols + 2
 
         # revert() works
         t.revert()
         t.revert()
-        assert len(t.columns()) == num_orig_cols
+        assert len(t.columns) == num_orig_cols
 
         # make sure this is still true after reloading the metadata once more
         reload_catalog()
         t = pxt.get_table(t._name)
-        assert len(t.columns()) == num_orig_cols
+        assert len(t.columns) == num_orig_cols
 
     def test_drop_column(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
-        num_orig_cols = len(t.columns())
+        num_orig_cols = len(t.columns)
         t.drop_column('c1')
-        assert len(t.columns()) == num_orig_cols - 1
+        assert len(t.columns) == num_orig_cols - 1
 
         with pytest.raises(excs.Error):
             t.drop_column('unknown')
@@ -1443,22 +1456,22 @@ class TestTable:
         # make sure this is still true after reloading the metadata
         reload_catalog()
         t = pxt.get_table(t._name)
-        assert len(t.columns()) == num_orig_cols - 1
+        assert len(t.columns) == num_orig_cols - 1
 
         # revert() works
         t.revert()
-        assert len(t.columns()) == num_orig_cols
+        assert len(t.columns) == num_orig_cols
 
         # make sure this is still true after reloading the metadata once more
         reload_catalog()
         t = pxt.get_table(t._name)
-        assert len(t.columns()) == num_orig_cols
+        assert len(t.columns) == num_orig_cols
 
     def test_rename_column(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
-        num_orig_cols = len(t.columns())
+        num_orig_cols = len(t.columns)
         t.rename_column('c1', 'c1_renamed')
-        assert len(t.columns()) == num_orig_cols
+        assert len(t.columns) == num_orig_cols
 
         def check_rename(t: pxt.Table, known: str, unknown: str) -> None:
             with pytest.raises(AttributeError) as exc_info:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,13 +91,6 @@ def create_table_data(
         ]
     }
 
-	# RESOLVE: At present we are passing catalog.Table as param t to this function
-	# from tests. It is done the handle returned by pxt.create_table() API.
-	# Yet, we called t.columns() here. AFAICT, the columns() API is only available
-	# for catalog.TableVersionPath and that API returns list[Column] (and not list
-	# of column name string). This is needed for the is_computed check - although
-	# the test callers for this function do not seem to be using computed columns.
-	# Making the API explicit here. But need to understand how this worked.
     if len(col_names) == 0:
         col_names = [c.name for c in t._tbl_version_path.columns() if not c.is_computed]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,8 +91,15 @@ def create_table_data(
         ]
     }
 
+	# RESOLVE: At present we are passing catalog.Table as param t to this function
+	# from tests. It is done the handle returned by pxt.create_table() API.
+	# Yet, we called t.columns() here. AFAICT, the columns() API is only available
+	# for catalog.TableVersionPath and that API returns list[Column] (and not list
+	# of column name string). This is needed for the is_computed check - although
+	# the test callers for this function do not seem to be using computed columns.
+	# Making the API explicit here. But need to understand how this worked.
     if len(col_names) == 0:
-        col_names = [c.name for c in t.columns() if not c.is_computed]
+        col_names = [c.name for c in t._tbl_version_path.columns() if not c.is_computed]
 
     col_types = t._schema
     for col_name in col_names:


### PR DESCRIPTION
This commit adds a columns property to the catalog.Table class. 
This is for user convenience to fetch the list of columns for a table.

Testing: 
new basic unit test added that verifies t.columns returns what we expect.
Also had to adjust other existing test code that was using t.columns() API.
