### PR TITLE
PXT-0244: Correct validity of col error properties

### DIFF
--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -101,7 +101,8 @@ class ColumnRef(Expr):
         # resolve column properties
         if name == ColumnPropertyRef.Property.ERRORTYPE.name.lower() \
                 or name == ColumnPropertyRef.Property.ERRORMSG.name.lower():
-            if not (self.col.is_computed and self.col.is_stored) and not self.col.col_type.is_media_type():
+            property_is_present = self.col.is_stored and (self.col.is_computed or self.col_type.is_media_type())
+            if not property_is_present:
                 raise excs.Error(f'{name} only valid for a stored computed or media column: {self}')
             return ColumnPropertyRef(self, ColumnPropertyRef.Property[name.upper()])
         if name == ColumnPropertyRef.Property.FILEURL.name.lower() \

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -253,6 +253,12 @@ class TestExprs:
         with pytest.raises(excs.Error) as excinfo:
             _ = img_t.select(img_t.c9.localpath).show()
         assert 'computed unstored' in str(excinfo.value)
+        with pytest.raises(excs.Error) as excinfo:
+            _ = img_t.select(img_t.c9.errormsg).show()
+        assert 'only valid for' in str(excinfo.value)
+        with pytest.raises(excs.Error) as excinfo:
+            _ = img_t.select(img_t.c9.errortype).show()
+        assert 'only valid for' in str(excinfo.value)
 
     def test_null_args(self, reset_db) -> None:
         # create table with two columns


### PR DESCRIPTION
This change corrects the logic for determining when errormsg and errortype properties are valid.
