### PR TITLE
Fix handling of Optional vs. Required in astype()

### DIFF
--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -166,7 +166,7 @@ class ColumnType:
         if t == cls.Type.DOCUMENT:
             return DocumentType()
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return self._to_str(as_schema=False)
 
     def _to_str(self, as_schema: bool) -> str:


### PR DESCRIPTION
- Ensures that astype() treats its type argument as if it appeared in a schema (nullable by default, Python builtins not allowed)
- Exprs of non-nullable type will remain non-nullable after an astype(), regardless of the astype() argument (since they are provably non-nullable)
- Casting from nullable to non-nullable is allowed and will generate errors if it encounters any Nones
- Adds unit tests to validate all of the above