### PR TITLE
PXT-274 - Use GPUs for sentence_transformers when available

### DIFF
--- a/pixeltable/functions/huggingface.py
+++ b/pixeltable/functions/huggingface.py
@@ -403,7 +403,7 @@ T = TypeVar('T')
 
 def _lookup_model(
     model_id: str,
-    create: Callable[[str, ...], T],
+    create: Callable[..., T],
     device: Optional[str] = None,
     pass_device_to_create: bool = False
 ) -> T:

--- a/pixeltable/functions/huggingface.py
+++ b/pixeltable/functions/huggingface.py
@@ -403,7 +403,7 @@ T = TypeVar('T')
 
 def _lookup_model(
     model_id: str,
-    create: Callable[[str], T],
+    create: Callable[[str, ...], T],
     device: Optional[str] = None,
     pass_device_to_create: bool = False
 ) -> T:
@@ -416,7 +416,7 @@ def _lookup_model(
         else:
             model = create(model_id)
         if isinstance(model, nn.Module):
-            if pass_device_to_create == False and device is not None:
+            if not pass_device_to_create and device is not None:
                 model.to(device)
             model.eval()
         _model_cache[key] = model


### PR DESCRIPTION
This commit changes the following sentence_transformers udf
- sentence_transformer
- sentence_transformer_list
- cross_encoder
- cross_encoder_list to use the GPU when available by specifying the torch.device.

Testing: make test ran clean on laptop (assume, it uses mps gpu). CI should run with cpu. Pending test in colab for cuda gpu. It is not yet clear how to verify/confirm it uses the device.