### PR TITLE
PXT-373 - Add if_not_exists parameter to drop_* APIs

### DIFF
--- a/pixeltable/catalog/__init__.py
+++ b/pixeltable/catalog/__init__.py
@@ -1,7 +1,7 @@
 from .catalog import Catalog
 from .column import Column
 from .dir import Dir
-from .globals import UpdateStatus, is_valid_identifier, is_valid_path, MediaValidation, IfExistsParam
+from .globals import UpdateStatus, is_valid_identifier, is_valid_path, MediaValidation, IfExistsParam, IfNotExistsParam
 from .insertable_table import InsertableTable
 from .named_function import NamedFunction
 from .path import Path

--- a/pixeltable/catalog/globals.py
+++ b/pixeltable/catalog/globals.py
@@ -66,15 +66,16 @@ class IfExistsParam(enum.Enum):
             raise excs.Error(f'{param_name} must be one of: [{val_strs}]')
 
 class IfNotExistsParam(enum.Enum):
-    ERROR = 'error'
-    IGNORE = 'ignore'
+    ERROR = 0
+    IGNORE = 1
 
     @classmethod
     def validated(cls, param_val: str, param_name: str) -> IfNotExistsParam:
         try:
             return cls[param_val.upper()]
         except KeyError:
-            raise excs.Error(f'{param_name} must be one of: {[e.value for e in cls]}')
+            val_strs = ', '.join(f'{s.lower()!r}' for s in cls.__members__.keys())
+            raise excs.Error(f'{param_name} must be one of: [{val_strs}]')
 
 def is_valid_identifier(name: str) -> bool:
     return name.isidentifier() and not name.startswith('_')

--- a/pixeltable/catalog/globals.py
+++ b/pixeltable/catalog/globals.py
@@ -65,6 +65,17 @@ class IfExistsParam(enum.Enum):
             val_strs = ', '.join(f'{s.lower()!r}' for s in cls.__members__.keys())
             raise excs.Error(f'{param_name} must be one of: [{val_strs}]')
 
+class IfNotExistsParam(enum.Enum):
+    ERROR = 'error'
+    IGNORE = 'ignore'
+
+    @classmethod
+    def validated(cls, param_val: str, param_name: str) -> IfNotExistsParam:
+        try:
+            return cls[param_val.upper()]
+        except KeyError:
+            raise excs.Error(f'{param_name} must be one of: {[e.value for e in cls]}')
+
 def is_valid_identifier(name: str) -> bool:
     return name.isidentifier() and not name.startswith('_')
 

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -702,17 +702,15 @@ class Table(SchemaObject):
             cls._verify_column(col, column_names)
             column_names.add(col.name)
 
-    def __check_column_name_exists(self, column_name: str, include_bases: bool = False, if_not_exists: IfNotExistsParam = IfNotExistsParam.ERROR) -> bool:
+    def __check_column_name_exists(self, column_name: str, include_bases: bool = False) -> None:
         col = self._tbl_version_path.get_column(column_name, include_bases)
-        if col is None and if_not_exists == IfNotExistsParam.ERROR:
+        if col is None:
             raise excs.Error(f'Column {column_name!r} unknown')
-        return col is not None
 
-    def __check_column_ref_exists(self, col_ref: ColumnRef, include_bases: bool = False, if_not_exists: IfNotExistsParam = IfNotExistsParam.ERROR) -> bool:
+    def __check_column_ref_exists(self, col_ref: ColumnRef, include_bases: bool = False) -> None:
         exists = self._tbl_version_path.has_column(col_ref.col, include_bases)
-        if not exists and if_not_exists == IfNotExistsParam.ERROR:
+        if not exists:
             raise excs.Error(f'Unknown column: {col_ref.col.qualified_name}')
-        return exists
 
     def drop_column(self, column: Union[str, ColumnRef], if_not_exists: Literal['error', 'ignore'] = 'error') -> None:
         """Drop a column from the table.
@@ -720,10 +718,10 @@ class Table(SchemaObject):
         Args:
             column: The name or reference of the column to drop.
             if_not_exists: Directive for handling a non-existent column.
+
                 Must be one of the following:
                 - `'error'`: raise an error if the column does not exist.
                 - `'ignore'`: do nothing if the column does not exist.
-                Defaults to `'error'`.
 
         Raises:
             Error: If the column does not exist and `if_exists='error'`,
@@ -746,19 +744,24 @@ class Table(SchemaObject):
             ... tbl.drop_col(tbl.col, if_not_exists='ignore')
         """
         self._check_is_dropped()
-        if self.get_metadata()['is_snapshot']:
+        if self._tbl_version_path.is_snapshot():
             raise excs.Error('Cannot drop column from a snapshot.')
         col: Column = None
         _if_not_exists = IfNotExistsParam.validated(if_not_exists, 'if_not_exists')
         if isinstance(column, str):
-            exists = self.__check_column_name_exists(column, False, _if_not_exists)
-            if not exists and _if_not_exists == IfNotExistsParam.IGNORE:
+            col = self._tbl_version_path.get_column(column, include_bases=False)
+            if col is None:
+                if _if_not_exists == IfNotExistsParam.ERROR:
+                    raise excs.Error(f'Column {column!r} unknown')
+                assert _if_not_exists == IfNotExistsParam.IGNORE
                 return
-            assert exists
             col = self._tbl_version.cols_by_name[column]
         else:
-            exists = self.__check_column_ref_exists(column, False, _if_not_exists)
-            if not exists and _if_not_exists == IfNotExistsParam.IGNORE:
+            exists = self._tbl_version_path.has_column(column.col, include_bases=False)
+            if not exists:
+                if _if_not_exists == IfNotExistsParam.ERROR:
+                    raise excs.Error(f'Unknown column: {column.col.qualified_name}')
+                assert _if_not_exists == IfNotExistsParam.IGNORE
                 return
             col = column.col
 
@@ -868,10 +871,10 @@ class Table(SchemaObject):
             raise excs.Error('Cannot add an index to a snapshot')
         col: Column
         if isinstance(column, str):
