### PR TITLE
fix: use != instead of 'is not' for string comparison

### DIFF
--- a/pixeltable/utils/documents.py
+++ b/pixeltable/utils/documents.py
@@ -95,6 +95,6 @@ def get_txt(path: str) -> Optional[str]:
     try:
         with open(path, "r") as f:
             doc = f.read()
-        return doc if doc is not '' else None
+        return doc if doc != '' else None
     except Exception:
         return None


### PR DESCRIPTION
The get_txt function was using 'is not' to compare strings, which checks for object identity rather than value equality. This could lead to unreliable behavior due to Python's string interning. Changed to use != operator for proper string value comparison.