### PR TITLE
Terminology: use 'aggregate' in place of 'aggregator' in UDF docs

### DIFF
--- a/docs/notebooks/feature-guides/udfs-in-pixeltable.ipynb
+++ b/docs/notebooks/feature-guides/udfs-in-pixeltable.ipynb
@@ -750,7 +750,7 @@
    "id": "7adafc69-dcf8-4f63-9010-db42d5ac3516",
    "metadata": {},
    "source": [
-    "## UDAs (Aggregator UDFs)"
+    "## UDAs (Aggregate UDFs)"
    ]
   },
   {
@@ -758,7 +758,7 @@
    "id": "41270cf1-48b2-4746-a526-030d2fa0256a",
    "metadata": {},
    "source": [
-    "Ordinary UDFs are always one-to-one on rows: each row of input generates one UDF output value. Functions that aggregate data, conversely, are many-to-one, and in Pixeltable they are represented by a related abstraction, the UDA (<i>U</i>ser-<i>D</i>efined <i>A</i>ggregator). Pixeltable has a number of built-in aggregators; if you've worked through the Fundamentals tutorial, you'll have already encountered a few of them, such as `sum` and `count`. In this section, we'll show how to define your own custom UDAs. For demonstration purposes, let's start by creating a table containing all the integers from 0 to 49."
+    "Ordinary UDFs are always one-to-one on rows: each row of input generates one UDF output value. Functions that aggregate data, conversely, are many-to-one, and in Pixeltable they are represented by a related abstraction, the UDA (<i>U</i>ser-<i>D</i>efined <i>A</i>ggregate). Pixeltable has a number of built-in UDAs; if you've worked through the Fundamentals tutorial, you'll have already encountered a few of them, such as `sum` and `count`. In this section, we'll show how to define your own custom UDAs. For demonstration purposes, let's start by creating a table containing all the integers from 0 to 49."
    ]
   },
   {
@@ -799,7 +799,7 @@
    "id": "8bdf4c2b-8ccc-4ab4-8ae0-3612f0a95654",
    "metadata": {},
    "source": [
-    "If we wanted to compute their sum using the built-in `sum` aggregator, we'd do it like this:"
+    "If we wanted to compute their sum using the built-in `sum` aggregate, we'd do it like this:"
    ]
   },
   {
@@ -913,7 +913,7 @@
    "id": "1f96d6c6-9524-452a-a12f-9006b426fe12",
    "metadata": {},
    "source": [
-    "Now let's define a new aggregator to compute the sum of squares of a set of numbers. To define an aggregator, we implement a subclass of the `pxt.Aggregator` Python class and decorate it with the `@pxt.uda` decorator, similar to what we did for UDFs. The subclass must implement three methods:\n",
+    "Now let's define a new aggregate to compute the sum of squares of a set of numbers. To define an aggregate, we implement a subclass of the `pxt.Aggregator` Python class and decorate it with the `@pxt.uda` decorator, similar to what we did for UDFs. The subclass must implement three methods:\n",
     "\n",
     "- `__init__()` - initializes the aggregator; can be used to parameterize aggregator behavior\n",
     "- `update()` - updates the internal state of the aggregator with a new value\n",


### PR DESCRIPTION
Standardizing as follows: the operation is an "aggregate"; the class instance that carries out the operation is an "aggregator".