### PR TITLE
PXT-330 Fix a bug in create_insert_plan

### DIFF
--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -224,7 +224,7 @@ class Planner:
         """Creates a plan for TableVersion.insert()"""
         assert not tbl.is_view()
         # stored_cols: all cols we need to store, incl computed cols (and indices)
-        stored_cols = [c for c in tbl.cols if c.is_stored]
+        stored_cols = [c for c in tbl.cols_by_id.values() if c.is_stored]
         assert len(stored_cols) > 0  # there needs to be something to store
         row_builder = exprs.RowBuilder([], stored_cols, [])
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -875,9 +875,9 @@ class TestTable:
             t.insert(c5=np.ndarray((3, 2)))
         assert 'expected ndarray((2, 3)' in str(exc_info.value)
 
-        # test that insert with a bad column succeeds when the
-        # table is empty and after the bad column is dropped
-        # because expression evaluation is skipped
+        # test that insert skips expression evaluation and does not
+        # populate any columns when the table is empty, and for any
+        # columns that are not part of the current schema.
         @pxt.udf(_force_stored=True)
         def bad_udf(x: str) -> str:
             assert False
@@ -894,7 +894,6 @@ class TestTable:
         assert t.count() == 1
         for tup in t.collect():
             assert tup['c1'] == 'this is a python string'
-
 
     def test_query(self, reset_db) -> None:
         skip_test_if_not_installed('boto3')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -875,9 +875,8 @@ class TestTable:
             t.insert(c5=np.ndarray((3, 2)))
         assert 'expected ndarray((2, 3)' in str(exc_info.value)
 
-        # test that insert skips expression evaluation and does not
-        # populate any columns when the table is empty, and for any
-        # columns that are not part of the current schema.
+        # test that insert skips expression evaluation for
+        # any columns that are not part of the current schema.
         @pxt.udf(_force_stored=True)
         def bad_udf(x: str) -> str:
             assert False


### PR DESCRIPTION
This commit fixes a bug in Planner.create_insert_plan where an insert continues to include a column even after it was dropped. This was because it was using catalog.TableVersion.cols to get the list of columns, but that tracks history of all the columns in the table/view. Fix is to use catalog.TableVersion.cols_by_id that tracks the current list of columns.

Testing: new testcase that reproduces the bug passes with the fix.