### PR TITLE
PXT-345 Add .txt support for DocumentType

### DIFF
--- a/pixeltable/iterators/document.py
+++ b/pixeltable/iterators/document.py
@@ -154,7 +154,6 @@ class DocumentSplitter(ComponentIterator):
         elif self._doc_handle.format == DocumentType.DocumentFormat.TXT:
             assert self._doc_handle.txt_doc is not None
             self._sections = self._txt_sections()
-            #self._sections = self._pdf_sections()
         else:
             assert False, f'Unsupported document format: {self._doc_handle.format}'
 
@@ -352,7 +351,7 @@ class DocumentSplitter(ComponentIterator):
         yield from emit()
 
     def _pdf_sections(self) -> Iterator[DocumentSection]:
-        """Create DocumentSections reflecting the pdf-specific or text separators"""
+        """Create DocumentSections reflecting the pdf-specific separators"""
         import fitz  # type: ignore[import-untyped]
         doc: fitz.Document = self._doc_handle.pdf_doc
         assert doc is not None
@@ -394,7 +393,11 @@ class DocumentSplitter(ComponentIterator):
             yield DocumentSection(text=_emit_text(), metadata=DocumentSectionMetadata())
 
     def _txt_sections(self) -> Iterator[DocumentSection]:
-        """Create DocumentSections for text files."""
+        """Create DocumentSections for text files.
+
+        Currently, it returns the entire text as a single section.
+        TODO: Add support for paragraphs.
+        """
         assert self._doc_handle.txt_doc is not None
         yield DocumentSection(text=ftfy.fix_text(self._doc_handle.txt_doc), metadata=DocumentSectionMetadata())
 

--- a/pixeltable/iterators/document.py
+++ b/pixeltable/iterators/document.py
@@ -151,6 +151,11 @@ class DocumentSplitter(ComponentIterator):
         elif self._doc_handle.format == DocumentType.DocumentFormat.PDF:
             assert self._doc_handle.pdf_doc is not None
             self._sections = self._pdf_sections()
+        elif self._doc_handle.format == DocumentType.DocumentFormat.TXT:
+            assert self._doc_handle.pdf_doc is not None
+            assert self._doc_handle.is_txt
+            #self._sections = [DocumentSection(text=self._doc_handle.txt_doc)]
+            self._sections = self._pdf_sections()
         else:
             assert False, f'Unsupported document format: {self._doc_handle.format}'
 
@@ -348,7 +353,7 @@ class DocumentSplitter(ComponentIterator):
         yield from emit()
 
     def _pdf_sections(self) -> Iterator[DocumentSection]:
-        """Create DocumentSections reflecting the pdf-specific separators"""
+        """Create DocumentSections reflecting the pdf-specific or text separators"""
         import fitz  # type: ignore[import-untyped]
         doc: fitz.Document = self._doc_handle.pdf_doc
         assert doc is not None

--- a/pixeltable/iterators/document.py
+++ b/pixeltable/iterators/document.py
@@ -152,10 +152,9 @@ class DocumentSplitter(ComponentIterator):
             assert self._doc_handle.pdf_doc is not None
             self._sections = self._pdf_sections()
         elif self._doc_handle.format == DocumentType.DocumentFormat.TXT:
-            assert self._doc_handle.pdf_doc is not None
-            assert self._doc_handle.is_txt
-            #self._sections = [DocumentSection(text=self._doc_handle.txt_doc)]
-            self._sections = self._pdf_sections()
+            assert self._doc_handle.txt_doc is not None
+            self._sections = self._txt_sections()
+            #self._sections = self._pdf_sections()
         else:
             assert False, f'Unsupported document format: {self._doc_handle.format}'
 
@@ -393,6 +392,11 @@ class DocumentSplitter(ComponentIterator):
 
         if accumulated_text and not emit_on_page:
             yield DocumentSection(text=_emit_text(), metadata=DocumentSectionMetadata())
