### PR TITLE
Reusable retry script for CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -119,8 +119,9 @@ jobs:
         if: ${{ matrix.poetry-options != '' && matrix.os == 'ubuntu-22.04' }}
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
-          sleep 10
-          ollama pull 'qwen2.5:0.5b'  # Pull this now so we fail-fast if there's a connection issue
+          sleep 10  # Wait for the ollama server to start
+          # Pull the model used for testing now, with retries, to safeguard against connection issues
+          ./scripts/retry.sh 3 30 ollama pull 'qwen2.5:0.5b'
       - name: Install poetry
         # setuptools >= 69.2 has been causing problems with github actions even when its
         # version is enforced in poetry. For now, explicitly revert to setuptools 69.1.1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -142,7 +142,7 @@ jobs:
           key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.poetry-options }}-${{
             hashFiles('.github/workflows/pytest.yml', 'poetry.lock', 'poetry.toml', 'pyproject.toml', 'Makefile') }}
       - name: Install the project dependencies
-        # Retry 3 times to be resilient against transitient connectivity issues.
+        # Retry 3 times to be resilient against transient connectivity issues.
         run: ./scripts/retry.sh 3 60 poetry install ${{ matrix.poetry-options }}
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10 and not on ubuntu-arm64

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -142,24 +142,8 @@ jobs:
           key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.poetry-options }}-${{
             hashFiles('.github/workflows/pytest.yml', 'poetry.lock', 'poetry.toml', 'pyproject.toml', 'Makefile') }}
       - name: Install the project dependencies
-        # Retry 3 times to be (hopefully) resilient against transient connection errors.
-        shell: bash -l {0}  # Don't use -e flag
-        run: |
-          set +e
-          RETRIES=3
-          while (( RETRIES-- > 0 )); do
-            poetry install ${{ matrix.poetry-options }}
-            RESULT="$?"
-            if [[ "$RESULT" == 0 ]]; then
-              break
-            fi
-            echo "Dependencies installation failed with exit code $RESULT; $RETRIES tries remaining."
-            sleep 60
-          done
-          if [[ "$RESULT" != 0 ]]; then
-            exit 1
-          fi
-          echo "Dependencies installation succeeded."
+        # Retry 3 times to be resilient against transitient connectivity issues.
+        run: ./scripts/retry.sh 3 60 poetry install ${{ matrix.poetry-options }}
       - name: Install yolox
         # Yolox cannot be installed with poetry and only seems to work with python <= 3.10 and not on ubuntu-arm64
         if: ${{ matrix.poetry-options != '' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-22.04' }}

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -l
+
+# Script to run a shell command several times with a delay between retries.
+# This is useful for running flaky commands in CI, such as those that depend on
+# network connectivity.
+# Usage: retry.sh <num-retries> <sleep-duration> <command>
+
+set +e
+
+retries="$1"
+sleep_interval="$2"
+shift 2
+
+if [[ -z "$@" ]]; then
+    echo "Usage: retry.sh <num-retries> <sleep-duration> <command>"
+    echo "Example: retry.sh 3 10 ollama pull 'qwen2.5:0.5b'"
+    exit 1
+fi
+
+echo "Running command with $retries retries: $@"
+
+while (( retries-- > 0)); do
+    $@
+    RESULT="$?"
+    if [[ "$RESULT" == 0 ]]; then
+        break
+    fi
+    echo "Failed with exit code $RESULT; $retries tries remaining."
+    if (( retries > 0 )); then
+        sleep $sleep_interval
+    fi
+done
+
+if [[ "$RESULT" != 0 ]]; then
+    echo "Command failed: $@"
+    exit 1
+fi
+
+echo "Command succeeded: $@"


### PR DESCRIPTION
We occasionally see problems in CI where a job fails due to a transient connectivity issue. This introduces a reusable retry script with the goal of making failure-prone CI steps more robust.