### PR TITLE
PXT-290: Allow APIs to accept table/column handles

### DIFF
--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -302,7 +302,7 @@ class Table(SchemaObject):
         cat = catalog.Catalog.get()
         # verify all dependents are deleted by now
         for dep in cat.tbl_dependents[self._id]:
-            assert dep._check_is_dropped() == True
+            dep._check_is_dropped()
         self._check_is_dropped()
         self._tbl_version.drop()
         self._is_dropped = True
@@ -628,7 +628,7 @@ class Table(SchemaObject):
 
         if col_name not in self._tbl_version.cols_by_name:
             raise excs.Error(f'Unknown column: {col_name}')
-        col = self._tbl_version.cols_by_name[name]
+        col = self._tbl_version.cols_by_name[col_name]
         dependent_user_cols = [c for c in col.dependent_cols if c.name is not None]
         if len(dependent_user_cols) > 0:
             raise excs.Error(

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -610,7 +610,7 @@ class Table(SchemaObject):
             raise excs.Error(f'Column {column_name!r} unknown')
 
     def __check_column_ref_exists(self, col_ref: ColumnRef, include_bases: bool = False) -> None:
-        tbl_cols: Iterable
+        tbl_cols: Iterable[Column]
         if include_bases:
             tbl_cols = self._tbl_version_path.columns()
         else:

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -298,6 +298,10 @@ class Table(SchemaObject):
         return self._description_html()._repr_html_()  # type: ignore[attr-defined]
 
     def _drop(self) -> None:
+        cat = catalog.Catalog.get()
+        # verify all dependents are deleted by now
+        for dep in cat.tbl_dependents[self._id]:
+            assert dep._check_is_dropped() == True
         self._check_is_dropped()
         self._tbl_version.drop()
         self._is_dropped = True

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -704,7 +704,7 @@ class Table(SchemaObject):
         of text over an image column.
 
         Args:
-            column: The name or reference of column to index; must be a `String` or `Image` column.
+            column: The name of, or reference to, the column to index; must be a `String` or `Image` column.
             idx_name: The name of index. If not specified, a name such as `'idx0'` will be generated automatically.
                 If specified, the name must be unique for this table.
             string_embed: A function to embed text; required if the column is a `String` column.
@@ -736,6 +736,8 @@ class Table(SchemaObject):
             ...     metric='ip'
             ... )
 