-            _ = self.__check_column_name_exists(column, include_bases=True)
+            self.__check_column_name_exists(column, include_bases=True)
             col = self._tbl_version_path.get_column(column, include_bases=True)
         else:
-            _ = self.__check_column_ref_exists(column, include_bases=True)
+            self.__check_column_ref_exists(column, include_bases=True)
             col = column.col
 
         if idx_name is not None and idx_name in self._tbl_version.idxs_by_name:
@@ -900,12 +903,13 @@ class Table(SchemaObject):
                     The column must have only one embedding index.
             idx_name: The name of the index to drop.
             if_not_exists: Directive for handling a non-existent index. Must be one of the following:
+
                 - `'error'`: raise an error if the index does not exist.
                 - `'ignore'`: do nothing if the index does not exist.
-                Defaults to `'error'`.
-                Note that if_not_exists parameter is only applicable when an idx_name is specified
-                and it does not exist, or when column is specified and it has no index.
-                if_not_exists does not apply to non-exisitng column.
+
+                Note that `if_not_exists` parameter is only applicable when an `idx_name` is specified
+                and it does not exist, or when `column` is specified and it has no index.
+                `if_not_exists` does not apply to non-exisitng column.
 
         Raises:
             Error: If `column` is specified, but the column does not exist, or it contains no embedding
@@ -938,10 +942,10 @@ class Table(SchemaObject):
         col: Column = None
         if idx_name is None:
             if isinstance(column, str):
-                _ = self.__check_column_name_exists(column, include_bases=True)
+                self.__check_column_name_exists(column, include_bases=True)
                 col = self._tbl_version_path.get_column(column, include_bases=True)
             else:
-                _ = self.__check_column_ref_exists(column, include_bases=True)
+                self.__check_column_ref_exists(column, include_bases=True)
                 col = column.col
             assert col is not None
         self._drop_index(col=col, idx_name=idx_name, _idx_class=index.EmbeddingIndex, if_not_exists=if_not_exists)
@@ -962,9 +966,10 @@ class Table(SchemaObject):
                     The column must have only one embedding index.
             idx_name: The name of the index to drop.
             if_not_exists: Directive for handling a non-existent index. Must be one of the following:
+
                 - `'error'`: raise an error if the index does not exist.
                 - `'ignore'`: do nothing if the index does not exist.
-                Defaults to `'error'`.
+
                 Note that if_not_exists parameter is only applicable when an idx_name is specified
                 and it does not exist, or when column is specified and it has no index.
                 if_not_exists does not apply to non-exisitng column.
@@ -1000,10 +1005,10 @@ class Table(SchemaObject):
         col: Column = None
         if idx_name is None:
             if isinstance(column, str):
-                _ = self.__check_column_name_exists(column, include_bases=True)
+                self.__check_column_name_exists(column, include_bases=True)
                 col = self._tbl_version_path.get_column(column, include_bases=True)
             else:
-                _ = self.__check_column_ref_exists(column, include_bases=True)
+                self.__check_column_ref_exists(column, include_bases=True)
                 col = column.col
             assert col is not None
         self._drop_index(col=col, idx_name=idx_name, if_not_exists=if_not_exists)

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -969,9 +969,9 @@ class Table(SchemaObject):
                 - `'error'`: raise an error if the index does not exist.
                 - `'ignore'`: do nothing if the index does not exist.
 
-                Note that if_not_exists parameter is only applicable when an idx_name is specified
-                and it does not exist, or when column is specified and it has no index.
-                if_not_exists does not apply to non-exisitng column.
+                Note that `if_not_exists` parameter is only applicable when an `idx_name` is specified
+                and it does not exist, or when `column` is specified and it has no index.
+                `if_not_exists` does not apply to non-exisitng column.
 
         Raises:
             Error: If `column` is specified, but the column does not exist, or it contains no

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -717,9 +717,8 @@ class Table(SchemaObject):
 
         Args:
             column: The name or reference of the column to drop.
-            if_not_exists: Directive for handling a non-existent column.
+            if_not_exists: Directive for handling a non-existent column. Must be one of the following:
 
