### PR TITLE
Fixes for PyAV 14

### DIFF
--- a/pixeltable/functions/video.py
+++ b/pixeltable/functions/video.py
@@ -132,7 +132,7 @@ def _get_metadata(path: str) -> dict:
         assert isinstance(container, av.container.InputContainer)
         streams_info = [__get_stream_metadata(stream) for stream in container.streams]
         result = {
-            'bit_exact': container.bit_exact,
+            'bit_exact': getattr(container, 'bit_exact', False),
             'bit_rate': container.bit_rate,
             'size': container.size,
             'metadata': container.metadata,

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -902,7 +902,7 @@ class VideoType(ColumnType):
                 if num_decoded < 2:
                     # this is most likely an image file
                     raise excs.Error(f'Not a valid video: {val}')
-        except av.AVError:
+        except av.FFmpegError:
             raise excs.Error(f'Not a valid video: {val}') from None
 
 
@@ -929,7 +929,7 @@ class AudioType(ColumnType):
                 for packet in container.demux(audio_stream):
                     for _ in packet.decode():
                         pass
-        except av.AVError as e:
+        except av.FFmpegError as e:
             raise excs.Error(f'Not a valid audio file: {val}\n{e}') from None
 
 


### PR DESCRIPTION
Fixes two issues caused by backwards-incompatible changes in PyAV 14.
- audio/video media validation
- audio/video metadata extraction

The changes are tested to work with both PyAV 14 and PyAV 11 (the reference version in our poetry environment).