+            Alternatively:
+
             >>> tbl.add_embedding_index(
             ...     tbl.img,
             ...     idx_name='clip_idx',
@@ -747,7 +749,7 @@ class Table(SchemaObject):
         if self._tbl_version_path.is_snapshot():
             raise excs.Error('Cannot add an index to a snapshot')
         self._check_is_dropped()
-        col: Column = None
+        col: Column
         if isinstance(column, str):
             self.__check_column_name_exists(column, include_bases=True)
             col = self._tbl_version_path.get_column(column, include_bases=True)
@@ -775,8 +777,8 @@ class Table(SchemaObject):
         embedding index; otherwise the specific index name must be provided instead.
 
         Args:
-            column: The name or reference of the column from which to drop the index.
-                                The column must have only one embedding index.
+            column: The name of, or reference to, the column from which to drop the index.
+                    The column must have only one embedding index.
             idx_name: The name of the index to drop.
 
         Raises:
@@ -824,8 +826,8 @@ class Table(SchemaObject):
         otherwise the specific index name must be provided instead.
 
         Args:
-            column: The name or handle of the column from which to drop the index.
-                                The column must have only one embedding index.
+            column: The name of, or reference to, the column from which to drop the index.
+                    The column must have only one embedding index.
             idx_name: The name of the index to drop.
 
         Raises:

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -610,12 +610,8 @@ class Table(SchemaObject):
             raise excs.Error(f'Column {column_name!r} unknown')
 
     def __check_column_ref_exists(self, col_ref: ColumnRef, include_bases: bool = False) -> None:
-        tbl_cols: Iterable[Column]
-        if include_bases:
-            tbl_cols = self._tbl_version_path.columns()
-        else:
-            tbl_cols = self._tbl_version.cols_by_name.values()
-        if col_ref.col not in tbl_cols:
+        exists = self._tbl_version_path.has_column_ref(col_ref, include_bases)
+        if not exists:
             raise excs.Error(f'Unknown column: {col_ref.col.qualified_name}')
 
     def drop_column(self, column: Union[str, ColumnRef]) -> None:

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -603,11 +603,11 @@ class Table(SchemaObject):
             cls._verify_column(col, column_names)
             column_names.add(col.name)
 
-    def drop_column(self, name: Union[str, Column]) -> None:
+    def drop_column(self, name: Union[str, ColumnRef]) -> None:
         """Drop a column from the table.
 
         Args:
-            name: The name or handle of the column to drop.
+            name: The name or reference of the column to drop.
 
         Raises:
             Error: If the column does not exist or if it is referenced by a dependent computed column.
@@ -624,7 +624,7 @@ class Table(SchemaObject):
         if isinstance(name, str):
             col_name = name
         else:
-            col_name = name.name
+            col_name = name.col.name
 
         if col_name not in self._tbl_version.cols_by_name:
             raise excs.Error(f'Unknown column: {col_name}')

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -602,7 +602,7 @@ class Table(SchemaObject):
             cls._verify_column(col, column_names)
             column_names.add(col.name)
 
-    def drop_column(self, name: str) -> None:
+    def drop_column(self, name: Union[str, Column]) -> None:
         """Drop a column from the table.
 
         Args:
@@ -616,13 +616,18 @@ class Table(SchemaObject):
 
             >>> tbl = pxt.get_table('my_table')
             ... tbl.drop_column('col')
+            OR
+            ... tbl.drop_column(col)
         """
         self._check_is_dropped()
+        if isinstance(name, str):
+            col_name = name
+        else:
+            col_name = name.name
 
-        if name not in self._tbl_version.cols_by_name:
-            raise excs.Error(f'Unknown column: {name}')
+        if col_name not in self._tbl_version.cols_by_name:
+            raise excs.Error(f'Unknown column: {col_name}')
         col = self._tbl_version.cols_by_name[name]
-
         dependent_user_cols = [c for c in col.dependent_cols if c.name is not None]
         if len(dependent_user_cols) > 0:
             raise excs.Error(

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -610,7 +610,7 @@ class Table(SchemaObject):
             raise excs.Error(f'Column {column_name!r} unknown')
 
     def __check_column_ref_exists(self, col_ref: ColumnRef, include_bases: bool = False) -> None:
-        exists = self._tbl_version_path.has_column_ref(col_ref, include_bases)
+        exists = self._tbl_version_path.has_column(col_ref.col, include_bases)
         if not exists:
             raise excs.Error(f'Unknown column: {col_ref.col.qualified_name}')
 

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -133,12 +133,6 @@ class TableVersionPath:
         else:
             return False
 
-    def has_column_ref(self, col_ref: exprs.ColumnRef, include_bases: bool = True) -> bool:
-        """Return True if this table has the given column reference.
-        """
-        assert col_ref is not None
-        return self.has_column(col_ref.col, include_bases)
-
     def as_dict(self) -> dict:
         return {
             'tbl_version': self.tbl_version.as_dict(),

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -133,6 +133,12 @@ class TableVersionPath:
         else:
             return False
 
+    def has_column_ref(self, col_ref: exprs.ColumnRef, include_bases: bool = True) -> bool:
+        """Return True if this table has the given column reference.
+        """
+        assert col_ref is not None
+        return self.has_column(col_ref.col, include_bases)
+
     def as_dict(self) -> dict:
         return {
             'tbl_version': self.tbl_version.as_dict(),

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -196,7 +196,7 @@ class View(Table):
         cat = catalog.Catalog.get()
         # verify all dependents are deleted by now
         for dep in cat.tbl_dependents[self._id]:
-            assert dep._check_is_dropped() == True
+            dep._check_is_dropped
         if self._snapshot_only:
             # there is not TableVersion to drop
             self._check_is_dropped()

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -196,7 +196,7 @@ class View(Table):
         cat = catalog.Catalog.get()
         # verify all dependents are deleted by now
         for dep in cat.tbl_dependents[self._id]:
-            dep._check_is_dropped
+            assert dep._is_dropped == True
         if self._snapshot_only:
             # there is not TableVersion to drop
             self._check_is_dropped()

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -194,6 +194,9 @@ class View(Table):
 
     def _drop(self) -> None:
         cat = catalog.Catalog.get()
+        # verify all dependents are deleted by now
+        for dep in cat.tbl_dependents[self._id]:
+            assert dep._check_is_dropped() == True
         if self._snapshot_only:
             # there is not TableVersion to drop
             self._check_is_dropped()

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -196,7 +196,7 @@ class View(Table):
         cat = catalog.Catalog.get()
         # verify all dependents are deleted by now
         for dep in cat.tbl_dependents[self._id]:
-            assert dep._is_dropped == True
+            assert dep._is_dropped
         if self._snapshot_only:
             # there is not TableVersion to drop
             self._check_is_dropped()

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -300,7 +300,7 @@ def drop_table(table: Union[str, catalog.Table], force: bool = False, ignore_err
     """Drop a table, view, or snapshot.
 
     Args:
-        table: name or [`Table`][pixeltable.Table] object of the table to be dropped.
+        table: Fully qualified name, or handle, of the table to be dropped.
         force: If `True`, will also drop all views and sub-views of this table.
         ignore_errors: If `True`, return silently if the table does not exist (without throwing an exception).
 
@@ -308,11 +308,11 @@ def drop_table(table: Union[str, catalog.Table], force: bool = False, ignore_err
         Error: If the name does not exist or does not designate a table object, and `ignore_errors=False`.
 
     Examples:
-        Drop a table by name:
-        >>> pxt.drop_table('my_table')
+        Drop a table by its fully qualified name:
+        >>> pxt.drop_table('subdir.my_table')
 
-        Drop a table by reference:
-        >>> t = pxt.get_table('my_table')
+        Drop a table by its handle:
+        >>> t = pxt.get_table('subdir.my_table')
         ... pxt.drop_table(t)
 
     """

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -296,38 +296,42 @@ def move(path: str, new_path: str) -> None:
     obj._move(new_p.name, new_dir._id)
 
 
-def drop_table(path: Union[str,catalog.Table], force: bool = False, ignore_errors: bool = False) -> None:
+def drop_table(table_name_or_obj: Union[str, catalog.Table], force: bool = False, ignore_errors: bool = False) -> None:
     """Drop a table, view, or snapshot.
 
     Args:
-        path: Path to the [`Table`][pixeltable.Table].
+        table_name_or_obj: name or object of the [`Table`][pixeltable.Table] to be dropped.
         force: If `True`, will also drop all views and sub-views of this table.
         ignore_errors: If `True`, return silently if the table does not exist (without throwing an exception).
 
     Raises:
-        Error: If the path does not exist or does not designate a table object, and `ignore_errors=False`.
+        Error: If the name does not exist or does not designate a table object, and `ignore_errors=False`.
 
     Examples:
+        Drop a table by name
         >>> pxt.drop_table('my_table')
-        OR
-        >>> t = pxt.create_table('my_table') or t = pxt.get_handle('my_table')
-        >>> pxt.drop_table(t)
+
+        Drop a table by object
+        >>> t = pxt.get_handle('my_table')
+        ... pxt.drop_table(t)
+
     """
     cat = Catalog.get()
-    if isinstance(path, str):
-        tbl_path_obj = catalog.Path(path)
+    if isinstance(table_name_or_obj, str):
+        tbl_path_obj = catalog.Path(table_name_or_obj)
         try:
             cat.paths.check_is_valid(tbl_path_obj, expected=catalog.Table)
         except Exception as e:
             if ignore_errors or force:
-                _logger.info(f'Skipped table `{path}` (does not exist).')
+                _logger.info(f'Skipped table `{table_name_or_obj}` (does not exist).')
                 return
             else:
                 raise e
         tbl = cat.paths[tbl_path_obj]
     else:
-        tbl = path
+        tbl = table_name_or_obj
         tbl_path_obj = catalog.Path(tbl._path)
+
     assert isinstance(tbl, catalog.Table)
     if len(cat.tbl_dependents[tbl._id]) > 0:
         dependent_paths = [dep._path for dep in cat.tbl_dependents[tbl._id]]
@@ -335,7 +339,7 @@ def drop_table(path: Union[str,catalog.Table], force: bool = False, ignore_error
             for dependent_path in dependent_paths:
                 drop_table(dependent_path, force=True)
         else:
-            raise excs.Error(f'Table {path} has dependents: {", ".join(dependent_paths)}')
+            raise excs.Error(f'Table {tbl._path} has dependents: {", ".join(dependent_paths)}')
     tbl._drop()
     del cat.paths[tbl_path_obj]
     _logger.info(f'Dropped table `{tbl._path}`.')

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -300,7 +300,7 @@ def drop_table(table: Union[str, catalog.Table], force: bool = False, ignore_err
     """Drop a table, view, or snapshot.
 
     Args:
-        table: "name or [`Table`][pixeltable.Table]" object of the table to be dropped.
+        table: name or [`Table`][pixeltable.Table] object of the table to be dropped.
         force: If `True`, will also drop all views and sub-views of this table.
         ignore_errors: If `True`, return silently if the table does not exist (without throwing an exception).
 

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -296,11 +296,11 @@ def move(path: str, new_path: str) -> None:
     obj._move(new_p.name, new_dir._id)
 
 
-def drop_table(table_name_or_obj: Union[str, catalog.Table], force: bool = False, ignore_errors: bool = False) -> None:
+def drop_table(table: Union[str, catalog.Table], force: bool = False, ignore_errors: bool = False) -> None:
     """Drop a table, view, or snapshot.
 
     Args:
-        table_name_or_obj: name or object of the [`Table`][pixeltable.Table] to be dropped.
+        table: "name or [`Table`][pixeltable.Table]" object of the table to be dropped.
         force: If `True`, will also drop all views and sub-views of this table.
         ignore_errors: If `True`, return silently if the table does not exist (without throwing an exception).
 
@@ -308,28 +308,28 @@ def drop_table(table_name_or_obj: Union[str, catalog.Table], force: bool = False
         Error: If the name does not exist or does not designate a table object, and `ignore_errors=False`.
 
     Examples:
-        Drop a table by name
+        Drop a table by name:
         >>> pxt.drop_table('my_table')
 
-        Drop a table by object
-        >>> t = pxt.get_handle('my_table')
+        Drop a table by reference:
+        >>> t = pxt.get_table('my_table')
         ... pxt.drop_table(t)
 
     """
     cat = Catalog.get()
-    if isinstance(table_name_or_obj, str):
-        tbl_path_obj = catalog.Path(table_name_or_obj)
+    if isinstance(table, str):
+        tbl_path_obj = catalog.Path(table)
         try:
             cat.paths.check_is_valid(tbl_path_obj, expected=catalog.Table)
         except Exception as e:
             if ignore_errors or force:
-                _logger.info(f'Skipped table `{table_name_or_obj}` (does not exist).')
+                _logger.info(f'Skipped table `{table}` (does not exist).')
                 return
             else:
                 raise e
         tbl = cat.paths[tbl_path_obj]
     else:
-        tbl = table_name_or_obj
+        tbl = table
         tbl_path_obj = catalog.Path(tbl._path)
 
     assert isinstance(tbl, catalog.Table)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -162,12 +162,20 @@ class TestIndex:
             img_t.add_embedding_index('img', idx_name='idx0', image_embed=clip_img_embed)
         assert 'duplicate index name' in str(exc_info.value).lower()
 
+        with pytest.raises(pxt.Error):
+            img_t.drop_embedding_index(column_name='category')
+        with pytest.raises(pxt.Error):
+            img_t.drop_embedding_index(column_name=img_t.category)
         img_t.add_embedding_index('category', string_embed=e5_embed)
 
         # revert() removes the index
         img_t.revert()
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column_name='category')
+
+        with pytest.raises(pxt.Error):
+            img_t.drop_embedding_index(column_name=img_t.category)
+
         assert 'does not have an index' in str(exc_info.value).lower()
 
         rows = list(img_t.collect())
@@ -221,6 +229,9 @@ class TestIndex:
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column_name='img')
         assert "column 'img' has multiple indices" in str(exc_info.value).lower()
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index(column_name=img_t.img)
+        assert "column 'img' has multiple indices" in str(exc_info.value).lower()
         img_t.drop_embedding_index(idx_name='other_idx')
 
         with pytest.raises(pxt.Error) as exc_info:
