### PR TITLE
PXT-372: Bug: Test-only: Assertion in ReloadTester

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1775,10 +1775,8 @@ class TestTable:
         _ = v.show()
 
         # sanity check persistence
-        #  TODO: debug and fix. PXT-372 tracks this.
-        # t.select commented out because some columns (add2, add3) do not reload successfully.
-        #_ = reload_tester.run_query(t.select())
-        _ = reload_tester.run_query(v.select(v.add4, v.add5))
+        _ = reload_tester.run_query(t.select())
+        _ = reload_tester.run_query(v.select())
 
         _ = reload_tester.run_reload_test()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -405,7 +405,8 @@ def assert_resultset_eq(r1: DataFrameResultSet, r2: DataFrameResultSet, compare_
         s1 = r1[r1_col]
         s2 = r2[r2_col]
         if r1.schema[r1_col].is_float_type():
-            assert np.allclose(np.array(s1), np.array(s2))
+            # To handle None values in float columns, we need to set the dtype and allow NaN comparison
+            assert np.allclose(np.array(s1, dtype=float), np.array(s2, dtype=float), equal_nan=True)
         elif r1.schema[r1_col].is_array_type():
             assert all(np.array_equal(a1, a2) for a1, a2 in zip(s1, s2))
         else:


### PR DESCRIPTION
For some test tables, ReloadTester was resulting in Assertion failure when comparing result sets after reload. Specifically, it ran into the following error from numpy:
TypeError: ufunc 'isfinite' not supported for the input types

RCA: For float columns, we use np.allclose() to compare the result sets. This allows us to compare values that are not exact match, but are equal with some tolerance. For ex, 9.45689 == 9.45688. np.allclose() results in this TypeError when it encounters a value None.

A computed column can run into errors during the computation eithe when it created, or when new data is inserted. At the time of creation, "on_error='ignore'" parameter can be used to ignore the errors. This lets the column value be set to None for rows that ran into errors. That is why for some test tables, ReloadTester ran into the error.

This commit fixed it by adjusting the np.allclose parameters. It explicitly sets the dtype=float so None is converted to NaN and also uses equal_nan=True to allow NaN comparison (by position). Direct value comparison, or array comparison, or result set comparison, work fine with None values.

Testing: a repro test that failed before now passes.