### PR TITLE
PXT-374: Bug: cannot create an index with the same name as one that e…

### DIFF
--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -494,6 +494,8 @@ class TableVersion:
         idx_md.schema_version_drop = self.schema_version
         assert idx_md.name in self.idxs_by_name
         idx_info = self.idxs_by_name[idx_md.name]
+        # remove this index entry from the active indexes (in memory)
+        # and the index metadata (in persistent table metadata)
         del self.idxs_by_name[idx_md.name]
         del self.idx_md[idx_id]
 

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -495,6 +495,7 @@ class TableVersion:
         assert idx_md.name in self.idxs_by_name
         idx_info = self.idxs_by_name[idx_md.name]
         del self.idxs_by_name[idx_md.name]
+        del self.idx_md[idx_id]
 
         with Env.get().engine.begin() as conn:
             self._drop_columns([idx_info.val_col, idx_info.undo_col])

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -155,26 +155,31 @@ class TestIndex:
         t = small_img_tbl
         sample_img = t.select(t.img).head(1)[0, 'img']
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
+        orig_res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
         t.revert()
         # creating an index with the same name again after a revert should be successful
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
-        _ = t.select(t.img.localpath).order_by(t.img.similarity(sample_img), asc=False).limit(3).collect()
+        res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
+        assert_resultset_eq(orig_res, res, True)
         t.revert()
         # should be true even after reloading from persistence
-        _ = reload_tester.run_reload_test()
+        reload_tester.run_reload_test()
         t = pxt.get_table('small_img_tbl')
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
-        _ = t.select(t.img.localpath).order_by(t.img.similarity(sample_img), asc=False).limit(3).collect()
+        res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
+        assert_resultset_eq(orig_res, res, True)
 
         # same should hold after a drop.
         t.drop_embedding_index(column='img')
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
-        _ = t.select(t.img.localpath).order_by(t.img.similarity(sample_img), asc=False).limit(3).collect()
+        res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
+        assert_resultset_eq(orig_res, res, True)
         t.drop_embedding_index(idx_name='clip_idx')
-        _ = reload_tester.run_reload_test()
+        reload_tester.run_reload_test()
         t = pxt.get_table('small_img_tbl')
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
-        _ = t.select(t.img.localpath).order_by(t.img.similarity(sample_img), asc=False).limit(3).collect()
+        res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
+        assert_resultset_eq(orig_res, res, True)
 
     def test_embedding_basic(self, img_tbl: pxt.Table, test_tbl: pxt.Table, reload_tester: ReloadTester) -> None:
         skip_test_if_not_installed('transformers')

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -149,7 +149,7 @@ class TestIndex:
             _ = t.order_by(t.split.similarity(sample_img)).limit(1).collect()
         assert "was created without the 'image_embed' parameter" in str(exc_info.value).lower()
 
-    def test_add_index_after_drop(self, small_img_tbl: pxt.Table, reload_tester: ReloadTester) -> None:
+    def test_add_index_after_drop(self, small_img_tbl: pxt.Table) -> None:
         """ Test the an index with the same name can be added after the previous one is dropped """
         skip_test_if_not_installed('transformers')
         t = small_img_tbl
@@ -163,7 +163,7 @@ class TestIndex:
         assert_resultset_eq(orig_res, res, True)
         t.revert()
         # should be true even after reloading from persistence
-        reload_tester.run_reload_test()
+        reload_catalog()
         t = pxt.get_table('small_img_tbl')
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
         res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
@@ -175,7 +175,7 @@ class TestIndex:
         res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
         assert_resultset_eq(orig_res, res, True)
         t.drop_embedding_index(idx_name='clip_idx')
-        reload_tester.run_reload_test()
+        reload_catalog()
         t = pxt.get_table('small_img_tbl')
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
         res = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()


### PR DESCRIPTION
…xisted before

When a named index is dropped, and then added again, the add step fails with an assertion that the index is already present in the index metadata. This error persists even on reloading from persistence.

RCA: table_version.drop_index code does not remove the index entry from the index metadata on success. It only removes it from the idxs_by_name.

This commit fixes the bug by updating the index metadata after drop.

Testing: a testcase that reproduced the bug before, passes with fix.