@@ -228,9 +239,9 @@ class TestIndex:
             _ = img_t.order_by(sim, asc=False).limit(1).collect()
         assert "index 'other_idx' not found" in str(exc_info.value).lower()
 
-        img_t.drop_embedding_index(column_name='img')
+        img_t.drop_embedding_index(column_name=img_t.img)
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name='img')
+            img_t.drop_embedding_index(column_name=img_t.img)
         assert 'does not have an index' in str(exc_info.value).lower()
 
         # revert() makes the index reappear

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -51,7 +51,7 @@ class TestIndex:
             validate_update_status(t.add_column(sim=t.img.similarity('parachute')))
             t.drop_column('sim')
 
-            t.drop_embedding_index(column_name_or_ref='img')
+            t.drop_embedding_index(column='img')
 
     def test_query(self, reset_db) -> None:
         skip_test_if_not_installed('transformers')
@@ -69,7 +69,7 @@ class TestIndex:
             {'text': 'machine learning is a subset of artificial intelligence'},
             {'text': 'gas car companies are in danger of being left behind by electric car companies'},
         ])
-        chunks.add_embedding_index(col_name_or_ref='text', string_embed=clip_text_embed)
+        chunks.add_embedding_index(column='text', string_embed=clip_text_embed)
 
         @chunks.query
         def top_k_chunks(query_text: str) -> pxt.DataFrame:
