### PR TITLE
PXT-371: add table context to ColumnRef

### DIFF
--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -140,7 +140,7 @@ class Table(SchemaObject):
     def __getattr__(self, name: str) -> 'pxt.exprs.ColumnRef':
         """Return a ColumnRef for the given name.
         """
-        return self._tbl_version_path.get_column_ref(name)
+        return self._tbl_version_path.get_column_ref(name, self._tbl_version_path.tbl_version)
 
     @overload
     def __getitem__(self, name: str) -> 'pxt.exprs.ColumnRef': ...

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -140,7 +140,7 @@ class Table(SchemaObject):
     def __getattr__(self, name: str) -> 'pxt.exprs.ColumnRef':
         """Return a ColumnRef for the given name.
         """
-        return self._tbl_version_path.get_column_ref(name, self._tbl_version_path.tbl_version)
+        return self._tbl_version_path.get_column_ref(name, self._tbl_version_path)
 
     @overload
     def __getitem__(self, name: str) -> 'pxt.exprs.ColumnRef': ...

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -483,6 +483,12 @@ class TableVersion:
 
         return status
 
+    def _get_embedding_idx_info(self, col: Column) -> dict[str, IndexInfo]:
+        return {
+            name: info for name, info in self.idxs_by_name.items()
+            if info.col == col and isinstance(info.idx, index.EmbeddingIndex)
+        }
+
     def drop_index(self, idx_id: int) -> None:
         assert not self.is_snapshot
         assert idx_id in self.idx_md

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -81,15 +81,16 @@ class TableVersionPath:
             return None
         return self.base.find_tbl_version(id)
 
-    def get_column_ref(self, col_name: str) -> exprs.ColumnRef:
+    def get_column_ref(self, col_name: str, _context: Optional[TableVersion] = None) -> exprs.ColumnRef:
         """Return a ColumnRef for the given column name."""
         from pixeltable.exprs import ColumnRef
         if col_name not in self.tbl_version.cols_by_name:
             if self.base is None:
                 raise AttributeError(f'Column {col_name} unknown')
-            return self.base.get_column_ref(col_name)
+            return self.base.get_column_ref(col_name, _context)
         col = self.tbl_version.cols_by_name[col_name]
-        return ColumnRef(col)
+        _context_tbl_version = _context if _context is not None else self.tbl_version
+        return ColumnRef(col, tbl_context=_context_tbl_version)
 
     def columns(self) -> list[Column]:
         """Return all user columns visible in this tbl version path, including columns from bases"""

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -81,7 +81,7 @@ class TableVersionPath:
             return None
         return self.base.find_tbl_version(id)
 
-    def get_column_ref(self, col_name: str, _context: Optional[TableVersion] = None) -> exprs.ColumnRef:
+    def get_column_ref(self, col_name: str, _context: Optional[TableVersionPath] = None) -> exprs.ColumnRef:
         """Return a ColumnRef for the given column name."""
         from pixeltable.exprs import ColumnRef
         if col_name not in self.tbl_version.cols_by_name:
@@ -89,8 +89,8 @@ class TableVersionPath:
                 raise AttributeError(f'Column {col_name} unknown')
             return self.base.get_column_ref(col_name, _context)
         col = self.tbl_version.cols_by_name[col_name]
