### PR TITLE
Fixes for pgserver

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,14 +65,6 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf /opt/hostedtoolcache
           df -h
-      - name: Create user runtime dir
-        if: ${{ matrix.os == 'ubuntu-arm64' || matrix.os == 'ubuntu-x64-t4' }}
-        # pgserver needs this dir, and it doesn't seem to exist on ubuntu-arm64 or t4 instances for some reason.
-        # It seems that on some instances it's /run/user/1000 and on others, /run/user/1001. To be safe, we
-        # ensure that both exist and have proper permissions.
-        run: |
-          sudo mkdir -p /run/user/1000 /run/user/1001
-          sudo chmod a+rwx /run/user/1000 /run/user/1001
       - name: Install conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -149,7 +149,7 @@ jobs:
         if: ${{ matrix.poetry-options != '' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-22.04' }}
         run: python -m pip install git+https://github.com/Megvii-BaseDetection/YOLOX@ac58e0a protobuf==5.27.0
       - name: Install WhisperX
-        if: ${{ matrix.poetry-options != '' && matrix.python-version != '3.13' }}
+        if: ${{ matrix.poetry-options != '' && matrix.python-version != '3.13' && matrix.os != 'ubuntu-x64-t4' }}
         run: python -m pip install git+https://github.com/m-bain/whisperX.git@f2da2f8 typer==0.9.0
       - name: Ensure pytest is installed
         # This is necessary for running the tests without --with dev

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -102,14 +102,6 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf /opt/hostedtoolcache
           df -h
-      - name: Create user runtime dir
-        if: ${{ matrix.os == 'ubuntu-arm64' || matrix.os == 'ubuntu-x64-t4' }}
-        # pgserver needs this dir, and it doesn't seem to exist on ubuntu-arm64 or t4 instances for some reason.
-        # It seems that on some instances it's /run/user/1000 and on others, /run/user/1001. To be safe, we
-        # ensure that both exist and have proper permissions.
-        run: |
-          sudo mkdir -p /run/user/1000 /run/user/1001
-          sudo chmod a+rwx /run/user/1000 /run/user/1001
       - name: Install conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -5533,41 +5533,41 @@ xmp = ["defusedxml"]
 
 [[package]]
 name = "pixeltable-pgserver"
-version = "0.2.8"
+version = "0.2.9"
 description = "Embedded Postgres Server for Pixeltable"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pixeltable_pgserver-0.2.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f53714d5eee98a2f12cd628d05dca0e37a492e267b313ebd8d12cc630aefa473"},
-    {file = "pixeltable_pgserver-0.2.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e7a40da1ec7f50a159e72ce9c31152cd0e092556eae169401d5465c3f02e8bfb"},
-    {file = "pixeltable_pgserver-0.2.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fea2c934a974fa9e478f49c094998c86496483e1bd54f3af06376828368d6fe"},
-    {file = "pixeltable_pgserver-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad13a5944bec656190f2c67e9b554400bef3ce87794c5d41153a37474aaa83a3"},
-    {file = "pixeltable_pgserver-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:a132815cc1b0b16cf44347f282861a01becb75b900523370de185297e41c153b"},
-    {file = "pixeltable_pgserver-0.2.8-cp310-cp310-win_arm64.whl", hash = "sha256:a41c322a363527ecde87cf2f78d2d509b3fc3697ae2c12755ac17d8fcfef81aa"},
-    {file = "pixeltable_pgserver-0.2.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6eb46b34968ce57a25be41aff59b93e8313b919314601481be1e443d6f891c99"},
-    {file = "pixeltable_pgserver-0.2.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d562b1740f5eebfbb0a9d699995082ee2e451a4da9bd1fc7592e33c7b4f8f22"},
-    {file = "pixeltable_pgserver-0.2.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e487fc90bf4f2184532a14822009672fe4063df1cd2b8b6402e7610d11d3aaee"},
-    {file = "pixeltable_pgserver-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d4e0ae7aea1a4b144a5ca01a573de3f295d1493058f09ac14ffc8c86b71c4b4"},
-    {file = "pixeltable_pgserver-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:b11bfcdbf9e62e1a952eafe85e0c7772babb560652953b181d0a05a9d52a7d6e"},
-    {file = "pixeltable_pgserver-0.2.8-cp311-cp311-win_arm64.whl", hash = "sha256:6d2468916efb20fa2842665df4183e773c3962aa949595cee7545e94ace96f51"},
-    {file = "pixeltable_pgserver-0.2.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f78c1aa007aae03621fb64bf9095c3d96e708a7c01d0be51e4a360eab2055213"},
-    {file = "pixeltable_pgserver-0.2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:84edc387bbd17c130cf0bee5a901eba5e68d85ab828979179f31502c13a75e6b"},
-    {file = "pixeltable_pgserver-0.2.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47f2d26d15573335d4abb6bc3523ad42f3abcc671a25e24591475085b090e68a"},
-    {file = "pixeltable_pgserver-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:789a2427aa6e1f79896b4fa2db406c332be2cde3a17cbb31ab0aeb1d636cdb6d"},
-    {file = "pixeltable_pgserver-0.2.8-cp312-cp312-win_amd64.whl", hash = "sha256:aa83db0cc7849343f904276e368216a0f9506dd51e277846cb9aa23cf7cc4dd3"},
-    {file = "pixeltable_pgserver-0.2.8-cp312-cp312-win_arm64.whl", hash = "sha256:79c5430cca87c205826c3eda5220f0bf03dc05a46e58efce29cb835ef530a13f"},
-    {file = "pixeltable_pgserver-0.2.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1971515f8830ddaad6dabd449d9886485fddbd9d7cae49fe82503277cb092451"},
-    {file = "pixeltable_pgserver-0.2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e76af01d70156eb25483f32d2319000df4b229dcbee04023489f98061e58968d"},
-    {file = "pixeltable_pgserver-0.2.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4d16251066b20cf95fdc1d4613a524348c62b969c49ac2604e96e56a30e31a1"},
-    {file = "pixeltable_pgserver-0.2.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae72c1183afee558a603fafa926a93885af8a7182ae5f3030b5de7be47e6ad4d"},
-    {file = "pixeltable_pgserver-0.2.8-cp313-cp313-win_amd64.whl", hash = "sha256:1728bf11c10525a89a95ae5482c5ea26f252bb92bae1201e7c41ecad195f6234"},
-    {file = "pixeltable_pgserver-0.2.8-cp313-cp313-win_arm64.whl", hash = "sha256:d6d815784df3c66300315385789ab2e870ead88d4845a0525b0ed72652eba18f"},
-    {file = "pixeltable_pgserver-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:64609dbd67e677885b8346e60ba4d77a2e376945ed447e702c64c77112ef347c"},
-    {file = "pixeltable_pgserver-0.2.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:78cdde2c562f65dd2a132fd0ba9490c98f0dfd01c1b1f0746ef11ffc58351e1f"},
-    {file = "pixeltable_pgserver-0.2.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7f53853ef7891d3627992a55645d8e089c3ded42fc1219ff95398e65990f634"},
-    {file = "pixeltable_pgserver-0.2.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d61ce35d2ee9aa8b03221a5fe2db91d8d2d32226ad59eed16d98bf12fa62b8"},
-    {file = "pixeltable_pgserver-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:272ea1905530d3b93723cb589640822b21aa66b2790bb42c0f33a1208be922f2"},
-    {file = "pixeltable_pgserver-0.2.8-cp39-cp39-win_arm64.whl", hash = "sha256:37a68d00d8e74119d5c7cf7d8acd2e872d2ea35ead6841ac74a1d4fc4fee1e5b"},
+    {file = "pixeltable_pgserver-0.2.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4bc2aeea52a7ec5266e27a87a2281134b976275818f1459786db5af5b94397eb"},
+    {file = "pixeltable_pgserver-0.2.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5d10cf5e522071a00b9aef82fe3cf3b9ade7e0e027622dc826930db005e4bd8f"},
+    {file = "pixeltable_pgserver-0.2.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:160e3a7070bfc7a5a930b8f9991356f149c3bad8ba0c8e516eb51ec2cd836404"},
+    {file = "pixeltable_pgserver-0.2.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc036fea993e446c802586601ea6ce329d851825577a379ad7b763793db32ce2"},
+    {file = "pixeltable_pgserver-0.2.9-cp310-cp310-win_amd64.whl", hash = "sha256:e4008739380bd076d376a93f1ef8b5201d7f897102344b678c1034d913b5d30f"},
+    {file = "pixeltable_pgserver-0.2.9-cp310-cp310-win_arm64.whl", hash = "sha256:e9a2d5f00baf3ba13e1d857920d10268f89da4c2d285590813bc943c4da77952"},
+    {file = "pixeltable_pgserver-0.2.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7f44ad1cdc828da7cfaa8b3c1d57937572f215cf55483e80d7e2f160b2e933a"},
+    {file = "pixeltable_pgserver-0.2.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1f6c936bdcdd5eaa90f73280c27eb90a75f7d1ed9d2bd1d4886f5f9bf862fe31"},
+    {file = "pixeltable_pgserver-0.2.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c4128c9d150f91fc23e92f1e5dd044900a0fb37bda36ff3a8e786b186761836"},
+    {file = "pixeltable_pgserver-0.2.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68f7a92579936179199b911a3ce361a7bf9ae21e274e6b1b11339d64f4684bac"},
+    {file = "pixeltable_pgserver-0.2.9-cp311-cp311-win_amd64.whl", hash = "sha256:a97360c04f9835f23d252382531f32708bca96b072c3b24855a8d72388cd9c24"},
+    {file = "pixeltable_pgserver-0.2.9-cp311-cp311-win_arm64.whl", hash = "sha256:0182b23f8f06a9195a12f61a4477e66d4ad31d9f0f92cbcf908f90f5ef90c3d7"},
+    {file = "pixeltable_pgserver-0.2.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9601eac289202ab47c3488378af2fd2cd73f2fd2b8652c07dbb296f252d96b7f"},
+    {file = "pixeltable_pgserver-0.2.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:45cda7687fbb3fd83fd439fd33cbd72e6654df346fb5052ccf0b2d7a8d0b4174"},
+    {file = "pixeltable_pgserver-0.2.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2536e59f2d7bd53c35d1ea3e2853e22e1c97732cfd1eddc0d0dcfe8ed6cb440"},
+    {file = "pixeltable_pgserver-0.2.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec9419dd8b445e88a667fd3b5f148d8b199e42988e8f94af5933652cfd68b656"},
+    {file = "pixeltable_pgserver-0.2.9-cp312-cp312-win_amd64.whl", hash = "sha256:c6ca033daa569f2c328ae2fc345bea73039fe87cee342957e99e11e96788b598"},
+    {file = "pixeltable_pgserver-0.2.9-cp312-cp312-win_arm64.whl", hash = "sha256:3b9556110db6693e1055a3106fcf9d27242f7db5678e72dfa385ff6a81594d07"},
+    {file = "pixeltable_pgserver-0.2.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fd9aa97a3bd25f452262577ec4213201afa1b1609a3779b86de00b957688d34"},
+    {file = "pixeltable_pgserver-0.2.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1dc12c0b180a03d02cce8b8059fab34cac24620be0c3d1a6996c06dca03d12b"},
+    {file = "pixeltable_pgserver-0.2.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62ceb999a5c4ca2e82d40955e9b5c786ba3fe0a3c6c4f425c114ce2406fca595"},
+    {file = "pixeltable_pgserver-0.2.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22896c041fc64139a32746b6bc04a5cf29f1c2570f353dfb1edaa74cf9f4daa0"},
+    {file = "pixeltable_pgserver-0.2.9-cp313-cp313-win_amd64.whl", hash = "sha256:b62188637ee8ecf4974944f622b4fd86a79a0afa9cee51fb808a21fde0b30fe8"},
+    {file = "pixeltable_pgserver-0.2.9-cp313-cp313-win_arm64.whl", hash = "sha256:d8faf1c31e24e3914257e711e0a08c28293eaec07e6a6844d25bc19b0967148a"},
+    {file = "pixeltable_pgserver-0.2.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:00911356b802b19f92338e1d9619f639a45da6383cda8e3f07bab75e52ceba7f"},
+    {file = "pixeltable_pgserver-0.2.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46731894318dfcf7bcc0ea4101d62f5dfc5f02e743b2189952331b98b3cec0d6"},
+    {file = "pixeltable_pgserver-0.2.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c7709883c5032c8c47d71a2dc0fe1ae93c603b5c5f0516424a2aa5e871aeb22"},
+    {file = "pixeltable_pgserver-0.2.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e4fea266150df0d7e18078744a6e08ae053fef38338e645755b6b777cdf1d8b"},
+    {file = "pixeltable_pgserver-0.2.9-cp39-cp39-win_amd64.whl", hash = "sha256:c912cd526c13d25a8d5d8072ff8ddd2912de266ce2bd6902f33a8dcd0d353cbf"},
+    {file = "pixeltable_pgserver-0.2.9-cp39-cp39-win_arm64.whl", hash = "sha256:d6b37d10819c4a5987d60f3a3c61a80ba5b49e2ef279ec235b121592e0d2a8ce"},
 ]
 
 [package.dependencies]
@@ -9883,4 +9883,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "f3074e6dc585d25b866250ded9cbfc6cf2221dfcd885881a643e9b8b2d0e4772"
+content-hash = "44acf7c75f1555074b3d0d270bb8004918a605816f853b3ce99643e6bd8f7171"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ tenacity = "^8.2"
 puremagic = ">=1.20"
 pymupdf = "^1.24.1"
 ftfy = "^6.2.0"
-pixeltable-pgserver = "==0.2.8"
+pixeltable-pgserver = "==0.2.9"
 
 [tool.poetry.group.dev]
 optional = true

--- a/tests/functions/test_huggingface.py
+++ b/tests/functions/test_huggingface.py
@@ -147,6 +147,7 @@ class TestHuggingface:
         assert status.num_excs == 0
         verify_row(t.tail(1)[0])
 
+    @pytest.mark.skipif(sysconfig.get_platform() == 'linux-aarch64', reason='Not supported on Linux ARM')
     def test_detr_for_object_detection(self, reset_db) -> None:
         skip_test_if_not_installed('transformers')
         from pixeltable.functions.huggingface import detr_for_object_detection
@@ -166,6 +167,7 @@ class TestHuggingface:
         assert 'bowl' in label_text
         assert 'broccoli' in label_text
 
+    @pytest.mark.skipif(sysconfig.get_platform() == 'linux-aarch64', reason='Not supported on Linux ARM')
     def test_vit_for_image_classification(self, reset_db) -> None:
         skip_test_if_not_installed('transformers')
         from pixeltable.functions.huggingface import vit_for_image_classification


### PR DESCRIPTION
Fixes for two issues with pgserver:
- pgserver fails to initialize on Linux installations where `run/user/$uid` does not exist (#412 / PXT-389)
- pgserver goes into an undefined state if its parent process is terminated on Windows (PXT-370)

Also updates the CI configuration for ubuntu-arm64 and ubuntu-x64-t4 configurations.