### PR TITLE
PXT-382: Bug: Similarity queries do not work correctly with ReloadTester

### DIFF
--- a/pixeltable/exprs/similarity_expr.py
+++ b/pixeltable/exprs/similarity_expr.py
@@ -23,7 +23,6 @@ class SimilarityExpr(Expr):
         assert item_expr.col_type.is_string_type() or item_expr.col_type.is_image_type()
 
         self.components = [col_ref, item_expr]
-        self.id = self._create_id()
 
         # determine index to use
         idx_info = col_ref.col.get_idx_info()
@@ -54,9 +53,13 @@ class SimilarityExpr(Expr):
             raise excs.Error(
                 f'Embedding index {self.idx_info.name!r} on column {self.idx_info.col.name!r} was created without the '
                 f"'image_embed' parameter and does not support image queries")
+        self.id = self._create_id()
 
     def __repr__(self) -> str:
         return f'{self.components[0]}.similarity({self.components[1]})'
+
+    def _id_attrs(self):
+        return super()._id_attrs() + [('idx_name', self.idx_info.name)]
 
     def default_column_name(self) -> str:
         return 'similarity'
@@ -81,8 +84,12 @@ class SimilarityExpr(Expr):
         # this should never get called
         assert False
 
+    def _as_dict(self) -> dict:
+        return {'idx_name': self.idx_info.name, **super()._as_dict()}
+
     @classmethod
     def _from_dict(cls, d: dict, components: list[Expr]) -> 'SimilarityExpr':
+        iname = d['idx_name'] if 'idx_name' in d else None
         assert len(components) == 2
         assert isinstance(components[0], ColumnRef)
-        return cls(components[0], components[1])
+        return cls(components[0], components[1], idx_name=iname)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,7 +146,22 @@ def img_tbl_exprs(indexed_img_tbl: catalog.Table) -> list[exprs.Expr]:
         t.img.rotate(90).resize([224, 224]),
         t.img.fileurl,
         t.img.localpath,
+    ]
+
+@pytest.fixture(scope='function')
+def sim_exprs_same_idx(indexed_img_tbl: catalog.Table) -> list[exprs.Expr]:
+    t = indexed_img_tbl
+    return [
         t.img.similarity('red truck'),
+        t.img.similarity('red truck', idx='img_idx0')
+    ]
+
+@pytest.fixture(scope='function')
+def sim_exprs_diff_idx(multi_idx_img_tbl: catalog.Table) -> list[exprs.Expr]:
+    t = multi_idx_img_tbl
+    return [
+        t.img.similarity('red truck', idx='img_idx1'),
+        t.img.similarity('red truck', idx='img_idx2'),
     ]
 
 @pytest.fixture(scope='function')
@@ -158,5 +173,14 @@ def indexed_img_tbl(reset_db) -> pxt.Table:
     skip_test_if_not_installed('transformers')
     t = create_img_tbl('indexed_img_tbl', num_rows=40)
     from .utils import clip_img_embed, clip_text_embed
-    t.add_embedding_index('img', metric='cosine', image_embed=clip_img_embed, string_embed=clip_text_embed)
+    t.add_embedding_index('img', idx_name='img_idx0', metric='cosine', image_embed=clip_img_embed, string_embed=clip_text_embed)
+    return t
+
+@pytest.fixture(scope='function')
+def multi_idx_img_tbl(reset_db) -> pxt.Table:
+    skip_test_if_not_installed('transformers')
+    t = create_img_tbl('multi_idx_img_tbl', num_rows=4)
+    from .utils import clip_img_embed, clip_text_embed
+    t.add_embedding_index('img', idx_name='img_idx1', metric='cosine', image_embed=clip_img_embed, string_embed=clip_text_embed)
+    t.add_embedding_index('img', idx_name='img_idx2', metric='cosine', image_embed=clip_img_embed, string_embed=clip_text_embed)
     return t

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,18 +146,11 @@ def img_tbl_exprs(indexed_img_tbl: catalog.Table) -> list[exprs.Expr]:
         t.img.rotate(90).resize([224, 224]),
         t.img.fileurl,
         t.img.localpath,