-                Must be one of the following:
                 - `'error'`: raise an error if the column does not exist.
                 - `'ignore'`: do nothing if the column does not exist.
 

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -117,13 +117,15 @@ def create_table(
 
     Returns:
         A handle to the newly created table, or to an already existing table at the path when `if_exists='ignore'`.
-        Please note the schema of the existing table may not match the schema provided in the call.
+            Please note the schema of the existing table may not match the schema provided in the call.
 
     Raises:
-        Error: if the path is invalid,
-            or if the path already exists and `if_exists='error'`,
-            or if the path already exists and is not a table,
-            or an error occurs while attempting to create the table.
+        Error: if
+
+            - the path is invalid, or
+            - the path already exists and `if_exists='error'`, or
+            - the path already exists and is not a table, or
+            - an error occurs while attempting to create the table.
 
     Examples:
         Create a table with an int and a string column:
@@ -234,10 +236,12 @@ def create_view(
             or the base of the existing view may not match those provided in the call.
 
     Raises:
-        Error: if the path is invalid,
-            or if the path already exists and `if_exists='error'`,
-            or if the path already exists and is not a view,
-            or an error occurs while attempting to create the view.
+        Error: if
+
+            - the path is invalid, or
+            - the path already exists and `if_exists='error'`, or
+            - the path already exists and is not a view, or
+            - an error occurs while attempting to create the view.
 
     Examples:
         Create a view `my_view` of an existing table `my_table`, filtering on rows where `col1` is greater than 10:
@@ -340,13 +344,15 @@ def create_snapshot(
 
     Returns:
         A handle to the [`Table`][pixeltable.Table] representing the newly created snapshot.
-        Please note the schema or base of the existing snapshot may not match those provided in the call.
+            Please note the schema or base of the existing snapshot may not match those provided in the call.
 
     Raises:
-        Error: if the path is invalid,
-            or if the path already exists and `if_exists='error'`,
-            or if the path already exists and is not a snapshot,
-            or an error occurs while attempting to create the snapshot.
+        Error: if
+
+            - the path is invalid, or
+            - the path already exists and `if_exists='error'`, or
+            - the path already exists and is not a snapshot, or
+            - an error occurs while attempting to create the snapshot.
 
     Examples:
         Create a snapshot `my_snapshot` of a table `my_table`:
@@ -454,6 +460,7 @@ def drop_table(table: Union[str, catalog.Table], force: bool = False,
 
     Raises:
         Error: if the qualified name
+
             - is invalid, or
             - does not exist and `if_not_exists='error'`, or
             - does not designate a table object, or
@@ -546,13 +553,15 @@ def create_dir(path_str: str, if_exists: Literal['error', 'ignore', 'replace', '
 
     Returns:
         A handle to the newly created directory, or to an already existing directory at the path when `if_exists='ignore'`.
-        Please note the existing directory may not be empty.
+            Please note the existing directory may not be empty.
 
     Raises:
-        Error: If the path is invalid,
-            or if the path already exists and `if_exists='error'`,
-            or if the path already exists and is not a directory,
-            or an error occurs while attempting to create the directory.
+        Error: If
+
+            - the path is invalid, or
+            - the path already exists and `if_exists='error'`, or
+            - the path already exists and is not a directory, or
+            - an error occurs while attempting to create the directory.
 
     Examples:
         >>> pxt.create_dir('my_dir')
@@ -610,8 +619,12 @@ def drop_dir(path_str: str, force: bool = False, if_not_exists: Literal['error',
             - `'ignore'`: do nothing and return
 
     Raises:
-        Error: If the path is invalid, or does not exist and `if_not_exists='error'`,
-            or is not designate a directory, or if the directory is not empty and `force` is False.
+        Error: If the path
+
+            - is invalid, or
+            - does not exist and `if_not_exists='error'`, or
+            - is not designate a directory, or
+            - is a direcotory but is not empty and `force=False`.
 
     Examples:
         Remove a directory, if it exists and is empty:

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -104,15 +104,16 @@ def create_table(
         num_retained_versions: Number of versions of the table to retain.
         comment: An optional comment; its meaning is user-defined.
         media_validation: Media validation policy for the table.
+
             - `'on_read'`: validate media files at query time
             - `'on_write'`: validate media files during insert/update operations
         if_exists: Directive regarding how to handle if the path already exists.
             Must be one of the following:
+
             - `'error'`: raise an error
             - `'ignore'`: do nothing and return the existing table handle
             - `'replace'`: if the existing table has no views, drop and replace it with a new one
             - `'replace_force'`: drop the existing table and all its views, and create a new one
-            Default is `'error'`.
 
     Returns:
         A handle to the newly created table, or to an already existing table at the path when `if_exists='ignore'`.
@@ -216,15 +217,16 @@ def create_view(
         num_retained_versions: Number of versions of the view to retain.
         comment: Optional comment for the view.
         media_validation: Media validation policy for the view.
+
             - `'on_read'`: validate media files at query time
             - `'on_write'`: validate media files during insert/update operations
         if_exists: Directive regarding how to handle if the path already exists.
             Must be one of the following:
+
             - `'error'`: raise an error
             - `'ignore'`: do nothing and return the existing view handle
             - `'replace'`: if the existing view has no dependents, drop and replace it with a new one
             - `'replace_force'`: drop the existing view and all its dependents, and create a new one
-            Default is `'error'`.
 
     Returns:
         A handle to the [`Table`][pixeltable.Table] representing the newly created view. If the path already
@@ -325,15 +327,16 @@ def create_snapshot(
         num_retained_versions: Number of versions of the view to retain.
         comment: Optional comment for the snapshot.
         media_validation: Media validation policy for the snapshot.
+
             - `'on_read'`: validate media files at query time
             - `'on_write'`: validate media files during insert/update operations
         if_exists: Directive regarding how to handle if the path already exists.
             Must be one of the following:
+
             - `'error'`: raise an error
             - `'ignore'`: do nothing and return the existing snapshot handle
             - `'replace'`: if the existing snapshot has no dependents, drop and replace it with a new one
             - `'replace_force'`: drop the existing snapshot and all its dependents, and create a new one
-            Default is `'error'`.
 
     Returns:
         A handle to the [`Table`][pixeltable.Table] representing the newly created snapshot.
@@ -445,13 +448,16 @@ def drop_table(table: Union[str, catalog.Table], force: bool = False,
         force: If `True`, will also drop all views and sub-views of this table.
         if_not_exists: Directive regarding how to handle if the path does not exist.
             Must be one of the following:
+
             - `'error'`: raise an error
             - `'ignore'`: do nothing and return
-            Default is `'error'`.
 
     Raises:
-        Error: If the name is invalid, or name does not exist and `if_not_exists='error'`,
-            or does not designate a table object, or has dependents and `force='False'`.
+        Error: if the qualified name
+            - is invalid, or
+            - does not exist and `if_not_exists='error'`, or
+            - does not designate a table object, or
+            - designates a table object but has dependents and `force=False`.
 
     Examples:
         Drop a table by its fully qualified name:
@@ -532,11 +538,11 @@ def create_dir(path_str: str, if_exists: Literal['error', 'ignore', 'replace', '
         path_str: Path to the directory.
         if_exists: Directive regarding how to handle if the path already exists.
             Must be one of the following:
+
             - `'error'`: raise an error
             - `'ignore'`: do nothing and return the existing directory handle
             - `'replace'`: if the existing directory is empty, drop it and create a new one
             - `'replace_force'`: drop the existing directory and all its children, and create a new one
-            Default is `'error'`.
 
     Returns:
         A handle to the newly created directory, or to an already existing directory at the path when `if_exists='ignore'`.
@@ -599,9 +605,9 @@ def drop_dir(path_str: str, force: bool = False, if_not_exists: Literal['error',
             with any views or snapshots that depend on any of the dropped tables.
         if_not_exists: Directive regarding how to handle if the path does not exist.
             Must be one of the following:
+
             - `'error'`: raise an error
             - `'ignore'`: do nothing and return
-            Default is `'error'`.
 
     Raises:
         Error: If the path is invalid, or does not exist and `if_not_exists='error'`,

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -152,10 +152,9 @@ class TestDirs:
 
         # if_not_exists='error' should raise error
         # default behavior is to raise error
-        expected_err = r'does not exist'
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r'does not exist'):
             pxt.drop_dir(dir_name, if_not_exists='error')
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r'does not exist'):
             pxt.drop_dir(dir_name)
 
         # if_not_exists='ignore' should be successful but a no-op
@@ -178,22 +177,19 @@ class TestDirs:
         make_tbl('dir1.t1')
 
         # bad name
-        expected_err = r'Invalid path format'
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r'Invalid path format'):
             pxt.drop_dir('1dir')
         # bad path
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r'Invalid path format'):
             pxt.drop_dir('dir1..sub1')
         # doesn't exist
         self._test_drop_if_not_exists('dir2')
         # not empty
-        expected_err = r'is not empty'
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r'is not empty'):
             pxt.drop_dir('dir1')
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r'is not empty'):
             pxt.drop_dir('dir1', if_not_exists='invalid')
-        expected_err = r"needs to be a directory but is a table"
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r"needs to be a directory but is a table"):
             pxt.drop_dir('t1')
 
         pxt.drop_dir('dir1.sub1.subsub1')

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -144,7 +144,34 @@ class TestDirs:
             assert ('already exists' in str(exc_info.value)
                 and 'not a Dir' in str(exc_info.value)), f" for if_exists='{_ie}'"
 
-    def test_rm(self, reset_db) -> None:
+    def _test_drop_if_not_exists(self, dir_name: str) -> None:
+        """ Test if_not_exists parameter of drop_dir """
+        orig_dirs = pxt.list_dirs(recursive=True)
+        # if_not_exists parameter can be used control behavior
+        # of drop_dir when the directory doesn't exist.
+
+        # if_not_exists='error' should raise error
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.drop_dir(dir_name, if_not_exists='error')
+        assert "does not exist" in str(exc_info.value)
+        # default behavior is to raise error
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.drop_dir(dir_name)
+        assert "does not exist" in str(exc_info.value)
+
+        # if_not_exists='ignore' should be successful but a no-op
+        pxt.drop_dir(dir_name, if_not_exists='ignore')
+        assert pxt.list_dirs(recursive=True) == orig_dirs
+        # when force=True, if_not_exists is ignored
+        pxt.drop_dir(dir_name, if_not_exists='error', force=True)
+        assert pxt.list_dirs(recursive=True) == orig_dirs
+        # invalid if_not_exists value is rejected, but only
+        # when the directory doesn't exist.
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.drop_dir(dir_name, if_not_exists='invalid')
+        assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value)
+
+    def test_drop(self, reset_db) -> None:
         dirs = ['dir1', 'dir1.sub1', 'dir1.sub1.subsub1']
         for name in dirs:
             pxt.create_dir(name)
@@ -152,17 +179,26 @@ class TestDirs:
         make_tbl('dir1.t1')
 
         # bad name
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             pxt.drop_dir('1dir')
+        assert 'Invalid path format' in str(exc_info.value)
         # bad path
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             pxt.drop_dir('dir1..sub1')
+        assert 'Invalid path format' in str(exc_info.value)
         # doesn't exist
-        with pytest.raises(excs.Error):
-            pxt.drop_dir('dir2')
+        self._test_drop_if_not_exists('dir2')
         # not empty
-        with pytest.raises(excs.Error):
+        with pytest.raises(excs.Error) as exc_info:
             pxt.drop_dir('dir1')
+        assert "is not empty" in str(exc_info.value)
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.drop_dir('dir1', if_not_exists='invalid')
+        assert "is not empty" in str(exc_info.value)
+        # not a directory
+        with pytest.raises(excs.Error) as exc_info:
+            pxt.drop_dir('t1')
+        assert "needs to be a directory but is a table" in str(exc_info.value)
 
         pxt.drop_dir('dir1.sub1.subsub1')
         assert pxt.list_dirs('dir1.sub1') == []
@@ -171,7 +207,7 @@ class TestDirs:
         reload_catalog()
         assert pxt.list_dirs('dir1.sub1') == []
 
-    def test_rm_force(self, reset_db) -> None:
+    def test_drop_force(self, reset_db) -> None:
         pxt.create_dir('dir1')
         pxt.create_dir('dir2')
         pxt.create_dir('dir1.subdir')

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -1,5 +1,4 @@
 import pytest
-import re
 
 import pixeltable as pxt
 from pixeltable import exceptions as excs
@@ -153,10 +152,10 @@ class TestDirs:
 
         # if_not_exists='error' should raise error
         # default behavior is to raise error
-        expected_err = "does not exist"
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r'does not exist'
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_dir(dir_name, if_not_exists='error')
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_dir(dir_name)
 
         # if_not_exists='ignore' should be successful but a no-op
@@ -179,22 +178,22 @@ class TestDirs:
         make_tbl('dir1.t1')
 
         # bad name
-        expected_err = 'invalid path format'
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r'Invalid path format'
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_dir('1dir')
         # bad path
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_dir('dir1..sub1')
         # doesn't exist
         self._test_drop_if_not_exists('dir2')
         # not empty
-        expected_err = 'is not empty'
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r'is not empty'
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_dir('dir1')
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_dir('dir1', if_not_exists='invalid')
-        expected_err = "needs to be a directory but is a table"
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r"needs to be a directory but is a table"
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_dir('t1')
 
         pxt.drop_dir('dir1.sub1.subsub1')

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -436,9 +436,20 @@ class TestIndex:
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(idx_name='doesnotexist')
         assert "index 'doesnotexist' does not exist" in str(exc_info.value).lower()
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='error')
+        assert "index 'doesnotexist' does not exist" in str(exc_info.value).lower()
+        img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='ignore')
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='invalid')
+        assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
 
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column='doesnotexist')
+        assert "column 'doesnotexist' unknown" in str(exc_info.value).lower()
+        # when dropping an index via a column, if_not_exists does not apply
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index(column='doesnotexist', if_not_exists='invalid')
         assert "column 'doesnotexist' unknown" in str(exc_info.value).lower()
         with pytest.raises(AttributeError) as exc_info:
             img_t.drop_embedding_index(column=img_t.doesnotexist)
@@ -446,6 +457,10 @@ class TestIndex:
 
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column='img')
+        assert "column 'img' does not have an index" in str(exc_info.value).lower()
+        # when dropping an index via a column, if_not_exists does not apply
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index(column='img', if_not_exists='error')
         assert "column 'img' does not have an index" in str(exc_info.value).lower()
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column=img_t.img)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -12,7 +12,8 @@ import pixeltable as pxt
 from pixeltable.functions.huggingface import clip_image, clip_text
 
 from .utils import (assert_img_eq, clip_img_embed, clip_text_embed, e5_embed, reload_catalog,
-                    skip_test_if_not_installed, validate_update_status, ReloadTester, get_sentences, assert_resultset_eq)
+                    skip_test_if_not_installed, validate_update_status, ReloadTester, get_sentences, assert_resultset_eq,
+                    assert_raises_error)
 
 
 class TestIndex:
@@ -429,55 +430,41 @@ class TestIndex:
             img_t.add_embedding_index('category', string_embed=self.bad_embed2)
         assert 'must return a 1d array of a specific length' in str(exc_info.value).lower()
 
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index()
-        assert "exactly one of 'column' or 'idx_name' must be provided" in str(exc_info.value).lower()
+        assert_raises_error("exactly one of 'column' or 'idx_name' must be provided", img_t.drop_embedding_index)
 
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(idx_name='doesnotexist')
-        assert "index 'doesnotexist' does not exist" in str(exc_info.value).lower()
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='error')
-        assert "index 'doesnotexist' does not exist" in str(exc_info.value).lower()
+        expected_err = "index 'doesnotexist' does not exist"
+        assert_raises_error(expected_err, img_t.drop_embedding_index, idx_name='doesnotexist')
+        assert_raises_error(expected_err, img_t.drop_embedding_index, idx_name='doesnotexist', if_not_exists='error')
+
         img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='ignore')
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='invalid')
-        assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
+        assert_raises_error(
+            "if_not_exists must be one of: ['error', 'ignore']",
+            img_t.drop_embedding_index, idx_name='doesnotexist', if_not_exists='invalid'
+        )
 
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column='doesnotexist')
-        assert "column 'doesnotexist' unknown" in str(exc_info.value).lower()
+        expected_err = "column 'doesnotexist' unknown"
+        assert_raises_error(expected_err, img_t.drop_embedding_index, column='doesnotexist')
         # when dropping an index via a column, if_not_exists does not
         # apply to non-existent column; it will still raise error.
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column='doesnotexist', if_not_exists='invalid')
-        assert "column 'doesnotexist' unknown" in str(exc_info.value).lower()
+        assert_raises_error(expected_err, img_t.drop_embedding_index, column='doesnotexist', if_not_exists='invalid')
         with pytest.raises(AttributeError) as exc_info:
             img_t.drop_embedding_index(column=img_t.doesnotexist)
         assert 'column doesnotexist unknown' in str(exc_info.value).lower()
 
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column='img')
-        assert "column 'img' does not have an index" in str(exc_info.value).lower()
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column=img_t.img)
-        assert "column 'img' does not have an index" in str(exc_info.value).lower()
+        expected_err = "column 'img' does not have an index"
+        assert_raises_error(expected_err, img_t.drop_embedding_index, column='img')
+        assert_raises_error(expected_err, img_t.drop_embedding_index, column=img_t.img)
         # when dropping an index via a column, if_not_exists applies if
         # the column does not have any index to drop.
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column='img', if_not_exists='error')
-        assert "column 'img' does not have an index" in str(exc_info.value).lower()
+        assert_raises_error(expected_err, img_t.drop_embedding_index, column='img', if_not_exists='error')
         img_t.drop_embedding_index(column=img_t.img, if_not_exists='ignore')
 
         img_t.add_embedding_index('img', idx_name='embed0', image_embed=clip_img_embed, string_embed=clip_text_embed)
         img_t.add_embedding_index('img', idx_name='embed1', image_embed=clip_img_embed, string_embed=clip_text_embed)
 
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column='img')
-        assert "column 'img' has multiple indices" in str(exc_info.value).lower()
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column=img_t.img)
-        assert "column 'img' has multiple indices" in str(exc_info.value).lower()
+        expected_err = "column 'img' has multiple indices"
+        assert_raises_error(expected_err, img_t.drop_embedding_index, column='img')
+        assert_raises_error(expected_err, img_t.drop_embedding_index, column=img_t.img)
 
         with pytest.raises(pxt.Error) as exc_info:
             sim = img_t.img.similarity('red truck')

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,7 +7,6 @@ from typing import Union, _GenericAlias
 import numpy as np
 import PIL.Image
 import pytest
