### PR TITLE
Use torchaudio for preprocessing instead of librosa

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -117,7 +117,10 @@ jobs:
         run: conda install -c conda-forge libiconv ffmpeg
       - name: Install ollama
         if: ${{ matrix.poetry-options != '' && matrix.os == 'ubuntu-22.04' }}
-        run: curl -fsSL https://ollama.com/install.sh | sh
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+          sleep 10
+          ollama pull 'qwen2.5:0.5b'  # Pull this now so we fail-fast if there's a connection issue
       - name: Install poetry
         # setuptools >= 69.2 has been causing problems with github actions even when its
         # version is enforced in poetry. For now, explicitly revert to setuptools 69.1.1

--- a/pixeltable/functions/huggingface.py
+++ b/pixeltable/functions/huggingface.py
@@ -427,7 +427,7 @@ def speech2text_for_conditional_generation(
     env.Env.get().require_package('sentencepiece')
     device = resolve_torch_device('auto', allow_mps=False)  # Doesn't seem to work on 'mps'; use 'cpu' instead
     import torch
-    import torchaudio
+    import torchaudio  # type: ignore[import-untyped]
     from transformers import Speech2TextForConditionalGeneration, Speech2TextProcessor
 
     model = _lookup_model(model_id, Speech2TextForConditionalGeneration.from_pretrained, device=device)


### PR DESCRIPTION
I'd initially used librosa for audio preprocessing in `speech2text_for_conditional_generation`. I'd assumed it was pulled in as a dependency by torchaudio; this turned out to be false (it was coming into our dependency tree from elsewhere).

This PR switches to use torchaudio for preprocessing instead. It's a little more work this way, but we avoid requiring librosa as a dependency in order to use it. (torchaudio is already needed by the model)