### PR TITLE
Fix for backwards-incompatible Mistral API change

### DIFF
--- a/pixeltable/functions/mistralai.py
+++ b/pixeltable/functions/mistralai.py
@@ -36,7 +36,6 @@ def chat_completions(
     temperature: Optional[float] = 0.7,
     top_p: Optional[float] = 1.0,
     max_tokens: Optional[int] = None,
-    min_tokens: Optional[int] = None,
     stop: Optional[list[str]] = None,
     random_seed: Optional[int] = None,
     response_format: Optional[dict] = None,
@@ -75,7 +74,6 @@ def chat_completions(
         temperature=temperature,
         top_p=top_p,
         max_tokens=_opt(max_tokens),
-        min_tokens=_opt(min_tokens),
         stop=stop,
         random_seed=_opt(random_seed),
         response_format=response_format,  # type: ignore[arg-type]

--- a/poetry.lock
+++ b/poetry.lock
@@ -4245,13 +4245,13 @@ files = [
 
 [[package]]
 name = "mistralai"
-version = "1.1.0"
+version = "1.2.1"
 description = "Python Client SDK for the Mistral AI API."
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "mistralai-1.1.0-py3-none-any.whl", hash = "sha256:eea0938975195f331d0ded12d14e3c982f09f1b68210200ed4ff0c6b9b22d0fb"},
-    {file = "mistralai-1.1.0.tar.gz", hash = "sha256:9d1fe778e0e8c6ddab714e6a64c6096bd39cfe119ff38ceb5019d8e089df08ba"},
+    {file = "mistralai-1.2.1-py3-none-any.whl", hash = "sha256:ef24b8f26d045b40db685f256289cf7bd027419e201034cbf4552adfa333aa18"},
+    {file = "mistralai-1.2.1.tar.gz", hash = "sha256:6b6c3548a6079926fffb96e375afe1ee8d226adedb7bb69ef028695cd5860b4f"},
 ]
 
 [package.dependencies]
@@ -10383,4 +10383,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "416af3401ff79ab7bca629230b13b2cbd287137ff3159e303dc25d9818009173"
+content-hash = "ca701aaa9f405f0b719c420ec8a2d9b83aa0236bd0d52b40b4368203d3d436fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ openai = "^1.10.0"
 anthropic = ">=0.34.2"
 together = "^1.3.1"
 fireworks-ai = "^0.13.0"
-mistralai = "^1.0.3"
+mistralai = "^1.2.1"
 replicate = "^1.0.2"
 boto3 = "==1.35.5"  # Locking a specific version of boto3 dramatically improves `poetry lock` runtimes
 spacy = ">=3.7"


### PR DESCRIPTION
The latest version of the Mistral SDK contains backward-incompatible API changes. This updates Pixeltable for compatibility