-    ]
-
-@pytest.fixture(scope='function')
-def sim_exprs_same_idx(indexed_img_tbl: catalog.Table) -> list[exprs.Expr]:
-    t = indexed_img_tbl
-    return [
-        t.img.similarity('red truck'),
         t.img.similarity('red truck', idx='img_idx0')
     ]
 
 @pytest.fixture(scope='function')
-def sim_exprs_diff_idx(multi_idx_img_tbl: catalog.Table) -> list[exprs.Expr]:
+def multi_img_tbl_exprs(multi_idx_img_tbl: catalog.Table) -> list[exprs.Expr]:
     t = multi_idx_img_tbl
     return [
         t.img.similarity('red truck', idx='img_idx1'),

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -865,41 +865,44 @@ class TestExprs:
             _ = t[t.img.nearest('musical instrument')].show(10)
 
     def test_ids(
-            self, test_tbl: catalog.Table, test_tbl_exprs: list[exprs.Expr],
-            img_tbl: catalog.Table, img_tbl_exprs: list[exprs.Expr]
+            self, test_tbl_exprs: list[exprs.Expr], img_tbl_exprs: list[exprs.Expr],
+            sim_exprs_same_idx: list[exprs.Expr], sim_exprs_diff_idx: list[exprs.Expr]
     ) -> None:
         skip_test_if_not_installed('transformers')
         d: dict[int, exprs.Expr] = {}
-        for e in test_tbl_exprs:
+        for e in test_tbl_exprs + img_tbl_exprs + sim_exprs_diff_idx:
             assert e.id is not None
             d[e.id] = e
-        for e in img_tbl_exprs:
+        assert len(d) == len(test_tbl_exprs) + len(img_tbl_exprs) + len(sim_exprs_diff_idx)
+        nexprs_before = len(d)
+        for e in sim_exprs_same_idx:
             assert e.id is not None
             d[e.id] = e
-        assert len(d) == len(test_tbl_exprs) + len(img_tbl_exprs)
+        assert len(d) == nexprs_before + 1
 
     def test_serialization(
-            self, test_tbl_exprs: list[exprs.Expr], img_tbl_exprs: list[exprs.Expr]
+            self, test_tbl_exprs: list[exprs.Expr], img_tbl_exprs: list[exprs.Expr],
+            sim_exprs_same_idx: list[exprs.Expr],  sim_exprs_diff_idx: list[exprs.Expr]
     ) -> None:
         """Test as_dict()/from_dict() (via serialize()/deserialize()) for all exprs."""
         skip_test_if_not_installed('transformers')
-        for e in test_tbl_exprs:
+        for e in test_tbl_exprs + img_tbl_exprs + sim_exprs_same_idx + sim_exprs_diff_idx:
             e_serialized = e.serialize()
             e_deserialized = Expr.deserialize(e_serialized)
             assert e.equals(e_deserialized)
 
-        for e in img_tbl_exprs:
-            e_serialized = e.serialize()
-            e_deserialized = Expr.deserialize(e_serialized)
-            assert e.equals(e_deserialized)
+        serialized_vals = set(e.serialize() for e in sim_exprs_same_idx)
+        assert len(serialized_vals) == 1
+        serialized_vals.clear()
+        serialized_vals.update(e.serialize() for e in sim_exprs_diff_idx)
+        assert len(serialized_vals) == len(sim_exprs_diff_idx)
 
-    def test_print(self, test_tbl_exprs: list[exprs.Expr], img_tbl_exprs: list[exprs.Expr]) -> None:
+    def test_print(self, test_tbl_exprs: list[exprs.Expr], img_tbl_exprs: list[exprs.Expr],
+                   sim_exprs_same_idx: list[exprs.Expr], sim_exprs_diff_idx: list[exprs.Expr]
+    ) -> None:
         skip_test_if_not_installed('transformers')
         _ = pxt.func.FunctionRegistry.get().module_fns
-        for e in test_tbl_exprs:
-            _ = str(e)
-            print(_)
-        for e in img_tbl_exprs:
+        for e in test_tbl_exprs + img_tbl_exprs + sim_exprs_same_idx + sim_exprs_diff_idx:
             _ = str(e)
             print(_)
 

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -872,20 +872,15 @@ class TestExprs:
         sim2 = t1.img.similarity('red truck', idx='img_idx0')
         assert sim1.id == sim2.id
         assert sim1.serialize() == sim2.serialize()
-        # index name should be present in the serialized expression
-        assert 'img_idx0' in sim1.serialize()
-        assert 'img_idx0' in sim2.serialize()
 
         t2 = multi_idx_img_tbl
-        # for a table with multiple embedding index, the index
+        # for a table with multiple embedding indexes, the index
         # to use must be specified to the similarity expression.
-        # So similarity exressions using different index should differ.
+        # So similarity expressions using different indexes should differ.
         sim1 = t2.img.similarity('red truck', idx='img_idx1')
         sim2 = t2.img.similarity('red truck', idx='img_idx2')
         assert sim1.id != sim2.id
         assert sim1.serialize() != sim2.serialize()
-        assert 'img_idx1' in sim1.serialize()
-        assert 'img_idx2' in sim2.serialize()
 
     def test_ids(
         self, test_tbl_exprs: list[exprs.Expr], img_tbl_exprs: list[exprs.Expr],

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -56,11 +56,9 @@ class TestIndex:
         # After the query is serialized, dropping and recreating the index should work
         # on reload, because the index is available again even if it is not the exact
         # same one.
-        # TODO: due to the bug (PXT-374) cannot create index after drop.
-        # So this scenario is commented out until the pending fix (PR#406) is merged.
         # recreate the index
-        #t.add_embedding_index('img', idx_name='img_idx1', metric='cosine', image_embed=clip_img_embed, string_embed=clip_text_embed)
-        #reload_tester.run_reload_test(clear=True)
+        t.add_embedding_index('img', idx_name='img_idx1', metric='cosine', image_embed=clip_img_embed, string_embed=clip_text_embed)
+        reload_tester.run_reload_test(clear=True)
 
     @pytest.mark.parametrize("use_index_name", [True, False])
     def test_similarity(self, use_index_name: bool, small_img_tbl: pxt.Table, reload_tester: ReloadTester) -> None:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -56,7 +56,6 @@ class TestIndex:
         # After the query is serialized, dropping and recreating the index should work
         # on reload, because the index is available again even if it is not the exact
         # same one.
-        # recreate the index
         t.add_embedding_index('img', idx_name='img_idx1', metric='cosine', image_embed=clip_img_embed, string_embed=clip_text_embed)
         reload_tester.run_reload_test(clear=True)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -524,11 +524,11 @@ def make_test_arrow_table(output_path: Path) -> str:
     return str(output_path / 'test.parquet')
 
 
-def assert_img_eq(img1: PIL.Image.Image, img2: PIL.Image.Image) -> None:
-    assert img1.mode == img2.mode
-    assert img1.size == img2.size
+def assert_img_eq(img1: PIL.Image.Image, img2: PIL.Image.Image, context: str) -> None:
+    assert img1.mode == img2.mode, context
+    assert img1.size == img2.size, context
     diff = PIL.ImageChops.difference(img1, img2)
-    assert diff.getbbox() is None
+    assert diff.getbbox() is None, context
 
 
 def reload_catalog() -> None:


### PR DESCRIPTION
When there are multiple embedding indexes on a column, the similarity query must specify the index to use. When such a similarity query with a particular index specified is executed after reloading metadata from persistence via the ReloadTester APIs, it fails to run.

RCA: the index name is passed to the SimilarityExpr as a runtime parameter and is not serialized to persistence as part of the SimilarityExpr. Therefore, on reloading from persistence, the index name information is lost and is set as None. Since there are multiple indexes, the SimilarityExpr fails with an error.

This commit fixes SimilarityExpr to include the index used.

Testing: added coverage for the changes. test repro that failed before, passes with the fix.