### PR TITLE
Add tests and a tutorial notebook for Ollama

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -115,6 +115,9 @@ jobs:
         # Needed for WhisperX
         if: ${{ matrix.poetry-options != '' }}
         run: conda install -c conda-forge libiconv ffmpeg
+      - name: Install ollama
+        if: ${{ matrix.poetry-options != '' && matrix.os == 'ubuntu-22.04' }}
+        run: curl -fsSL https://ollama.com/install.sh | sh
       - name: Install poetry
         # setuptools >= 69.2 has been causing problems with github actions even when its
         # version is enforced in poetry. For now, explicitly revert to setuptools 69.1.1

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ KERNEL_NAME := $(shell basename `pwd`)
 help:
 	@echo "Usage: make <target>"
 	@echo "You must be in a conda environment to install the Pixeltable dev environment."
-	@echo "See: https://www.notion.so/Setting-up-a-dev-environment-83a1ca32de034f94bd7fee0ddb46fed8"
+	@echo "See: https://github.com/pixeltable/pixeltable/blob/main/CONTRIBUTING.md"
 	@echo ""
 	@echo "Targets:"
 	@echo "  install       Install the development environment"

--- a/docs/release/tutorials/working-with-ollama.ipynb
+++ b/docs/release/tutorials/working-with-ollama.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "983yjns496tx"
+   },
+   "source": [
+    "[![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/pixeltable/pixeltable/blob/release/docs/release/tutorials/working-with-ollama.ipynb)&nbsp;&nbsp;\n",
+    "[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/release/tutorials/working-with-ollama.ipynb)&nbsp;&nbsp;\n",
+    "<a href=\"https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/release/tutorials/working-with-ollama.ipynb\" download><img src=\"https://img.shields.io/badge/%E2%AC%87-Download%20Notebook-blue\" alt=\"Download Notebook\"></a>\n",
+    "\n",
+    "# Working with Ollama in Pixeltable\n",
+    "\n",
+    "Ollama is a popular platform for local serving of LLMs. In this tutorial, we'll show how to integrate Ollama models into a Pixeltable workflow.\n",
+    "\n",
+    "## Install Ollama\n",
+    "\n",
+    "You'll need to have an Ollama server instance to query. There are several ways to do this.\n",
+    "\n",
+    "### Running on a Local Machine\n",
+    "\n",
+    "- If you're running this notebook on your own machine, running Windows, Mac OS, or Linux, you can install Ollama at: <https://ollama.com/download>\n",
+    "\n",
+    "### Running on Google Colab\n",
+    "\n",
+    "- OR, if you're running on Colab, you can install Ollama by uncommenting and running the following code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To install Ollama on colab, uncomment and run the following\n",
+    "# three lines (this will also work on a local Linux machine\n",
+    "# if you don't already have Ollama installed).\n",
+    "\n",
+    "# !curl -fsSL https://ollama.com/install.sh | sh\n",
+    "# import subprocess\n",
+    "# ollama_process = subprocess.Popen(['ollama', 'serve'], stderr=subprocess.PIPE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running on a remote Ollama server\n",
+    "\n",
+    "- OR, if you have access to an Ollama server running remotely, you can uncomment and run the following line, replacing the default URL with the URL of your remote Ollama instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To run the notebook against an instance of Ollama running on a\n",
+    "# remote server, uncomment the following line and specify the URL.\n",
+    "\n",
+    "# os.environs['OLLAMA_HOST'] = 'https://127.0.0.1:11434'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once you've completed the installation, run the following commands to verify that it's been successfully installed. This may result in an LLM being downloaded, so it may take some time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU ollama"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"The capital city of Missouri is Jefferson City. It's located in the central part of the state and serves as the administrative center for the Midwestern U.S. territory of Missouri. The state is known for its rich history, particularly regarding the Missouri River, which runs through its central parts and provides access to major cities along the border with Illinois.\""
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import ollama\n",
+    "\n",
+    "ollama.pull('qwen2.5:0.5b')\n",
+    "ollama.generate('qwen2.5:0.5b', 'What is the capital of Missouri?')['response']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install Pixeltable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's install Pixeltable and create a table for the demo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9pckrD01ik-e",
+    "outputId": "060b8b32-48a6-48a0-e720-4eacf94d83ef"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install -qU pixeltable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "5ti10tXu5m3X",
+    "outputId": "30848066-1e9b-4efd-aad7-b2271a031ec3"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to Pixeltable database at: postgresql+psycopg://postgres:@/pixeltable?host=/Users/asiegel/.pixeltable/pgdata\n",
+      "Created directory `ollama_demo`.\n",
+      "Created table `chat`.\n",
+      "Added 0 column values with 0 errors.\n",
+      "Added 0 column values with 0 errors.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pixeltable as pxt\n",
+    "from pixeltable.functions.ollama import chat\n",
+    "\n",
+    "pxt.drop_dir('ollama_demo', force=True)\n",
+    "pxt.create_dir('ollama_demo')\n",
+    "t = pxt.create_table('ollama_demo.chat', {'input': pxt.String})\n",
+    "\n",
+    "messages = [{'role': 'user', 'content': t.input}]\n",
+    "\n",
+    "t['output'] = chat(\n",
+    "    messages=messages,\n",
+    "    model='qwen2.5:0.5b',\n",
+    "    # These parameters are optional and can be used to tune model behavior:\n",
+    "    options={'max_tokens': 300, 'top_p': 0.9, 'temperature': 0.5},\n",
+    ")\n",
+    "\n",
+    "# Extract the response content into a separate column\n",
+    "\n",
+    "t['response'] = t.output.message.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can insert our input prompts into the table now. As always, Pixeltable automatically updates the computed columns by calling the relevant Ollama endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 599
+    },
+    "id": "IkMM7OYb5rQ_",
+    "outputId": "8e94af3e-485c-49f2-d7ba-b5490ec83af9"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing cells: 100%|████████████████████████████████████████████| 3/3 [00:02<00:00,  1.18 cells/s]\n",
+      "Inserting rows into `chat`: 1 rows [00:00, 75.39 rows/s]\n",
+      "Computing cells: 100%|████████████████████████████████████████████| 3/3 [00:02<00:00,  1.17 cells/s]\n",
+      "Inserted 1 row with 0 errors.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>input</th>\n",
+       "      <th>response</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>What are the most popular services for LLM inference?</td>\n",
+       "      <td>LLM (Large Language Model) inference is a complex process that involves generating human-like text using artificial intelligence models. The most popular services and technologies used in this field include:\n",
+       "\n",
+       "1. **Hugging Face**: Hugging Face, an open-source platform, provides several APIs and libraries for building LLMs. Some of the most commonly used ones are:\n",
+       "   - `transformers` (for natural language processing)\n",
+       "   - `torchtext` (for text generation)\n",
+       "   - `t5` (for T5 models)\n",
+       "   - `pytorc ......  based on user input.\n",
+       "\n",
+       "These services are popular because they provide flexibility, speed, and ease of use for developers who want to work with large language models. The choice of service depends on the specific requirements of your project, including the type of data you&#x27;re working with, the level of customization you need, and whether you prefer a more lightweight or more powerful solution.\n",
+       "\n",
+       "If you have any questions about these services or if you need help choosing one, feel free to ask!</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "                                               input  \\\n",
+       "0  What are the most popular services for LLM inf...   \n",
+       "\n",
+       "                                            response  \n",
+       "0  LLM (Large Language Model) inference is a comp...  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Start a conversation\n",
+    "t.insert(input='What are the most popular services for LLM inference?')\n",
+    "t.select(t.input, t.response).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lTtQcjKQAlis"
+   },
+   "source": [
+    "### Learn More\n",
+    "\n",
+    "To learn more about advanced techniques like RAG operations in Pixeltable, check out the [RAG Operations in Pixeltable](https://pixeltable.readme.io/docs/rag-operations-in-pixeltable) tutorial.\n",
+    "\n",
+    "If you have any questions, don't hesitate to reach out."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.20"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/functions/test_ollama.py
+++ b/tests/functions/test_ollama.py
@@ -1,0 +1,82 @@
+from typing import Optional
+
+import numpy as np
+import pytest
+
+import pixeltable as pxt
+from tests.utils import skip_test_if_not_installed, validate_update_status
+
+
+class TestOllama:
+
+    @pytest.mark.xdist_group('ollama')
+    def test_generate(self, reset_db):
+        self.__ensure_ollama_availability()
+        from pixeltable.functions.ollama import generate
+
+        t = pxt.create_table('test_tbl', {'input': pxt.String})
+
+        # msgs = [{'role': 'user', 'content': t.input}]
+        t['output'] = generate(t.input, model='qwen2.5:0.5b')
+        t['output2'] = generate(
+            t.input,
+            model='qwen2.5:0.5b',
+            options={'temperature': 1.0, 'max_tokens': 300, 'top_p': 0.9, 'top_k': 40},
+        )
+        validate_update_status(t.insert(input='The average July rainfall in Topeka is '))
+        results = t.collect()
+        assert len(results['output'][0]['response']) > 0
+        assert len(results['output2'][0]['response']) > 0
+
+    @pytest.mark.xdist_group('ollama')
+    def test_chat(self, reset_db):
+        self.__ensure_ollama_availability()
+        from pixeltable.functions.ollama import chat
+
+        t = pxt.create_table('test_tbl', {'input': pxt.String})
+
+        msgs = [
+            {'role': 'system', 'content': 'You are a helpful assistant.'},
+            {'role': 'user', 'content': t.input}
+        ]
+
+        t['output'] = chat(msgs, model='qwen2.5:0.5b')
+        t['output2'] = chat(
+            msgs,
+            model='qwen2.5:0.5b',
+            options={'temperature': 1.0, 'max_tokens': 300, 'top_p': 0.9, 'top_k': 40},
+        )
+        validate_update_status(t.insert(input='What are the spiciest varieties of peppers?'))
+        results = t.collect()
+        assert len(results['output'][0]['message']['content']) > 0
+        assert len(results['output2'][0]['message']['content']) > 0
+
+    @pytest.mark.xdist_group('ollama')
+    def test_embed(self, reset_db):
+        self.__ensure_ollama_availability()
+        from pixeltable.functions.ollama import embed
+
+        t = pxt.create_table('test_tbl', {'input': pxt.String})
+
+        t['output'] = embed(t.input, model='qwen2.5:0.5b')
+        validate_update_status(t.insert(input='I am a purple cloud.'))
+        results = t.collect()
+        assert isinstance(results['output'][0], np.ndarray)
+        assert len(results['output'][0]) == 896
+
+    def __ensure_ollama_availability(self):
+        skip_test_if_not_installed('ollama')
+        if self.__ollama_available is None:
+            import ollama
+            try:
+                ollama.pull('qwen2.5:0.5b')
+                ollama.generate(model='qwen2.5:0.5b', prompt='Are you properly configured?')
+                self.__ollama_available = True
+            except Exception as exc:
+                self.__ollama_available = False
+                self.__ollama_exception = exc
+        if not self.__ollama_available:
+            pytest.skip(f'ollama not available: {self.__ollama_exception}')
+
+    __ollama_available: Optional[bool] = None
+    __ollama_exception: Optional[Exception] = None

--- a/tests/io/test_fiftyone.py
+++ b/tests/io/test_fiftyone.py
@@ -1,3 +1,4 @@
+import sysconfig
 import pytest
 
 import pixeltable as pxt
@@ -6,6 +7,7 @@ import pixeltable.exceptions as excs
 from ..utils import get_image_files, skip_test_if_not_installed
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == 'linux-aarch64', reason='Not supported on Linux ARM')
 class TestFiftyone:
     def test_export_images(self, reset_db) -> None:
         skip_test_if_not_installed('fiftyone')


### PR DESCRIPTION
Adds unit tests and a tutorial notebook for Ollama.

The tests will only run in an environment where a local Ollama server has been installed. Linux CI now installs it.

The notebook incorporates a means of dynamically spinning up an Ollama server in colab.