-import re
 
 import pixeltable as pxt
 from pixeltable.functions.huggingface import clip_image, clip_text
@@ -434,10 +433,10 @@ class TestIndex:
             img_t.drop_embedding_index()
         assert "exactly one of 'column' or 'idx_name' must be provided" in str(exc_info.value).lower()
 
-        expected_err = "index 'doesnotexist' does not exist"
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r"Index 'doesnotexist' does not exist"
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(idx_name='doesnotexist')
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='error')
 
         img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='ignore')
@@ -445,38 +444,38 @@ class TestIndex:
             img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='invalid')
         assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
 
-        expected_err = "column 'doesnotexist' unknown"
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r"Column 'doesnotexist' unknown"
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(column='doesnotexist')
         # when dropping an index via a column, if_not_exists does not
         # apply to non-existent column; it will still raise error.
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(column='doesnotexist', if_not_exists='invalid')
         with pytest.raises(AttributeError) as exc_info:
             img_t.drop_embedding_index(column=img_t.doesnotexist)
         assert 'column doesnotexist unknown' in str(exc_info.value).lower()
 
-        expected_err = "column 'img' does not have an index"
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r"Column 'img' does not have an index"
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(column='img')
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(column=img_t.img)
         # when dropping an index via a column, if_not_exists applies if
         # the column does not have any index to drop.
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(column='img', if_not_exists='error')
         img_t.drop_embedding_index(column=img_t.img, if_not_exists='ignore')
 
         img_t.add_embedding_index('img', idx_name='embed0', image_embed=clip_img_embed, string_embed=clip_text_embed)
         img_t.add_embedding_index('img', idx_name='embed1', image_embed=clip_img_embed, string_embed=clip_text_embed)
 