-        _context_tbl_version = _context if _context is not None else self.tbl_version
-        return ColumnRef(col, tbl_context=_context_tbl_version)
+        _context_tbl_version_path = _context if _context is not None else self
+        return ColumnRef(col, tbl_context=_context_tbl_version_path)
 
     def columns(self) -> list[Column]:
         """Return all user columns visible in this tbl version path, including columns from bases"""

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -183,7 +183,7 @@ class DataFrame:
             a pair composed of the list of expressions and the list of corresponding names
         """
         if select_list is None:
-            select_list = [(exprs.ColumnRef(col), None) for tbl in tbls for col in tbl.columns()]
+            select_list = [(exprs.ColumnRef(col, tbl_context=tbl), None) for tbl in tbls for col in tbl.columns()]
 
         out_exprs: list[exprs.Expr] = []
         out_names: list[str] = []  # keep track of order
@@ -649,7 +649,7 @@ class DataFrame:
             rhs_col = other.get_column(col_ref.col.name, include_bases=True)
             if rhs_col is None:
                 raise excs.Error(f"'on': column {col_ref.col.name!r} not found in joined table")
-            rhs_col_ref = exprs.ColumnRef(rhs_col)
+            rhs_col_ref = exprs.ColumnRef(rhs_col, tbl_context=other)
 
             lhs_col_ref: Optional[exprs.ColumnRef] = None
             if any(tbl.has_column(col_ref.col, include_bases=True) for tbl in self._from_clause.tbls):
@@ -663,7 +663,7 @@ class DataFrame:
                         continue
                     if lhs_col_ref is not None:
                         raise excs.Error(f"'on': ambiguous column reference: {col_ref.col.name!r}")
-                    lhs_col_ref = exprs.ColumnRef(col)
+                    lhs_col_ref = exprs.ColumnRef(col, tbl_context=tbl)
                 if lhs_col_ref is None:
                     tbl_names = [tbl.tbl_name() for tbl in self._from_clause.tbls]
                     raise excs.Error(

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -221,6 +221,15 @@ class ColumnRef(Expr):
         res = next(self.iterator)
         data_row[self.slot_idx] = res[self.col.name]
 
+    def get_idx_info(self) -> dict[str, 'TableVersion.IndexInfo']:
+        assert self.col is not None
+        assert self.tbl_context is not None
+        idx_info = {name: info for name, info in self.tbl_context.idxs_by_name.items() if info.col == self.col}
+        print(f'----> DEBUG_A: ColumnRef.get_idx_info() {self.col.name} {self.tbl_context.name} {self.col.tbl.name} len(idx_info)={len(idx_info)}')
+        if len(idx_info) == 0:
+            return self.col.get_idx_info()
+        return idx_info
+
     def _as_dict(self) -> dict:
         tbl = self.col.tbl
         version = tbl.version if tbl.is_snapshot else None

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -92,7 +92,7 @@ class ColumnRef(Expr):
     def _id_attrs(self) -> list[tuple[str, Any]]:
         return (
             super()._id_attrs()
-            + [('tbl_id', self.col.tbl.id), ('col_id', self.col.id), ('perform_validation', self.perform_validation), ('tbl_context', self.tbl_context.id)]
+            + [('tbl_id', self.col.tbl.id), ('col_id', self.col.id), ('perform_validation', self.perform_validation)]#, ('tbl_context', self.tbl_context.id)]
         )
 
     # override

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, TYPE_CHECKING
 from uuid import UUID
 
 import sqlalchemy as sql
@@ -16,6 +16,8 @@ from .expr import Expr
 from .row_builder import RowBuilder
 from .sql_element_cache import SqlElementCache
 
+if TYPE_CHECKING:
+    from ..catalog import TableVersion
 
 class ColumnRef(Expr):
     """A reference to a table column
@@ -46,11 +48,16 @@ class ColumnRef(Expr):
     pos_idx: Optional[int]
     id: int
     perform_validation: bool  # if True, performs media validation
+    tbl_context: Optional[TableVersion]
 
-    def __init__(self, col: catalog.Column, perform_validation: Optional[bool] = None):
+    def __init__(self, col: catalog.Column, perform_validation: Optional[bool] = None, tbl_context: Optional[TableVersion] = None):
         super().__init__(col.col_type)
         assert col.tbl is not None
         self.col = col
+        if tbl_context is not None:
+            self.tbl_context = tbl_context
+        else:
+            self.tbl_context = col.tbl
         self.is_unstored_iter_col = \
             col.tbl.is_component_view() and col.tbl.is_iterator_column(col) and not col.is_stored
         self.iter_arg_ctx = None

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -75,7 +75,7 @@ class ColumnRef(Expr):
         else:
             assert perform_validation is None or not perform_validation
         if self.perform_validation:
-            non_validating_col_ref = ColumnRef(col, perform_validation=False)
+            non_validating_col_ref = ColumnRef(col, perform_validation=False, tbl_context=self.tbl_context)
             self.components = [non_validating_col_ref]
         self.id = self._create_id()
 

--- a/pixeltable/exprs/similarity_expr.py
+++ b/pixeltable/exprs/similarity_expr.py
@@ -25,15 +25,12 @@ class SimilarityExpr(Expr):
         self.components = [col_ref, item_expr]
 
         # determine index to use
-        idx_info = col_ref.get_idx_info()
+        embedding_idx_info = col_ref.get_idx_info(idx_name)
         from pixeltable import index
-        embedding_idx_info = {
-            info.name: info for info in idx_info.values() if isinstance(info.idx, index.EmbeddingIndex)
-        }
         if len(embedding_idx_info) == 0:
             raise excs.Error(f'No index found for column {col_ref.col!r}')