+
+    def _txt_sections(self) -> Iterator[DocumentSection]:
+        """Create DocumentSections for text files."""
+        assert self._doc_handle.txt_doc is not None
+        yield DocumentSection(text=ftfy.fix_text(self._doc_handle.txt_doc), metadata=DocumentSectionMetadata())
 
     def _sentence_sections(self, input_sections: Iterable[DocumentSection]) -> Iterator[DocumentSection]:
         """Split the input sections into sentences"""

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -940,6 +940,7 @@ class DocumentType(ColumnType):
         MD = 1
         PDF = 2
         XML = 3
+        TXT = 4
 
     def __init__(self, nullable: bool = False, doc_formats: Optional[str] = None):
         super().__init__(self.Type.DOCUMENT, nullable=nullable)

--- a/pixeltable/utils/documents.py
+++ b/pixeltable/utils/documents.py
@@ -42,7 +42,7 @@ def get_document_handle(path: str) -> Optional[DocumentHandle]:
             return DocumentHandle(format=ts.DocumentType.DocumentFormat.XML, bs_doc=bs_doc)
 
     if doc_format == '.txt':
-        txt_doc = get_txt_handle(path)
+        txt_doc = get_txt(path)
         if txt_doc is not None:
             return DocumentHandle(format=ts.DocumentType.DocumentFormat.TXT, txt_doc=txt_doc)
 
@@ -91,7 +91,7 @@ def get_markdown_handle(path: str) -> Optional[dict]:
     except Exception:
         return None
 
-def get_txt_handle(path: str) -> Optional[str]:
+def get_txt(path: str) -> Optional[str]:
     try:
         with open(path, "r") as f:
             doc = f.read()

--- a/pixeltable/utils/documents.py
+++ b/pixeltable/utils/documents.py
@@ -15,6 +15,7 @@ class DocumentHandle:
     bs_doc: Optional[bs4.BeautifulSoup] = None
     md_ast: Optional[dict] = None
     pdf_doc: Optional[fitz.Document] = None
+    is_txt: Optional[bool] = False
 
 
 def get_document_handle(path: str) -> Optional[DocumentHandle]:
@@ -39,6 +40,11 @@ def get_document_handle(path: str) -> Optional[DocumentHandle]:
         bs_doc = get_xml_handle(path)
         if bs_doc is not None:
             return DocumentHandle(format=ts.DocumentType.DocumentFormat.XML, bs_doc=bs_doc)
+
+    if doc_format == '.txt':
+        txt_doc = get_txt_handle(path)
+        if txt_doc is not None:
+            return DocumentHandle(format=ts.DocumentType.DocumentFormat.TXT, pdf_doc=txt_doc, is_txt=True)
 
     return None
 
@@ -82,5 +88,14 @@ def get_markdown_handle(path: str) -> Optional[dict]:
             text = file.read()
         md_ast = mistune.create_markdown(renderer=None)
         return md_ast(text)
+    except Exception:
+        return None
+
+def get_txt_handle(path: str) -> Optional[fitz.Document]:
+    try:
+        doc = fitz.open(path)
+        # try to read one page
+        next(page for page in doc)
+        return doc
     except Exception:
         return None

--- a/pixeltable/utils/documents.py
+++ b/pixeltable/utils/documents.py
@@ -15,7 +15,7 @@ class DocumentHandle:
     bs_doc: Optional[bs4.BeautifulSoup] = None
     md_ast: Optional[dict] = None
     pdf_doc: Optional[fitz.Document] = None
-    is_txt: Optional[bool] = False
+    txt_doc: Optional[str] = None
 
 
 def get_document_handle(path: str) -> Optional[DocumentHandle]:
@@ -44,7 +44,7 @@ def get_document_handle(path: str) -> Optional[DocumentHandle]:
     if doc_format == '.txt':
         txt_doc = get_txt_handle(path)
         if txt_doc is not None:
-            return DocumentHandle(format=ts.DocumentType.DocumentFormat.TXT, pdf_doc=txt_doc, is_txt=True)
+            return DocumentHandle(format=ts.DocumentType.DocumentFormat.TXT, txt_doc=txt_doc)
 
     return None
 
@@ -91,11 +91,10 @@ def get_markdown_handle(path: str) -> Optional[dict]:
     except Exception:
         return None
 
