### PR TITLE
Windows Support: Update Makefile to enforce file creation with -Force option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ setup-install:
 ifeq ($(OS),Windows_NT)
 	@powershell -Command "if (-not (Test-Path '.make-install')) { New-Item -ItemType Directory -Path '.make-install' }"
 else
-	@if [ ! -d ".make-install" ]; then $(MKDIR) .make-install; fi
+	@$(MKDIR) .make-install
 endif
 ifdef CONDA_DEFAULT_ENV
 ifeq ($(CONDA_DEFAULT_ENV),base)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq ($(OS),Windows_NT)
     # Define Windows-specific commands
     SHELL_PREFIX := pwsh.exe
     MKDIR := powershell -Command New-Item -ItemType Directory -Path
-    TOUCH := powershell -Command New-Item -ItemType File -Path
+    TOUCH := powershell -Command New-Item -ItemType File -Path -Force
     RM := powershell -Command Remove-Item -Force
     RMDIR := powershell -Command Remove-Item -Force -Recurse
     SET_ENV := set
@@ -78,13 +78,13 @@ WHISPERX_OK := $(shell python -c "import sys; sys.stdout.write(str(sys.version_i
 	@python -m pip install -qU pip
 	@python -m pip install -q poetry==1.8.4
 	@poetry self add "poetry-dynamic-versioning[plugin]"
-	@$(TOUCH) .make-install/poetry -Force
+	@$(TOUCH) .make-install/poetry
 
 .make-install/deps: poetry.lock
 	@echo "Installing dependencies from poetry ..."
 	@$(SET_ENV) CMAKE_ARGS='-DLLAVA_BUILD=OFF'
 	@poetry install --with dev
-	@$(TOUCH) .make-install/deps -Force
+	@$(TOUCH) .make-install/deps
 
 .make-install/others:
 ifeq ($(YOLOX_OK), True)
@@ -105,7 +105,7 @@ else
 endif
 	@echo "Installing Jupyter kernel ..."
 	@python -m ipykernel install --user --name=$(KERNEL_NAME)
-	@$(TOUCH) .make-install/others -Force
+	@$(TOUCH) .make-install/others
 
 .PHONY: install
 install: setup-install .make-install/poetry .make-install/deps .make-install/others


### PR DESCRIPTION
## Summary
     - Added -Force option to file creation commands in Makefile for Windows compatibility
     - Ensures .make-install/poetry, .make-install/deps, and .make-install/others files are created without errors
     - Improves installation process reliability on Windows systems