@@ -162,7 +162,7 @@ class TestIndex:
 
         with pytest.raises(pxt.Error) as exc_info:
             # cannot pass another table's column reference
-            img_t.drop_embedding_index(column_name_or_ref=dummy_img_t.img);
+            img_t.drop_embedding_index(column=dummy_img_t.img);
         assert 'unknown column: dummy.img' in str(exc_info.value).lower()
 
         # predicates on media columns that have both a B-tree and an embedding index still work
@@ -182,10 +182,10 @@ class TestIndex:
         # revert() removes the index
         img_t.revert()
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref='category')
+            img_t.drop_embedding_index(column='category')
         assert 'does not have an index' in str(exc_info.value).lower()
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref=img_t.category)
+            img_t.drop_embedding_index(column=img_t.category)
         assert 'does not have an index' in str(exc_info.value).lower()
 
         rows = list(img_t.collect())
@@ -237,10 +237,10 @@ class TestIndex:
         assert "index 'doesnotexist' not found" in str(exc_info.value).lower()
 
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref='img')
+            img_t.drop_embedding_index(column='img')
         assert "column 'img' has multiple indices" in str(exc_info.value).lower()
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref=img_t.img)
+            img_t.drop_embedding_index(column=img_t.img)
         assert "column 'img' has multiple indices" in str(exc_info.value).lower()
         img_t.drop_embedding_index(idx_name='other_idx')
 