-def get_txt_handle(path: str) -> Optional[fitz.Document]:
+def get_txt_handle(path: str) -> Optional[str]:
     try:
-        doc = fitz.open(path)
-        # try to read one page
-        next(page for page in doc)
-        return doc
+        with open(path, "r") as f:
+            doc = f.read()
+        return doc if doc is not '' else None
     except Exception:
         return None

--- a/tests/data/documents/pxtbrief.txt
+++ b/tests/data/documents/pxtbrief.txt
@@ -1,0 +1,35 @@
+Pixeltable Briefing Doc
+Source: GitHub Repository: pixeltable/pixeltable
+
+Main Themes:
+
+AI Data Infrastructure: Pixeltable is a Python library designed to simplify the management and processing of multimodal data for machine learning workflows.
+Declarative and Incremental Approach: It provides a declarative interface for data operations and emphasizes incremental updates to avoid redundant computations.
+Multimodal Support: Pixeltable handles various data types like text, images, audio, and video, making it suitable for diverse AI applications.
+
+Key Features and Advantages:
+
+Unified Data Handling: Pixeltable seamlessly integrates data storage, versioning, indexing, and orchestration into a single table interface.
+Computed Columns: Data transformations, model inferences, and custom logic are encapsulated as computed columns, streamlining data manipulation.
+Incremental Updates: Pixeltable tracks data changes and only performs necessary updates, saving time and computational resources.
+Python Integration: Pixeltable integrates seamlessly with existing Python libraries and custom user-defined functions (UDFs).
+Multimodal Workflows: It supports various AI tasks, including computer vision, LLM applications, and multimodal workflows.
+
+Key Quotes:
+
+Declarative, Multimodal, and Incremental: "Pixeltable is a Python library providing a declarative interface for multimodal data (text, images, audio, video). It features built-in versioning, lineage tracking, and incremental updates, enabling users to store, transform, index, and iterate on data for their ML workflows."
+Computed Columns: "Data transformations, model inference, and custom logic are embedded as computed columns."
+Benefits: "It gives you transparency and reproducibility. All generated data is automatically recorded and versioned."
+Cost Efficiency: "It saves you money. All data changes are automatically incremental. You never need to re-run pipelines from scratch because you’re adding data."
+
+Use Cases:
+
+Computer Vision: Frame extraction, object detection, video indexing, annotation management, and model evaluation.
+LLM Workflows: Document chunking, embedding generation, vector search, prompt management, and chain management.
+Multimodal Applications: Unified data storage, cross-modal search, pipeline orchestration, asset management, and quality control.
+Target Audience:
+
+ML Engineers and Data Scientists: Pixeltable simplifies data management, allowing them to focus on model development and application building.
+Conclusion:
+
+Pixeltable offers a powerful and efficient solution for managing and processing multimodal data in AI workflows. Its declarative approach, incremental updates, and seamless Python integration make it a valuable tool for streamlining AI development and enhancing productivity.