-        expected_err = "column 'img' has multiple indices"
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r"Column 'img' has multiple indices"
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(column='img')
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(pxt.Error, match=expected_err):
             img_t.drop_embedding_index(column=img_t.img)
 
-        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(pxt.Error, match=expected_err):
             sim = img_t.img.similarity('red truck')
             _ = img_t.order_by(sim, asc=False).limit(1).collect()
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -447,7 +447,8 @@ class TestIndex:
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column='doesnotexist')
         assert "column 'doesnotexist' unknown" in str(exc_info.value).lower()
-        # when dropping an index via a column, if_not_exists does not apply
+        # when dropping an index via a column, if_not_exists does not
+        # apply to non-existent column; it will still raise error.
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column='doesnotexist', if_not_exists='invalid')
         assert "column 'doesnotexist' unknown" in str(exc_info.value).lower()
@@ -458,13 +459,15 @@ class TestIndex:
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column='img')
         assert "column 'img' does not have an index" in str(exc_info.value).lower()
-        # when dropping an index via a column, if_not_exists does not apply
-        with pytest.raises(pxt.Error) as exc_info:
-            img_t.drop_embedding_index(column='img', if_not_exists='error')
-        assert "column 'img' does not have an index" in str(exc_info.value).lower()
         with pytest.raises(pxt.Error) as exc_info:
             img_t.drop_embedding_index(column=img_t.img)
         assert "column 'img' does not have an index" in str(exc_info.value).lower()