@@ -249,9 +249,9 @@ class TestIndex:
             _ = img_t.order_by(sim, asc=False).limit(1).collect()
         assert "index 'other_idx' not found" in str(exc_info.value).lower()
 
-        img_t.drop_embedding_index(column_name_or_ref=img_t.img)
+        img_t.drop_embedding_index(column=img_t.img)
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref=img_t.img)
+            img_t.drop_embedding_index(column=img_t.img)
         assert 'does not have an index' in str(exc_info.value).lower()
 
         # revert() makes the index reappear
@@ -314,34 +314,34 @@ class TestIndex:
 
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index()
-        assert "exactly one of 'column_name_or_ref' or 'idx_name' must be provided" in str(exc_info.value).lower()
+        assert "exactly one of 'column' or 'idx_name' must be provided" in str(exc_info.value).lower()
 
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(idx_name='doesnotexist')
         assert "index 'doesnotexist' does not exist" in str(exc_info.value).lower()
 
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref='doesnotexist')
+            img_t.drop_embedding_index(column='doesnotexist')
         assert "column 'doesnotexist' unknown" in str(exc_info.value).lower()
         with pytest.raises(AttributeError) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref=img_t.doesnotexist)
+            img_t.drop_embedding_index(column=img_t.doesnotexist)
         assert 'column doesnotexist unknown' in str(exc_info.value).lower()
 
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref='img')
+            img_t.drop_embedding_index(column='img')
         assert "column 'img' does not have an index" in str(exc_info.value).lower()
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref=img_t.img)
+            img_t.drop_embedding_index(column=img_t.img)
         assert "column 'img' does not have an index" in str(exc_info.value).lower()
 
         img_t.add_embedding_index('img', idx_name='embed0', image_embed=clip_img_embed, string_embed=clip_text_embed)
         img_t.add_embedding_index('img', idx_name='embed1', image_embed=clip_img_embed, string_embed=clip_text_embed)
 
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref='img')
+            img_t.drop_embedding_index(column='img')
         assert "column 'img' has multiple indices" in str(exc_info.value).lower()
         with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column_name_or_ref=img_t.img)