--- a/tests/data/documents/pxtfaq.txt
+++ b/tests/data/documents/pxtfaq.txt
@@ -1,0 +1,30 @@
+Pixeltable FAQ
+What is Pixeltable?
+Pixeltable is a Python library designed to simplify the management and processing of multimodal data (text, images, audio, video) for machine learning workflows. It offers a declarative, table-like interface for data storage, transformation, indexing, and retrieval. Key features include built-in versioning, lineage tracking, and incremental updates, making it easier to maintain and iterate on data throughout the ML lifecycle.
+
+What are the key benefits of using Pixeltable?
+Transparency and Reproducibility: All data transformations and generated outputs are automatically tracked and versioned, ensuring transparency and reproducibility of experiments. This eliminates the risk of losing track of data lineage and facilitates collaboration.
+Cost Savings: Pixeltable's incremental update mechanism ensures that only modified data is processed, saving computational resources and time compared to re-running entire pipelines from scratch.
+Integration with Existing Tools: Pixeltable is designed to seamlessly integrate with existing Python libraries and tools. You can leverage your preferred models, frameworks, and AI practices while Pixeltable handles the underlying data infrastructure and orchestration.
+How does Pixeltable handle data transformations and model inference?
+Pixeltable employs a concept called "computed columns" to represent data transformations, model inference, and custom logic. These computed columns are defined declaratively, allowing you to express complex data manipulation steps in a concise and readable manner. Pixeltable automatically manages the execution and caching of these operations, optimizing performance and simplifying your workflow.
+
+What types of data can I work with in Pixeltable?
+Pixeltable supports a wide range of data types, including text, images, audio, and video. It allows you to interact with video data at the frame level and documents at the chunk level. Additionally, Pixeltable is data format agnostic and can access tables as Parquet files, PyTorch datasets, or COCO annotations.
+
+Can I use Pixeltable for multimodal workflows?
+Yes, Pixeltable is specifically designed to handle multimodal workflows. It provides a unified table interface for managing and processing different data types, simplifying cross-modal search and analysis tasks. Pixeltable's native support for similarity search and embedding indexes further enhances its capabilities in this area.
+
+How does Pixeltable compare to traditional approaches for computer vision and LLM workflows?
+Pixeltable simplifies various aspects of computer vision and LLM workflows compared to traditional approaches. For instance, it automates tasks like frame extraction, object detection, video indexing, and document chunking, eliminating the need for custom code and complex pipelines. Moreover, Pixeltable provides built-in support for embedding generation, vector search, and prompt management, streamlining these critical components of LLM applications.
+
+Is Pixeltable a low-code platform or a replacement for existing AI tools?
+Pixeltable is not a low-code platform or a replacement for existing AI tools. It aims to enhance your current toolkit by streamlining the data infrastructure and orchestration layers. It empowers you to leverage your preferred frameworks and techniques while providing a robust and efficient foundation for data management and processing.
+
+How can I contribute to Pixeltable?
+There are several ways to contribute to Pixeltable:
+
+Report Issues: If you encounter bugs or issues, open an issue on the GitHub repository with detailed information for reproduction.
+Submit Changes: Contribute code by forking the repository, creating a feature branch, and submitting a pull request.
+Join the Discussion: Participate in discussions, share your Pixeltable projects and use cases, and help other community members.
+Improve Documentation: Suggest examples, propose improvements, or contribute to tutorials.

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -230,8 +230,10 @@ class TestDocument:
         for md_str in [','.join(t) for t in md_tuples]:
             print(f'{md_str=}')
             chunks_t = pxt.create_view(
-                'chunks', doc_t,
-                iterator=DocumentSplitter.create(document=doc_t.doc, separators='sentence', metadata=md_str))
+                            'chunks', doc_t,
+                            iterator=DocumentSplitter.create(document=doc_t.doc,
+                                                             separators='sentence',
+                                                             metadata=md_str))
             res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
             requested_md_elements = set(md_str.split(','))
             for md_element in md_elements:
