### PR TITLE
PXT-388: Change the SQL Engine isolation level to 'REPEATABLE READ'

### DIFF
--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -831,7 +831,7 @@ class TableVersion:
                 if error_if_not_exists:
                     raise excs.Error(f'batch_update(): {len(unmatched_rows)} row(s) not found')
                 if insert_if_not_exists:
-                    insert_status = self.insert(unmatched_rows, None, print_stats=False, fail_on_exception=False)
+                    insert_status = self.insert(unmatched_rows, None, conn=conn, print_stats=False, fail_on_exception=False)
                     result += insert_status
             return result
 

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -357,7 +357,7 @@ class Env:
             self.db_url,
             echo=echo,
             future=True,
-            isolation_level='AUTOCOMMIT',
+            isolation_level='REPEATABLE READ',
             connect_args=connect_args,
         )
         self._logger.info(f'Created SQLAlchemy engine at: {self.db_url}')

--- a/pixeltable/exec/sql_node.py
+++ b/pixeltable/exec/sql_node.py
@@ -262,7 +262,7 @@ class SqlNode(ExecNode):
             explain_str = '\n'.join([str(row) for row in explain_result])
             _logger.debug(f'SqlScanNode explain:\n{explain_str}')
         except Exception as e:
-            _logger.warning(f'EXPLAIN failed')
+            _logger.warning(f'EXPLAIN failed with error: {e}')
 
     def __iter__(self) -> Iterator[DataRowBatch]:
         # run the query; do this here rather than in _open(), exceptions are only expected during iteration

--- a/pixeltable/functions/timestamp.py
+++ b/pixeltable/functions/timestamp.py
@@ -232,7 +232,7 @@ def _(
         sql.cast(day, sql.Integer),
         sql.cast(hour, sql.Integer),
         sql.cast(minute, sql.Integer),
-        sql.cast(second + microsecond / 1000000.0, sql.Double))
+        sql.cast(second + microsecond / 1000000.0, sql.Float))
 
 # @pxt.udf
 # def date(self: datetime) -> datetime:


### PR DESCRIPTION
This commit changes the SQL Engine default isolation level from AUTOCOMMIT to REPEATABLE READ. This exposed two bugs:

1. batch_update() API hangs when if_not_exists='insert'

RCA: In the "insert if not exists" mode, batch_update() translates to two steps: a) update existing rows in the batch to new values, and b) insert non-existing rows in the batch. The code was using two different connection for these two steps. This resulted in a self-deadlock when updating the table metadata row that is common for both steps.

This commit fixes the code to use the same connection for both steps.

2. make_timestamp() resulted in sqlalchemy.exc.InternalError and transcation abort.

RCA: make_timestamp() UDF to SQL conversion was producting wrong SQL query. It cast a value to sql.Double which generates "double" which is not a valid datatype in Postgres and results in an error. Even though the error is seen irrespective of isolation level, for repeated read the connection is lost and xact aborted.

This commit fixes the code to use sql.Float instead.