+            img_t.drop_embedding_index(column=img_t.img)
         assert "column 'img' has multiple indices" in str(exc_info.value).lower()
 
         with pytest.raises(pxt.Error) as exc_info:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -69,7 +69,7 @@ class TestIndex:
             {'text': 'machine learning is a subset of artificial intelligence'},
             {'text': 'gas car companies are in danger of being left behind by electric car companies'},
         ])
-        chunks.add_embedding_index(col_name='text', string_embed=clip_text_embed)
+        chunks.add_embedding_index(col_name_or_ref='text', string_embed=clip_text_embed)
 
         @chunks.query
         def top_k_chunks(query_text: str) -> pxt.DataFrame:
@@ -166,7 +166,7 @@ class TestIndex:
             img_t.drop_embedding_index(column_name='category')
         with pytest.raises(pxt.Error):
             img_t.drop_embedding_index(column_name=img_t.category)
-        img_t.add_embedding_index('category', string_embed=e5_embed)
+        img_t.add_embedding_index(img_t.category, string_embed=e5_embed)
 
         # revert() removes the index
         img_t.revert()
@@ -208,7 +208,7 @@ class TestIndex:
         img_t.revert()
 
         # multiple indices
-        img_t.add_embedding_index('img', idx_name='other_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
+        img_t.add_embedding_index(img_t.img, idx_name='other_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
         with pytest.raises(pxt.Error) as exc_info:
             sim = img_t.img.similarity('red truck')
             _ = img_t.order_by(sim, asc=False).limit(1).collect()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -446,7 +446,7 @@ class TestTable:
         pxt.drop_table('test_tbl', force=True)  # Drops everything else
         assert len(pxt.list_tables()) == 0
 
-    def test_drop_column(self, reset_db) -> None:
+    def test_drop_column_via_handle(self, reset_db) -> None:
         t = pxt.create_table('test1', {'c1': pxt.String, 'c2': pxt.String})
         t.insert([{'c1':'a1', 'c2':'b1'}, {'c1':'a2', 'c2':'b2'}])
         assert 'c3' not in t.columns
@@ -454,18 +454,18 @@ class TestTable:
             t.drop_column('c3')
         assert 'c2' in t.columns
         t.drop_column('c2')
-        with pytest.raises(excs.Error):
+        with pytest.raises(AttributeError):
             _ = t.c2
         with pytest.raises(excs.Error):
             _ = t.drop_column('c2')
 
         t.add_column(c2=pxt.Int)
-        with pytest.raises(excs.Error):
+        with pytest.raises(AttributeError):
             t.drop_column(t.c3)
         t.drop_column(t.c2)
-        with pytest.raises(excs.Error):
+        with pytest.raises(AttributeError):
             _ = t.c2
-        with pytest.raises(excs.Error):
+        with pytest.raises(AttributeError):
             _ = t.drop_column(t.c2)
 
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -386,6 +386,38 @@ class TestTable:
         with pytest.raises(excs.Error):
             _ = t.show(1)
 
+    def test_drop_table_via_handle(self, test_tbl: pxt.Table) -> None:
+        t = pxt.create_table('test1', {'c1': pxt.String})
+        pxt.drop_table(t)
+        with pytest.raises(excs.Error):
+            _ = pxt.get_table('test1')
+        with pytest.raises(excs.Error):
+            _ = t.show(1)
+        t = pxt.create_table('test2', {'c1': pxt.String})
+        t = pxt.get_table('test2')
+        pxt.drop_table(t)
+        with pytest.raises(excs.Error):
+            _ = pxt.get_table('test2')
+        with pytest.raises(excs.Error):
+            _ = t.show(1)
+        t = pxt.create_table('test3', {'c1': pxt.String})
+        v = pxt.create_view('view3', t)
+        pxt.drop_table(v)
+        with pytest.raises(excs.Error):
+            _ = pxt.get_table('view3')
+        with pytest.raises(excs.Error):
+            _ = v.show(1)
+        _ = pxt.get_table('test3')
+        v = pxt.create_view('view4', t)
+        v = pxt.get_table('view4')
+        pxt.drop_table(v)
+        with pytest.raises(excs.Error):
+            _ = pxt.get_table('view4')
+        with pytest.raises(excs.Error):
+            _ = v.show(1)
+        _ = pxt.get_table('test3')
+        pxt.drop_table(t)
+
     def test_drop_table_force(self, test_tbl: pxt.Table) -> None:
         t = pxt.get_table('test_tbl')
         v1 = pxt.create_view('v1', t)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -381,40 +381,50 @@ class TestTable:
     def test_drop_table(self, test_tbl: pxt.Table) -> None:
         t = pxt.get_table('test_tbl')
         pxt.drop_table('test_tbl')
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             _ = pxt.get_table('test_tbl')
-        with pytest.raises(excs.Error):
+        assert 'no such path: test_tbl' in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.show(1)
+        assert 'table test_tbl has been dropped' in str(exc_info.value).lower()
 
     def test_drop_table_via_handle(self, test_tbl: pxt.Table) -> None:
         t = pxt.create_table('test1', {'c1': pxt.String})
         pxt.drop_table(t)
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             _ = pxt.get_table('test1')
-        with pytest.raises(excs.Error):
+        assert 'no such path: test1' in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.show(1)
+        assert 'table test1 has been dropped' in str(exc_info.value).lower()
         t = pxt.create_table('test2', {'c1': pxt.String})
         t = pxt.get_table('test2')
         pxt.drop_table(t)
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             _ = pxt.get_table('test2')
-        with pytest.raises(excs.Error):
+        assert 'no such path: test2' in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.show(1)
+        assert 'table test2 has been dropped' in str(exc_info.value).lower()
         t = pxt.create_table('test3', {'c1': pxt.String})
         v = pxt.create_view('view3', t)
         pxt.drop_table(v)
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             _ = pxt.get_table('view3')
-        with pytest.raises(excs.Error):
+        assert 'no such path: view3' in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
             _ = v.show(1)
+        assert 'view view3 has been dropped' in str(exc_info.value).lower()
         _ = pxt.get_table('test3')
         v = pxt.create_view('view4', t)
         v = pxt.get_table('view4')
         pxt.drop_table(v)
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             _ = pxt.get_table('view4')
-        with pytest.raises(excs.Error):
+        assert 'no such path: view4' in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
             _ = v.show(1)
+        assert 'view view4 has been dropped' in str(exc_info.value).lower()
         _ = pxt.get_table('test3')
         pxt.drop_table(t)
 
@@ -443,30 +453,8 @@ class TestTable:
         assert len(pxt.list_tables()) == 4
         assert 'v2' not in pxt.list_tables()
         assert 'v4' not in pxt.list_tables()
-        pxt.drop_table('test_tbl', force=True)  # Drops everything else
+        pxt.drop_table(t, force=True)  # Drops everything else
         assert len(pxt.list_tables()) == 0
-
-    def test_drop_column_via_handle(self, reset_db) -> None:
-        t = pxt.create_table('test1', {'c1': pxt.String, 'c2': pxt.String})
-        t.insert([{'c1':'a1', 'c2':'b1'}, {'c1':'a2', 'c2':'b2'}])
-        assert 'c3' not in t.columns
-        with pytest.raises(excs.Error):
-            t.drop_column('c3')
-        assert 'c2' in t.columns
-        t.drop_column('c2')
-        with pytest.raises(AttributeError):
-            _ = t.c2
-        with pytest.raises(excs.Error):
-            _ = t.drop_column('c2')
-
-        t.add_column(c2=pxt.Int)
-        with pytest.raises(AttributeError):
-            t.drop_column(t.c3)
-        t.drop_column(t.c2)
-        with pytest.raises(AttributeError):
-            _ = t.c2
-        with pytest.raises(AttributeError):
-            _ = t.drop_column(t.c2)
 
 
     @pytest.mark.skip(reason='Skip until we figure out the right API for altering table attributes')
@@ -1551,9 +1539,21 @@ class TestTable:
         num_orig_cols = len(t.columns)
         t.drop_column('c1')
         assert len(t.columns) == num_orig_cols - 1
+        assert 'c1' not in t.columns
+        with pytest.raises(AttributeError) as exc_info:
+            _ = t.c1
+        assert 'column c1 unknown' in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
+            _ = t.drop_column('c1')
+        assert "column 'c1' unknown" in str(exc_info.value).lower()
 
-        with pytest.raises(excs.Error):
+        assert 'unknown' not in t.columns
+        with pytest.raises(excs.Error) as exc_info:
             t.drop_column('unknown')
+        assert "column 'unknown' unknown" in str(exc_info.value).lower()
+        with pytest.raises(AttributeError) as exc_info:
+            t.drop_column(t.unknown)
+        assert 'column unknown unknown' in str(exc_info.value).lower()
 
         # make sure this is still true after reloading the metadata
         reload_catalog()
@@ -1563,11 +1563,41 @@ class TestTable:
         # revert() works
         t.revert()
         assert len(t.columns) == num_orig_cols
+        assert 'c1' in t.columns
+        _ = t.c1
 
         # make sure this is still true after reloading the metadata once more
         reload_catalog()
         t = pxt.get_table(t._name)
         assert len(t.columns) == num_orig_cols
+        assert 'c1' in t.columns
+        _ = t.c1
+
+    def test_drop_column_via_reference(self, reset_db) -> None:
+        t1 = pxt.create_table('test1', {'c1': pxt.String, 'c2': pxt.String})
+        t1.insert([{'c1': 'a1', 'c2': 'b1'}, {'c1': 'a2', 'c2': 'b2'}])
+        t2 = pxt.create_table('test2', {'c1': pxt.String, 'c2': pxt.String})
+
+        # cannot pass another table's column reference
+        with pytest.raises(excs.Error) as exc_info:
+            t1.drop_column(t2.c2)
+        assert 'unknown column: test2.c2' in str(exc_info.value).lower()
+        assert 'c2' in t1.columns
+        assert 'c2' in t2.columns
+        _ = t1.c2
+        _ = t2.c2
+
+        t1.drop_column(t1.c2)
+        assert 'c2' not in t1.columns
+        with pytest.raises(AttributeError) as exc_info:
+            _ = t1.c2
+        assert 'column c2 unknown' in str(exc_info.value).lower()
+        with pytest.raises(AttributeError) as exc_info:
+            t1.drop_column(t1.c2)
+        assert 'column c2 unknown' in str(exc_info.value).lower()
+        assert 'c2' in t2.columns
+        pxt.drop_table(t1)
+        pxt.drop_table(t2)
 
     def test_rename_column(self, test_tbl: catalog.Table) -> None:
         t = test_tbl


### PR DESCRIPTION
This commit allows the following APIs to accept table/column handles
as an alternative to the table/column name
- drop_embedding_index and drop_index APIs accept a column reference as an alternative to the column name.
- drop_column API accepts column handle as an alternative to the column name.
- drop_table API to accept a table handle as an alternative to the table name.

This commit also adds an assertion in the catalog.Table._drop 
and catalog.View._drop internal API to assert that the dependencies
are dropped before they are invoked.

Testing: added new tests or enhanced existing ones