@@ -258,10 +260,10 @@ class TestDocument:
         encoding = tiktoken.get_encoding('cl100k_base')
 
         chunks_t = pxt.create_view(
-                'chunks', doc_t,
-                iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                 separators='',
-                                                 metadata='page'))
+                        'chunks', doc_t,
+                        iterator=DocumentSplitter.create(document=doc_t.doc,
+                                                        separators='',
+                                                        metadata='page'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 1
         assert len(res[0]['text']) == 2793
@@ -270,10 +272,10 @@ class TestDocument:
 
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
-                'chunks', doc_t,
-                iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                 separators='paragraph',
-                                                 metadata='page'))
+                        'chunks', doc_t,
+                        iterator=DocumentSplitter.create(document=doc_t.doc,
+                                                        separators='paragraph',
+                                                        metadata='page'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 1
         assert len(res[0]['text']) == 2793
@@ -281,10 +283,10 @@ class TestDocument:
 
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
-                'chunks', doc_t,
-                iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                 separators='sentence',
-                                                 metadata='page'))
+                        'chunks', doc_t,
+                        iterator=DocumentSplitter.create(document=doc_t.doc,
+                                                        separators='sentence',
+                                                        metadata='page'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 23
         assert res[0]['text'] == 'Pixeltable Briefing Doc\nSource: GitHub Repository: pixeltable/pixeltable\n\nMain Themes:\n\nAI Data Infrastructure: Pixeltable is a Python library designed to simplify the management and processing of multimodal data for machine learning workflows.\n'
@@ -294,11 +296,11 @@ class TestDocument:
 
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
-                'chunks', doc_t,
-                iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                 separators='sentence, char_limit',
-                                                 limit=50, overlap=0,
-                                                 metadata='title,heading,sourceline,page,bounding_box'))
+                        'chunks', doc_t,
+                        iterator=DocumentSplitter.create(document=doc_t.doc,
+                                                        separators='sentence, char_limit',
+                                                        limit=50, overlap=0,
+                                                        metadata='title,heading,sourceline,page,bounding_box'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 67
         assert res[0]['text'] == 'Pixeltable Briefing Doc\nSource: GitHub Repository:'

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -126,7 +126,7 @@ class TestDocument:
         skip_test_if_not_installed('spacy')
 
         # DocumentSplitter does not support XML
-        file_paths = [path for path in self.valid_doc_paths() if not (path.endswith('.xml'))]
+        file_paths = [path for path in self.valid_doc_paths() if not path.endswith('.xml')]
         doc_t = pxt.create_table('docs', {'doc': pxt.Document})
         status = doc_t.insert({'doc': p} for p in file_paths)
         assert status.num_excs == 0
@@ -230,10 +230,8 @@ class TestDocument:
         for md_str in [','.join(t) for t in md_tuples]:
             print(f'{md_str=}')
             chunks_t = pxt.create_view(
-                            'chunks', doc_t,
-                            iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                             separators='sentence',
-                                                             metadata=md_str))
+                'chunks', doc_t,
+                iterator=DocumentSplitter.create(document=doc_t.doc, separators='sentence', metadata=md_str))
             res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
             requested_md_elements = set(md_str.split(','))
             for md_element in md_elements:
@@ -256,26 +254,22 @@ class TestDocument:
         doc_t = pxt.create_table('docs', {'doc': pxt.Document})
         status = doc_t.insert({'doc': p} for p in file_paths)
         assert status.num_excs == 0
-        import tiktoken
-        encoding = tiktoken.get_encoding('cl100k_base')
 
         chunks_t = pxt.create_view(
-                        'chunks', doc_t,
-                        iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                        separators='',
-                                                        metadata='page'))
+            'chunks', doc_t,
+            iterator=DocumentSplitter.create(document=doc_t.doc,
+                separators='', metadata='page'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 1
         assert len(res[0]['text']) == 2793
         assert str(res[0]['text']).startswith('Pixeltable Briefing Doc\nSource: GitHub Repository: pixeltable/pixeltable\n')
-        assert res[0]['page'] == None
+        assert res[0]['page'] is None
 
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
-                        'chunks', doc_t,
-                        iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                        separators='paragraph',
-                                                        metadata='page'))
+            'chunks', doc_t,
+            iterator=DocumentSplitter.create(document=doc_t.doc,
+                separators='paragraph', metadata='page'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 1
         assert len(res[0]['text']) == 2793
@@ -283,10 +277,9 @@ class TestDocument:
 
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
-                        'chunks', doc_t,
-                        iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                        separators='sentence',
-                                                        metadata='page'))
+            'chunks', doc_t,
+            iterator=DocumentSplitter.create(document=doc_t.doc,
+                separators='sentence', metadata='page'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 23
         assert res[0]['text'] == 'Pixeltable Briefing Doc\nSource: GitHub Repository: pixeltable/pixeltable\n\nMain Themes:\n\nAI Data Infrastructure: Pixeltable is a Python library designed to simplify the management and processing of multimodal data for machine learning workflows.\n'
@@ -296,11 +289,11 @@ class TestDocument:
 
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
-                        'chunks', doc_t,
-                        iterator=DocumentSplitter.create(document=doc_t.doc,
-                                                        separators='sentence, char_limit',
-                                                        limit=50, overlap=0,
-                                                        metadata='title,heading,sourceline,page,bounding_box'))
+            'chunks', doc_t,
+            iterator=DocumentSplitter.create(document=doc_t.doc,
+                separators='sentence, char_limit',
+                limit=50, overlap=0,
+                metadata='title,heading,sourceline,page,bounding_box'))
         res = chunks_t.order_by(chunks_t.doc, chunks_t.pos).collect()
         assert len(res) == 67
         assert res[0]['text'] == 'Pixeltable Briefing Doc\nSource: GitHub Repository:'
