### PR TITLE
Update Gemini version to 0.8.4

### DIFF
--- a/pixeltable/functions/gemini.py
+++ b/pixeltable/functions/gemini.py
@@ -13,7 +13,7 @@ from pixeltable import env
 
 @env.register_client('gemini')
 def _(api_key: str) -> None:
-    import google.generativeai as genai  # type: ignore[import-untyped]
+    import google.generativeai as genai
     genai.configure(api_key=api_key)
 
 

--- a/pixeltable/functions/gemini.py
+++ b/pixeltable/functions/gemini.py
@@ -36,8 +36,6 @@ def generate_content(
     response_schema: Optional[dict] = None,
     presence_penalty: Optional[float] = None,
     frequency_penalty: Optional[float] = None,
-    response_logprobs: Optional[bool] = None,
-    logprobs: Optional[int] = None,
 ) -> dict:
     """
     Generate content from the specified model. For additional details, see:
@@ -60,7 +58,7 @@ def generate_content(
         Add a computed column that applies the model `gemini-1.5-flash`
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
-        >>> tbl['response'] = generate_content(tbl.prompt, model_name='gemini-1.5-flash')
+        >>> tbl.add_computed_column(response=generate_content(tbl.prompt, model_name='gemini-1.5-flash'))
     """
     env.Env.get().require_package('google.generativeai')
     _ensure_loaded()
@@ -78,8 +76,6 @@ def generate_content(
         response_schema=response_schema,
         presence_penalty=presence_penalty,
         frequency_penalty=frequency_penalty,
-        response_logprobs=response_logprobs,
-        logprobs=logprobs,
     )
     response = model.generate_content(contents, generation_config=gc)
     return response.to_dict()

--- a/poetry.lock
+++ b/poetry.lock
@@ -2402,19 +2402,22 @@ files = [
 
 [[package]]
 name = "google-ai-generativelanguage"
-version = "0.6.10"
+version = "0.6.15"
 description = "Google Ai Generativelanguage API client library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google_ai_generativelanguage-0.6.10-py3-none-any.whl", hash = "sha256:854a2bf833d18be05ad5ef13c755567b66a4f4a870f099b62c61fe11bddabcf4"},
-    {file = "google_ai_generativelanguage-0.6.10.tar.gz", hash = "sha256:6fa642c964d8728006fe7e8771026fc0b599ae0ebeaf83caf550941e8e693455"},
+    {file = "google_ai_generativelanguage-0.6.15-py3-none-any.whl", hash = "sha256:5a03ef86377aa184ffef3662ca28f19eeee158733e45d7947982eb953c6ebb6c"},
+    {file = "google_ai_generativelanguage-0.6.15.tar.gz", hash = "sha256:8f6d9dc4c12b065fe2d0289026171acea5183ebf2d0b11cefe12f3821e159ec3"},
 ]
 
 [package.dependencies]
 google-api-core = {version = ">=1.34.1,<2.0.dev0 || >=2.11.dev0,<3.0.0dev", extras = ["grpc"]}
 google-auth = ">=2.14.1,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0dev"
-proto-plus = ">=1.22.3,<2.0.0dev"
+proto-plus = [
+    {version = ">=1.22.3,<2.0.0dev", markers = "python_version < \"3.13\""},
+    {version = ">=1.25.0,<2.0.0dev", markers = "python_version >= \"3.13\""},
+]
 protobuf = ">=3.20.2,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<6.0.0dev"
 
 [[package]]
@@ -2510,16 +2513,16 @@ httplib2 = ">=0.19.0"
 
 [[package]]
 name = "google-generativeai"
-version = "0.8.3"
+version = "0.8.4"
 description = "Google Generative AI High level API client library and tools."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "google_generativeai-0.8.3-py3-none-any.whl", hash = "sha256:1108ff89d5b8e59f51e63d1a8bf84701cd84656e17ca28d73aeed745e736d9b7"},
+    {file = "google_generativeai-0.8.4-py3-none-any.whl", hash = "sha256:e987b33ea6decde1e69191ddcaec6ef974458864d243de7191db50c21a7c5b82"},
 ]
 
 [package.dependencies]
-google-ai-generativelanguage = "0.6.10"
+google-ai-generativelanguage = "0.6.15"
 google-api-core = "*"
 google-api-python-client = "*"
 google-auth = ">=2.15.0"
@@ -9893,4 +9896,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "5d01765e06e9c8441ce2772de5923f876ed8c2914f46d88f3a1a343f97a7ebc0"
+content-hash = "fba7aa737ae51ef7ca131d4c8457330480af96e0df415e60c8967e061db9502e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ together = "^1.3.1"
 fireworks-ai = "^0.13.0"
 mistralai = "^1.2.1"
 replicate = "^1.0.2"
-google-generativeai = "^0.8.3"
+google-generativeai = "^0.8.4"
 boto3 = "==1.35.5"  # Locking a specific version of boto3 dramatically improves `poetry lock` runtimes
 spacy = ">=3.7"
 sentencepiece = ">=0.2.0"


### PR DESCRIPTION
The Gemini SDK version 0.8.4 contains backwards-incompatible changes (vs 0.8.3) that broke our Pixeltable integration. This PR fixes it.