-        if idx_name is not None and idx_name not in embedding_idx_info:
-            raise excs.Error(f'Index {idx_name!r} not found for column {col_ref.col.name!r}')
+        if idx_name is not None:
+            assert idx_name in embedding_idx_info
         if len(embedding_idx_info) > 1:
             if idx_name is None:
                 raise excs.Error(

--- a/pixeltable/exprs/similarity_expr.py
+++ b/pixeltable/exprs/similarity_expr.py
@@ -25,7 +25,7 @@ class SimilarityExpr(Expr):
         self.components = [col_ref, item_expr]
 
         # determine index to use
-        idx_info = col_ref.col.get_idx_info()
+        idx_info = col_ref.get_idx_info()
         from pixeltable import index
         embedding_idx_info = {
             info.name: info for info in idx_info.values() if isinstance(info.idx, index.EmbeddingIndex)

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -482,7 +482,7 @@ class Planner:
         # retrieve all stored cols and all target exprs
         recomputed_cols = set(recompute_targets.copy())
         copied_cols = [col for col in target.cols_by_id.values() if col.is_stored and not col in recomputed_cols]
-        select_list: list[exprs.Expr] = [exprs.ColumnRef(col) for col in copied_cols]
+        select_list: list[exprs.Expr] = [exprs.ColumnRef(col, tbl_context=view) for col in copied_cols]
         # resolve recomputed exprs to stored columns in the base
         recomputed_exprs = \
             [c.value_expr.copy().resolve_computed_cols(resolve_cols=recomputed_cols) for c in recomputed_cols]

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -359,13 +359,13 @@ class Planner:
             col for col in target.cols_by_id.values()
             if col.is_stored and not col in updated_cols and not col in recomputed_base_cols
         ]
-        select_list: list[exprs.Expr] = [exprs.ColumnRef(col) for col in copied_cols]
+        select_list: list[exprs.Expr] = [exprs.ColumnRef(col, tbl_context=tbl) for col in copied_cols]
         select_list.extend(update_targets.values())
 
         recomputed_exprs = \
             [c.value_expr.copy().resolve_computed_cols(resolve_cols=recomputed_base_cols) for c in recomputed_base_cols]
         # recomputed cols reference the new values of the updated cols
-        spec: dict[exprs.Expr, exprs.Expr] = {exprs.ColumnRef(col): e for col, e in update_targets.items()}
+        spec: dict[exprs.Expr, exprs.Expr] = {exprs.ColumnRef(col, tbl_context=tbl): e for col, e in update_targets.items()}
         exprs.Expr.list_substitute(recomputed_exprs, spec)
         select_list.extend(recomputed_exprs)
 
@@ -417,8 +417,8 @@ class Planner:
             col for col in target.cols_by_id.values()
             if col.is_stored and not col in updated_cols and not col in recomputed_base_cols
         ]
-        select_list: list[exprs.Expr] = [exprs.ColumnRef(col) for col in copied_cols]
-        select_list.extend(exprs.ColumnRef(col) for col in updated_cols)
+        select_list: list[exprs.Expr] = [exprs.ColumnRef(col, tbl_context=tbl) for col in copied_cols]
+        select_list.extend(exprs.ColumnRef(col, tbl_context=tbl) for col in updated_cols)
 
         recomputed_exprs = \
             [c.value_expr.copy().resolve_computed_cols(resolve_cols=recomputed_base_cols) for c in recomputed_base_cols]

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -117,12 +117,15 @@ class TestExprs:
         assert colref.col.tbl.name == 'test_view'
         assert colref.tbl_context.name == 'test_view'
         assert v.select(v.v1).count() == 10
+        assert v.v1.count() == 10
 
         colref = v.c2
         assert colref.col.tbl.name == 'test_tbl'
         assert colref.tbl_context.name == 'test_view'
-        assert v.select(v.c2).count() == 10 # should be 10, but is 100?
+        assert v.select(v.c2).count() == 10
         assert v.select(v.c2).head(5)['c2'] == [90, 91, 92, 93, 94]
+        assert v.c2.count() == 10 # should be 10, but is 100?
+        assert v.c2.head(5)['c2'] == [90, 91, 92, 93, 94] # should be [90, 91, 92, 93, 94], but is [0, 1, 2, 3, 4]?
 
     def test_compound_predicates(self, test_tbl: catalog.Table) -> None:
         t = test_tbl

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -190,8 +190,23 @@ class TestExprs:
         assert s3.select(s3.c2).head(3)['c2'] == [90, 91, 92]
         assert s3.c2.count() == 10
         assert s3.c2.head(3)['c2'] == [90, 91, 92]
-        # assert exc_info == "Expression 'c2' cannot be evaluated in the context of this query's tables (test_view)"
         _ = reload_tester.run_query(s3.select(s3.v1, s3.c2))