+        # when dropping an index via a column, if_not_exists applies if
+        # the column does not have any index to drop.
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index(column='img', if_not_exists='error')
+        assert "column 'img' does not have an index" in str(exc_info.value).lower()
+        img_t.drop_embedding_index(column=img_t.img, if_not_exists='ignore')
 
         img_t.add_embedding_index('img', idx_name='embed0', image_embed=clip_img_embed, string_embed=clip_text_embed)
         img_t.add_embedding_index('img', idx_name='embed1', image_embed=clip_img_embed, string_embed=clip_text_embed)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,13 +7,13 @@ from typing import Union, _GenericAlias
 import numpy as np
 import PIL.Image
 import pytest
+import re
 
 import pixeltable as pxt
 from pixeltable.functions.huggingface import clip_image, clip_text
 
 from .utils import (assert_img_eq, clip_img_embed, clip_text_embed, e5_embed, reload_catalog,
-                    skip_test_if_not_installed, validate_update_status, ReloadTester, get_sentences, assert_resultset_eq,
-                    assert_raises_error)
+                    skip_test_if_not_installed, validate_update_status, ReloadTester, get_sentences, assert_resultset_eq)
 
 
 class TestIndex:
@@ -430,46 +430,55 @@ class TestIndex:
             img_t.add_embedding_index('category', string_embed=self.bad_embed2)
         assert 'must return a 1d array of a specific length' in str(exc_info.value).lower()
 
-        assert_raises_error("exactly one of 'column' or 'idx_name' must be provided", img_t.drop_embedding_index)
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index()
+        assert "exactly one of 'column' or 'idx_name' must be provided" in str(exc_info.value).lower()
 
         expected_err = "index 'doesnotexist' does not exist"
-        assert_raises_error(expected_err, img_t.drop_embedding_index, idx_name='doesnotexist')
-        assert_raises_error(expected_err, img_t.drop_embedding_index, idx_name='doesnotexist', if_not_exists='error')
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(idx_name='doesnotexist')
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='error')
 
         img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='ignore')
-        assert_raises_error(
-            "if_not_exists must be one of: ['error', 'ignore']",
-            img_t.drop_embedding_index, idx_name='doesnotexist', if_not_exists='invalid'
-        )
+        with pytest.raises(pxt.Error) as exc_info:
+            img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='invalid')
+        assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
 
         expected_err = "column 'doesnotexist' unknown"
-        assert_raises_error(expected_err, img_t.drop_embedding_index, column='doesnotexist')
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(column='doesnotexist')
         # when dropping an index via a column, if_not_exists does not
         # apply to non-existent column; it will still raise error.
-        assert_raises_error(expected_err, img_t.drop_embedding_index, column='doesnotexist', if_not_exists='invalid')
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(column='doesnotexist', if_not_exists='invalid')
         with pytest.raises(AttributeError) as exc_info:
             img_t.drop_embedding_index(column=img_t.doesnotexist)
         assert 'column doesnotexist unknown' in str(exc_info.value).lower()
 
         expected_err = "column 'img' does not have an index"
-        assert_raises_error(expected_err, img_t.drop_embedding_index, column='img')
-        assert_raises_error(expected_err, img_t.drop_embedding_index, column=img_t.img)
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(column='img')
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(column=img_t.img)
         # when dropping an index via a column, if_not_exists applies if
         # the column does not have any index to drop.
