### PR TITLE
Update Expr.id after a call to substitute()

### DIFF
--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -190,6 +190,7 @@ class Expr(abc.ABC):
                 return new.copy()
         for i in range(len(self.components)):
             self.components[i] = self.components[i].substitute(spec)
+        self.id = self._create_id()
         return self
 
     @classmethod

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -346,6 +346,7 @@ class TestFunction:
 
     def test_expr_udf(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
+        t.add_computed_column(other_int=t.c2 + 5)
 
         res1 = t.select(out=self.add1(t.c2)).order_by(t.c2).collect()
         res2 = t.select(t.c2 + 1).order_by(t.c2).collect()
@@ -354,6 +355,11 @@ class TestFunction:
         # return type inferred from expression
         res1 = t.select(out=self.add2(t.c2, t.c2)).order_by(t.c2).collect()
         res2 = t.select(t.c2 * 2).order_by(t.c2).collect()
+        assert_resultset_eq(res1, res2)
+
+        # multiple evaluations of the same expr_udf in the same computation
+        res1 = t.select(out1=self.add1(t.c2), out2=self.add1(t.other_int)).order_by(t.c2).collect()
+        res2 = t.select(t.c2 + 1, t.other_int + 1).order_by(t.c2).collect()
         assert_resultset_eq(res1, res2)
 
         with pytest.raises(TypeError) as exc_info:


### PR DESCRIPTION
Expr.substitute() changes the composition of an Expr, but isn't updating the id. As a result, it's possible to end up with two expressions with the same id but different outputs. This causes Pixeltable to give the wrong answer to statements such as

`t.select(f(t.c1), f(t.c2))`

where `f` is an `@expr_udf`. Here `f(t.c1)` and `f(t.c2)` are distinct substitutions of the same variable expression; before this fix, they would have the same id, and hence be equated in the cache. The `select` statement thus would yield two identical columns, both equal to whichever subexpression was mentioned first.