@@ -308,10 +301,9 @@ class TestDocument:
         for r in res:
             assert len(r['text']) <= 50
             assert r['title'] == ''
-            assert r['heading'] == None
-            assert r['sourceline'] == None
-            assert r['page'] == None
+            assert r['heading'] is None
+            assert r['sourceline'] is None
+            assert r['page']is None
             assert r['doc'].endswith('pxtbrief.txt')
 
         pxt.drop_table('chunks')
-

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -242,6 +242,9 @@ class TestDocument:
                         _ = res[md_element]
             pxt.drop_table('chunks')
 
+    # test_doc_splitter above already tests the behaviour
+    # common for all document types. This tests adds specific
+    # verification for .txt file with specific content.
     def test_doc_splitter_txt(self, reset_db) -> None:
         skip_test_if_not_installed('tiktoken')
         skip_test_if_not_installed('spacy')

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -242,14 +242,16 @@ class TestDocument:
                         _ = res[md_element]
             pxt.drop_table('chunks')
 
-    # test_doc_splitter above already tests the behaviour
-    # common for all document types. This tests adds specific
-    # verification for .txt file with specific content.
     def test_doc_splitter_txt(self, reset_db) -> None:
+        ''' Test the DocumentSplitter with a .txt file
+
+        test_doc_splitter above already tests the behaviour
+        common for all document types. This test adds specific
+        verification for a .txt file with specific content.
+        '''
         skip_test_if_not_installed('tiktoken')
         skip_test_if_not_installed('spacy')
 
-        # DocumentSplitter does not support XML
         file_paths = [path for path in self.valid_doc_paths() if path.endswith('pxtbrief.txt')]
         doc_t = pxt.create_table('docs', {'doc': pxt.Document})
         status = doc_t.insert({'doc': p} for p in file_paths)
@@ -265,6 +267,9 @@ class TestDocument:
         assert str(res[0]['text']).startswith('Pixeltable Briefing Doc\nSource: GitHub Repository: pixeltable/pixeltable\n')
         assert res[0]['page'] is None
 
+        # test with different separators.
+        # Until we add support to split text into paragraphs,
+        # the 'paragraph' separator is ignored and has no effect.
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
             'chunks', doc_t,
@@ -275,6 +280,8 @@ class TestDocument:
         assert len(res[0]['text']) == 2793
         assert str(res[0]['text']).startswith('Pixeltable Briefing Doc\nSource: GitHub Repository: pixeltable/pixeltable\n')
 
+        # test with 'sentence' separator
+        # The text is split into 23 sentences.
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
             'chunks', doc_t,
@@ -287,6 +294,8 @@ class TestDocument:
         assert res[22]['text'] == 'Its declarative approach, incremental updates, and seamless Python integration make it a valuable tool for streamlining AI development and enhancing productivity.\n'
         assert len(res[22]['text']) == 163
 
+        # test with 'char_limit' separator
+        # The text is split into 67 chunks, each with a maximum of 50 characters.
         pxt.drop_table('chunks')
         chunks_t = pxt.create_view(
             'chunks', doc_t,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -243,12 +243,12 @@ class TestDocument:
             pxt.drop_table('chunks')
 
     def test_doc_splitter_txt(self, reset_db) -> None:
-        ''' Test the DocumentSplitter with a .txt file
+        """ Test the DocumentSplitter with a .txt file
 
         test_doc_splitter above already tests the behaviour
         common for all document types. This test adds specific
         verification for a .txt file with specific content.
-        '''
+        """
         skip_test_if_not_installed('tiktoken')
         skip_test_if_not_installed('spacy')
 


### PR DESCRIPTION
This commit allows a .txt file to be added as a DocumentType and supports DocumentSplitter for it.

Testing: enhanced existing testcases and added a .txt specific testcase.