-        assert_raises_error(expected_err, img_t.drop_embedding_index, column='img', if_not_exists='error')
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(column='img', if_not_exists='error')
         img_t.drop_embedding_index(column=img_t.img, if_not_exists='ignore')
 
         img_t.add_embedding_index('img', idx_name='embed0', image_embed=clip_img_embed, string_embed=clip_text_embed)
         img_t.add_embedding_index('img', idx_name='embed1', image_embed=clip_img_embed, string_embed=clip_text_embed)
 
         expected_err = "column 'img' has multiple indices"
-        assert_raises_error(expected_err, img_t.drop_embedding_index, column='img')
-        assert_raises_error(expected_err, img_t.drop_embedding_index, column=img_t.img)
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(column='img')
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
+            img_t.drop_embedding_index(column=img_t.img)
 
-        with pytest.raises(pxt.Error) as exc_info:
+        with pytest.raises(pxt.Error, match=re.compile(expected_err, re.IGNORECASE)):
             sim = img_t.img.similarity('red truck')
             _ = img_t.order_by(sim, asc=False).limit(1).collect()
-        assert "column 'img' has multiple indices" in str(exc_info.value).lower()
 
     def run_btree_test(self, data: list, data_type: Union[type, _GenericAlias]) -> pxt.Table:
         t = pxt.create_table('btree_test', {'data': data_type})

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -433,10 +433,9 @@ class TestIndex:
             img_t.drop_embedding_index()
         assert "exactly one of 'column' or 'idx_name' must be provided" in str(exc_info.value).lower()
 
-        expected_err = r"Index 'doesnotexist' does not exist"
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Index 'doesnotexist' does not exist"):
             img_t.drop_embedding_index(idx_name='doesnotexist')
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Index 'doesnotexist' does not exist"):
             img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='error')
 
         img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='ignore')
@@ -444,38 +443,35 @@ class TestIndex:
             img_t.drop_embedding_index(idx_name='doesnotexist', if_not_exists='invalid')
         assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
 
-        expected_err = r"Column 'doesnotexist' unknown"
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'doesnotexist' unknown"):
             img_t.drop_embedding_index(column='doesnotexist')
         # when dropping an index via a column, if_not_exists does not
         # apply to non-existent column; it will still raise error.
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'doesnotexist' unknown"):
             img_t.drop_embedding_index(column='doesnotexist', if_not_exists='invalid')
         with pytest.raises(AttributeError) as exc_info:
             img_t.drop_embedding_index(column=img_t.doesnotexist)
         assert 'column doesnotexist unknown' in str(exc_info.value).lower()
 
-        expected_err = r"Column 'img' does not have an index"
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'img' does not have an index"):
             img_t.drop_embedding_index(column='img')
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'img' does not have an index"):
             img_t.drop_embedding_index(column=img_t.img)
         # when dropping an index via a column, if_not_exists applies if
         # the column does not have any index to drop.
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'img' does not have an index"):
             img_t.drop_embedding_index(column='img', if_not_exists='error')
         img_t.drop_embedding_index(column=img_t.img, if_not_exists='ignore')
 
         img_t.add_embedding_index('img', idx_name='embed0', image_embed=clip_img_embed, string_embed=clip_text_embed)
         img_t.add_embedding_index('img', idx_name='embed1', image_embed=clip_img_embed, string_embed=clip_text_embed)
 
-        expected_err = r"Column 'img' has multiple indices"
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'img' has multiple indices"):
             img_t.drop_embedding_index(column='img')
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'img' has multiple indices"):
             img_t.drop_embedding_index(column=img_t.img)
 
-        with pytest.raises(pxt.Error, match=expected_err):
+        with pytest.raises(pxt.Error, match=r"Column 'img' has multiple indices"):
             sim = img_t.img.similarity('red truck')
             _ = img_t.order_by(sim, asc=False).limit(1).collect()
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -10,7 +10,6 @@ import pandas as pd
 import PIL
 import pytest
 from jsonschema.exceptions import ValidationError
-import re
 
 import pixeltable as pxt
 import pixeltable.functions as pxtf
@@ -579,11 +578,11 @@ class TestTable:
         assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
 
         # if_not_exists='error' should raise an error if the table exists
-        expected_err = "does not exist"
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        expected_err = r"does not exist"
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_table(non_existing_t, if_not_exists='error')
         # default behavior is to raise an error if the table does not exist
-        with pytest.raises(excs.Error, match=re.compile(expected_err, re.IGNORECASE)):
+        with pytest.raises(excs.Error, match=expected_err):
             pxt.drop_table(non_existing_t)
         # if_not_exists='ignore' should not raise an error
         pxt.drop_table(non_existing_t, if_not_exists='ignore')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -23,7 +23,8 @@ from pixeltable.utils.media_store import MediaStore
 
 from .utils import (assert_resultset_eq, create_table_data, get_audio_files, get_documents, get_image_files,
                     get_multimedia_commons_video_uris, get_video_files, make_tbl, read_data_file, reload_catalog,
-                    skip_test_if_not_installed, strip_lines, validate_update_status, ReloadTester)
+                    skip_test_if_not_installed, strip_lines, validate_update_status, ReloadTester,
+                    assert_raises_error, get_raised_error)
 
 
 class TestTable:
@@ -567,23 +568,20 @@ class TestTable:
         pxt.drop_table(t, force=True)  # Drops everything else
         assert len(pxt.list_tables()) == 0
 
-    def test_drop_table_if_not_exists_helper(self) -> None:
+    def test_drop_table_if_not_exists(self) -> None:
         """ Test the if_not_exists parameter of drop_table API """
         non_existing_t = 'non_existing_table'
         table_list = pxt.list_tables()
         assert non_existing_t not in table_list
         # invalid if_not_exists value is rejected
-        with pytest.raises(excs.Error) as exc_info:
-            pxt.drop_table(non_existing_t, if_not_exists='invalid')
-        assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value)
+        assert_raises_error(
+            "if_not_exists must be one of: ['error', 'ignore']",
+            pxt.drop_table, non_existing_t, if_not_exists='invalid'
+        )
         # if_not_exists='error' should raise an error if the table exists