+
+        # the tbl_context has no impact on the id and equality
+        assert t.c2.id == v.c2.id
+        assert t.c2.id == s.c2.id
+        assert t.c2.id == s2.c2.id
+        assert t.c2.id == s3.c2.id
+        assert t.c2.equals(v.c2)
+        assert t.c2.equals(s.c2)
+        assert t.c2.equals(s2.c2)
+        assert t.c2.equals(s3.c2)
+        # the tbl_context is persisted and so the expressions
+        # will differ when serialized
+        assert t.c2.serialize() != v.c2.serialize()
+        assert t.c2.serialize() != s.c2.serialize()
+        assert t.c2.serialize() != s2.c2.serialize()
+        assert t.c2.serialize() != s3.c2.serialize()
 
         reload_tester.run_reload_test()
 

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -104,7 +104,7 @@ class TestExprs:
 
     def _verify_colref(self, colref: ColumnRef, col_tbl_name: str, context_tbl_name: str) -> None:
         assert colref.col.tbl.name == col_tbl_name
-        assert colref.tbl_context.name == context_tbl_name
+        assert colref.tbl_context.tbl_name() == context_tbl_name
 
     def test_column_ref_context(self, test_tbl: catalog.Table, reload_tester: ReloadTester) -> None:
         """ Test the table context is setup and works as expected for ColumnRef expression"""
@@ -188,11 +188,8 @@ class TestExprs:
 
         assert s3.select(s3.c2).count() == 10
         assert s3.select(s3.c2).head(3)['c2'] == [90, 91, 92]
-        # not working, raises an exception that c2 is not found in test_view.
-        # looks like a effective version not set issue.
-        with pytest.raises(excs.Error) as exc_info:
-            assert s3.c2.count() == 10
-            assert s3.c2.head(3)['c2'] == [90, 91, 92]
+        assert s3.c2.count() == 10
+        assert s3.c2.head(3)['c2'] == [90, 91, 92]
         # assert exc_info == "Expression 'c2' cannot be evaluated in the context of this query's tables (test_view)"
         _ = reload_tester.run_query(s3.select(s3.v1, s3.c2))
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -363,11 +363,11 @@ class TestIndex:
         v.add_embedding_index(v.s, string_embed=pxt.functions.huggingface.sentence_transformer.using(model_id='all-mpnet-base-v2'))
         v.add_embedding_index(t.s, string_embed=pxt.functions.huggingface.sentence_transformer.using(model_id='all-mpnet-base-v2'))
         # Expected to verify the following:
-        # df = v.select(sim=v.s.similarity(sents[1]))
-        # res2 = df.collect()
-        # assert_resultset_eq(res1, res2)
+        df = v.select(sim=v.s.similarity(sents[1], idx='idx1'))
+        res2 = df.collect()
+        assert_resultset_eq(res1, res2)
         # and
-        # _ = reload_tester.run_query(df)
+        #_ = reload_tester.run_query(df)
         #
         # But found a bug, instead. PXT-371 tracks this.
         # RCA: The indexes above are on the view, not the base table.
@@ -376,9 +376,11 @@ class TestIndex:
         # the table in the ColumnRef, which is the base table.
         # So it raises error that there's no index.
         # Fix needs discussion.
-        with pytest.raises(pxt.Error) as exc_info:
-            df = v.select(sim=v.s.similarity(sents[1]))
-        assert 'no index found for column' in str(exc_info.value).lower()
+        #with pytest.raises(pxt.Error) as exc_info:
+        df = v.select(sim=v.s.similarity(sents[1], idx='idx2'))
+        res2 = df.collect()
+        assert_resultset_eq(res1, res2)
+        #assert 'no index found for column' in str(exc_info.value).lower()
         _ = reload_tester.run_query(v.select())
 
         _ = reload_tester.run_reload_test()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -367,7 +367,7 @@ class TestIndex:
         res2 = df.collect()
         assert_resultset_eq(res1, res2)
         # and
-        #_ = reload_tester.run_query(df)
+        _ = reload_tester.run_query(df)
         #
         # But found a bug, instead. PXT-371 tracks this.
         # RCA: The indexes above are on the view, not the base table.
@@ -380,6 +380,11 @@ class TestIndex:
         df = v.select(sim=v.s.similarity(sents[1], idx='idx2'))
         res2 = df.collect()
         assert_resultset_eq(res1, res2)
+        _ = reload_tester.run_query(df)
+        df = v.select(sim=v.s.similarity(sents[1], idx='idx0'))
+        res2 = df.collect()
+        assert_resultset_eq(res1, res2)
+        _ = reload_tester.run_query(df)
         #assert 'no index found for column' in str(exc_info.value).lower()
         _ = reload_tester.run_query(v.select())
 


### PR DESCRIPTION
A column in the base table can be referenced by the table
or a view/snapshot derived from it. This commit adds a table
context to the ColumnRef expression to differentiate the context
in which the column is being used/referenced. 
This is currently needed to select the right embedding index on 
a base column, and to produce the right result when a column is
queried directly (v.colname.show()).
The table context is not used anywhere else.