-        with pytest.raises(excs.Error) as exc_info:
-            pxt.drop_table(non_existing_t, if_not_exists='error')
-        assert 'does not exist' in str(exc_info.value)
+        assert_raises_error("does not exist", pxt.drop_table, non_existing_t, if_not_exists='error')
         # default behavior is to raise an error if the table does not exist
-        with pytest.raises(excs.Error) as exc_info:
-            pxt.drop_table(non_existing_t)
-        assert 'does not exist' in str(exc_info.value)
+        assert_raises_error("does not exist", pxt.drop_table, non_existing_t)
         # if_not_exists='ignore' should not raise an error
         pxt.drop_table(non_existing_t, if_not_exists='ignore')
         # force=True should not raise an error, irrespective of if_not_exists value
@@ -1804,16 +1802,16 @@ class TestTable:
     def __test_drop_column_if_not_exists(self, t: catalog.Table, non_existing_col: Union[str, ColumnRef]) -> None:
         """ Test the if_not_exists parameter of drop_column API """
         # invalid if_not_exists parameter is rejected
-        with pytest.raises(excs.Error) as exc_info:
-            t.drop_column(non_existing_col, if_not_exists='invalid')
-        assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
+        assert_raises_error(
+            "if_not_exists must be one of: ['error', 'ignore']",
+            t.drop_column, non_existing_col, if_not_exists='invalid'
+        )
         # if_not_exists='error' raises an error if the column does not exist
-        with pytest.raises(excs.Error) as exc_info:
-            t.drop_column(non_existing_col, if_not_exists='error')
+        err_msg = get_raised_error(t.drop_column, non_existing_col, if_not_exists='error')
         if isinstance(non_existing_col, str):
-            assert f"column '{non_existing_col}' unknown" in str(exc_info.value).lower()
+            assert f"column '{non_existing_col}' unknown" in err_msg
         else:
-            assert f"unknown column: {non_existing_col.col.qualified_name}" in str(exc_info.value).lower()
+            assert f"unknown column: {non_existing_col.col.qualified_name}" in err_msg
         # if_not_exists='ignore' does nothing if the column does not exist
         t.drop_column(non_existing_col, if_not_exists='ignore')
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2099,7 +2099,7 @@ class TestTable:
             _ = t.add_embedding_index('c2', string_embed=str.split)
         assert expected_err_msg in str(exc_info.value).lower()
         with pytest.raises(excs.Error) as exc_info:
-            _ = t.drop_embedding_index(column='c2')
+            _ = t.drop_embedding_index(column='c2', if_not_exists='ignore')
         assert expected_err_msg in str(exc_info.value).lower()
         with pytest.raises(excs.Error) as exc_info:
             _ = t.drop_index(column='c2')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -578,11 +578,10 @@ class TestTable:
         assert "if_not_exists must be one of: ['error', 'ignore']" in str(exc_info.value).lower()
 
         # if_not_exists='error' should raise an error if the table exists
-        expected_err = r"does not exist"
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r"does not exist"):
             pxt.drop_table(non_existing_t, if_not_exists='error')
         # default behavior is to raise an error if the table does not exist
-        with pytest.raises(excs.Error, match=expected_err):
+        with pytest.raises(excs.Error, match=r"does not exist"):
             pxt.drop_table(non_existing_t)
         # if_not_exists='ignore' should not raise an error
         pxt.drop_table(non_existing_t, if_not_exists='ignore')

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -16,8 +16,8 @@ class TestVideo:
     def create_tbls(
         self, base_name: str = 'video_tbl', view_name: str = 'frame_view'
     ) -> tuple[catalog.InsertableTable, catalog.Table]:
-        pxt.drop_table(view_name, ignore_errors=True)
-        pxt.drop_table(base_name, ignore_errors=True)
+        pxt.drop_table(view_name, if_not_exists='ignore')
+        pxt.drop_table(base_name, if_not_exists='ignore')
         base_t = pxt.create_table(base_name, {'video': pxt.Video})
         view_t = pxt.create_view(view_name, base_t, iterator=FrameIterator.create(video=base_t.video, fps=1))
         return base_t, view_t

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -530,6 +530,16 @@ def assert_img_eq(img1: PIL.Image.Image, img2: PIL.Image.Image, context: str) ->
     diff = PIL.ImageChops.difference(img1, img2)
     assert diff.getbbox() is None, context
 
+def assert_raises_error(expected_message, func, *args, **kwargs):
+    """ Assert that the function raises an excs.Error with the expected message """
+    err_msg = get_raised_error(func, *args, **kwargs)
+    assert expected_message in err_msg
+
+def get_raised_error(func, *args, **kwargs):
+    """ Assert that the function raises an excs.Error and return the error message """
+    with pytest.raises(excs.Error) as exc_info:
+        func(*args, **kwargs)
+    return str(exc_info.value).lower()
 
 def reload_catalog() -> None:
     catalog.Catalog.clear()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -530,16 +530,6 @@ def assert_img_eq(img1: PIL.Image.Image, img2: PIL.Image.Image, context: str) ->
     diff = PIL.ImageChops.difference(img1, img2)
     assert diff.getbbox() is None, context
 
-def assert_raises_error(expected_message, func, *args, **kwargs):
-    """ Assert that the function raises an excs.Error with the expected message """
-    err_msg = get_raised_error(func, *args, **kwargs)
-    assert expected_message in err_msg
-
-def get_raised_error(func, *args, **kwargs):
-    """ Assert that the function raises an excs.Error and return the error message """
-    with pytest.raises(excs.Error) as exc_info:
-        func(*args, **kwargs)
-    return str(exc_info.value).lower()
 
 def reload_catalog() -> None:
     catalog.Catalog.clear()


### PR DESCRIPTION
This commit adds a new parameter - if_not_exists - to the drop_dir, drop_table,
drop_embedding_index, drop_index and drop_column APIs. This can be used to
direct the API to either raise an error or do nothing and return when a dir/table/index/column
does not exist.

Testing: added new test for the new parameter.