### PR TITLE
Support generalized arrays (unparameterized or with only a dtype)

### DIFF
--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -164,7 +164,7 @@ class InsertableTable(Table):
                     row[col_name] = checked_val
                 except TypeError as e:
                     msg = str(e)
-                    raise excs.Error(f'Error in column {col.name}: {msg[0].lower() + msg[1:]}\nRow: {row}')
+                    raise excs.Error(f'Error in column {col.name}: {msg[0].lower() + msg[1:]}\nRow: {row}') from e
 
     def delete(self, where: Optional['pxt.exprs.Expr'] = None) -> UpdateStatus:
         """Delete rows in this table.

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -801,6 +801,8 @@ class ArrayType(ColumnType):
     def __init__(self, shape: Optional[tuple[Optional[int], ...]] = None, dtype: Optional[ColumnType] = None, nullable: bool = False):
         super().__init__(self.Type.ARRAY, nullable=nullable)
         assert shape is None or dtype is not None, (shape, dtype)  # cannot specify a shape without a dtype
+        assert dtype is None or dtype.is_int_type() or dtype.is_float_type() or dtype.is_bool_type() or dtype.is_string_type()
+
         self.shape = shape
         self.pxt_dtype = dtype
         self.dtype = None if dtype is None else dtype._type
@@ -840,8 +842,7 @@ class ArrayType(ColumnType):
             return 'Array'
         if self.shape is None:
             return f'Array[{self.pxt_dtype}]'
-        if self.dtype is None:
-            return f'Array[{self.shape}]'
+        assert self.dtype is not None
         return f'Array[{self.shape}, {self.pxt_dtype}]'
 
     @classmethod
@@ -888,11 +889,9 @@ class ArrayType(ColumnType):
                 return False
             # check that the shapes are compatible
             for n1, n2 in zip(val.shape, self.shape):
-                if n1 is None:
-                    return False
+                assert n1 is not None  # `val` must have a concrete shape
                 if n2 is None:
-                    # wildcard
-                    continue
+                    continue  # wildcard
                 if n1 != n2:
                     return False
 

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -793,12 +793,17 @@ class JsonType(ColumnType):
 
 
 class ArrayType(ColumnType):
-    def __init__(self, shape: tuple[Union[int, None], ...], dtype: ColumnType, nullable: bool = False):
+
+    shape: Optional[tuple[Optional[int], ...]]
+    pxt_dtype: Optional[ColumnType]
+    dtype: Optional[ColumnType.Type]
+
+    def __init__(self, shape: Optional[tuple[Optional[int], ...]] = None, dtype: Optional[ColumnType] = None, nullable: bool = False):
         super().__init__(self.Type.ARRAY, nullable=nullable)
+        assert shape is None or dtype is not None, (shape, dtype)  # cannot specify a shape without a dtype
         self.shape = shape
-        assert dtype.is_int_type() or dtype.is_float_type() or dtype.is_bool_type() or dtype.is_string_type()
         self.pxt_dtype = dtype
-        self.dtype = dtype._type
+        self.dtype = None if dtype is None else dtype._type
 
     def copy(self, nullable: bool) -> ColumnType:
         return ArrayType(self.shape, self.pxt_dtype, nullable=nullable)
@@ -812,28 +817,39 @@ class ArrayType(ColumnType):
     def supertype(self, other: ColumnType) -> Optional[ArrayType]:
         if not isinstance(other, ArrayType):
             return None
+        super_dtype = self.Type.supertype(self.dtype, other.dtype, self.common_supertypes)
+        if super_dtype is None:
+            # if the dtypes are incompatible, then the supertype is a fully general array
+            return ArrayType(nullable=(self.nullable or other.nullable))
+        super_shape: Optional[tuple[Optional[int], ...]]
         if len(self.shape) != len(other.shape):
-            return None
-        base_type = self.Type.supertype(self.dtype, other.dtype, self.common_supertypes)
-        if base_type is None:
-            return None
-        shape = [n1 if n1 == n2 else None for n1, n2 in zip(self.shape, other.shape)]
-        return ArrayType(tuple(shape), self.make_type(base_type), nullable=(self.nullable or other.nullable))
+            super_shape = None
+        else:
+            super_shape = tuple(n1 if n1 == n2 else None for n1, n2 in zip(self.shape, other.shape))
+        return ArrayType(super_shape, self.make_type(super_dtype), nullable=(self.nullable or other.nullable))
 
     def _as_dict(self) -> dict:
         result = super()._as_dict()
-        result.update(shape=list(self.shape), dtype=self.dtype.value)
+        shape_as_list = None if self.shape is None else list(self.shape)
+        dtype_value = None if self.dtype is None else self.dtype.value
+        result.update(shape=shape_as_list, dtype=dtype_value)
         return result
 
     def _to_base_str(self) -> str:
+        if self.shape is None and self.dtype is None:
+            return 'Array'
+        if self.shape is None:
+            return f'Array[{self.pxt_dtype}]'
+        if self.dtype is None:
+            return f'Array[{self.shape}]'
         return f'Array[{self.shape}, {self.pxt_dtype}]'
 
     @classmethod
     def _from_dict(cls, d: dict) -> ColumnType:
         assert 'shape' in d
         assert 'dtype' in d
-        shape = tuple(d['shape'])
-        dtype = cls.make_type(cls.Type(d['dtype']))
+        shape = None if d['shape'] is None else tuple(d['shape'])
+        dtype = None if d['dtype'] is None else cls.make_type(cls.Type(d['dtype']))
         return cls(shape, dtype, nullable=d['nullable'])
 
     @classmethod
@@ -855,18 +871,32 @@ class ArrayType(ColumnType):
     def is_valid_literal(self, val: np.ndarray) -> bool:
         if not isinstance(val, np.ndarray):
             return False
-        if len(val.shape) != len(self.shape):
+
+        # If a dtype is specified, check that there's a match
+        if self.dtype is not None and not np.issubdtype(val.dtype, self.numpy_dtype()):
             return False
-        # check that the shapes are compatible
-        for n1, n2 in zip(val.shape, self.shape):
-            if n1 is None:
+
+        # If no dtype is specified, we still need to check that the dtype is one of the supported types
+        if self.dtype is None and not any(
+            np.issubdtype(val.dtype, ndtype) for ndtype in [np.int64, np.float32, np.bool_, np.str_]
+        ):
+            return False
+
+        # If a shape is specified, check that there's a match
+        if self.shape is not None:
+            if len(val.shape) != len(self.shape):
                 return False
-            if n2 is None:
-                # wildcard
-                continue
-            if n1 != n2:
-                return False
-        return np.issubdtype(val.dtype, self.numpy_dtype())
+            # check that the shapes are compatible
+            for n1, n2 in zip(val.shape, self.shape):
+                if n1 is None:
+                    return False
+                if n2 is None:
+                    # wildcard
+                    continue
+                if n1 != n2:
+                    return False
+
+        return True
 
     def _to_json_schema(self) -> dict[str, Any]:
         return {
@@ -878,9 +908,17 @@ class ArrayType(ColumnType):
         if not isinstance(val, np.ndarray):
             raise TypeError(f'Expected numpy.ndarray, got {val.__class__.__name__}')
         if not self.is_valid_literal(val):
-            raise TypeError((
-                f'Expected ndarray({self.shape}, dtype={self.numpy_dtype()}), '
-                f'got ndarray({val.shape}, dtype={val.dtype})'))
+            if self.shape is not None:
+                raise TypeError(
+                    f'Expected numpy.ndarray({self.shape}, dtype={self.numpy_dtype()}), '
+                    f'got numpy.ndarray({val.shape}, dtype={val.dtype})'
+                )
+            elif self.dtype is not None:
+                raise TypeError(
+                    f'Expected numpy.ndarray of dtype {self.numpy_dtype()}, got numpy.ndarray of dtype {val.dtype}'
+                )
+            else:
+                raise TypeError(f'Unsupported dtype for numpy.ndarray: {val.dtype}')
 
     def _create_literal(self, val: Any) -> Any:
         if isinstance(val, (list, tuple)):
@@ -892,7 +930,9 @@ class ArrayType(ColumnType):
     def to_sa_type(self) -> sql.types.TypeEngine:
         return sql.LargeBinary()
 
-    def numpy_dtype(self) -> np.dtype:
+    def numpy_dtype(self) -> Optional[np.dtype]:
+        if self.dtype is None:
+            return None
         if self.dtype == self.Type.INT:
             return np.dtype(np.int64)
         if self.dtype == self.Type.FLOAT:
@@ -901,7 +941,7 @@ class ArrayType(ColumnType):
             return np.dtype(np.bool_)
         if self.dtype == self.Type.STRING:
             return np.dtype(np.str_)
-        assert False
+        assert False, self.dtype
 
 
 class ImageType(ColumnType):
@@ -1174,6 +1214,8 @@ class Array(np.ndarray, _PxtType):
         params = item if isinstance(item, tuple) else (item,)
         shape: Optional[tuple] = None
         dtype: Optional[ColumnType] = None
+        if not any(isinstance(param, (type, _AnnotatedAlias)) for param in params):
+            raise TypeError('Array type parameter must include a dtype.')
         for param in params:
             if isinstance(param, tuple):
                 if not all(n is None or (isinstance(n, int) and n >= 1) for n in param):
@@ -1181,21 +1223,17 @@ class Array(np.ndarray, _PxtType):
                 if shape is not None:
                     raise TypeError(f'Duplicate Array type parameter: {param}')
                 shape = param
-            elif isinstance(param, type) or isinstance(param, _AnnotatedAlias):
+            elif isinstance(param, (type, _AnnotatedAlias)):
                 if dtype is not None:
                     raise TypeError(f'Duplicate Array type parameter: {param}')
                 dtype = ColumnType.normalize_type(param, allow_builtin_types=False)
             else:
                 raise TypeError(f'Invalid Array type parameter: {param}')
-        if shape is None:
-            raise TypeError('Array type is missing parameter: shape')
-        if dtype is None:
-            raise TypeError('Array type is missing parameter: dtype')
         return typing.Annotated[np.ndarray, ArrayType(shape=shape, dtype=dtype, nullable=False)]
 
     @classmethod
     def as_col_type(cls, nullable: bool) -> ColumnType:
-        raise TypeError('Array type cannot be used without specifying shape and dtype')
+        return ArrayType(nullable=nullable)
 
 
 class Image(PIL.Image.Image, _PxtType):

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -804,7 +804,7 @@ class ArrayType(ColumnType):
         assert dtype is None or dtype.is_int_type() or dtype.is_float_type() or dtype.is_bool_type() or dtype.is_string_type()
 
         self.shape = shape
-        self.pxt_dtype = dtype
+        self.pxt_dtype = dtype  # we need this for copy() and __str__()
         self.dtype = None if dtype is None else dtype._type
 
     def copy(self, nullable: bool) -> ColumnType:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1063,26 +1063,22 @@ class TestTable:
         # bad array literal
         pxt.drop_table(tbl_name, if_not_exists='ignore')
         t = pxt.create_table(tbl_name, {'c5': pxt.Array[(2, 3), pxt.Int]})  # type: ignore[misc]
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match=r'expected numpy.ndarray\(\(2, 3\)'):
             t.insert(c5=np.ndarray((3, 2)))
-        assert 'expected numpy.ndarray((2, 3)' in str(exc_info.value)
 
         # bad array literal
         pxt.drop_table(tbl_name, if_not_exists='ignore')
         t = pxt.create_table(tbl_name, {'c5': pxt.Array[pxt.Int]})  # type: ignore[misc]
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match='expected numpy.ndarray of dtype int64'):
             t.insert(c5=np.ndarray((3, 2), dtype=np.float32))
-        assert 'expected numpy.ndarray of dtype int64' in str(exc_info.value)
 
         # bad array literal
         pxt.drop_table(tbl_name, if_not_exists='ignore')
         t = pxt.create_table(tbl_name, {'c5': pxt.Array})
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match='expected numpy.ndarray, got'):
             t.insert(c5=8)
-        assert 'expected numpy.ndarray, got' in str(exc_info.value)
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match='unsupported dtype'):
             t.insert(c5=np.ndarray((3, 2), dtype=np.complex128))  # unsupported dtype
-        assert 'unsupported dtype' in str(exc_info.value)
 
         # test that insert skips expression evaluation for
         # any columns that are not part of the current schema.
@@ -2292,7 +2288,7 @@ class TestTable:
             {
                 'fixed_shape': np.zeros((3, 7, 5), dtype=np.int64),
                 'gen_shape': np.zeros((2, 6), dtype=np.float32),
-                'gen': np.array([[1, 7, 3], [2, 4, 5]])
+                'gen': np.array([[1, 7, 3], [2, 4, 5]], dtype=np.int64)
             }
         ]
         t.insert(rows)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -387,6 +387,10 @@ class TestTable:
             'req_json_col': pxt.Required[pxt.Json],
             'array_col': pxt.Array[(5, None, 3), pxt.Int],  # type: ignore[misc]
             'req_array_col': pxt.Required[pxt.Array[(5, None, 3), pxt.Int]],  # type: ignore[misc]
+            'gen_array_col': pxt.Array[pxt.Float],  # type: ignore[misc]
+            'req_gen_array_col': pxt.Required[pxt.Array[pxt.Float]],
+            'full_gen_array_col': pxt.Array,
+            'req_full_gen_array_col': pxt.Required[pxt.Array],
             'img_col': pxt.Image,
             'req_img_col': pxt.Required[pxt.Image],
             'spec_img_col': pxt.Image[(300, 300), 'RGB'],  # type: ignore[misc]
@@ -420,6 +424,10 @@ class TestTable:
             'req_json_col': pxt.JsonType(nullable=False),
             'array_col': pxt.ArrayType((5, None, 3), dtype=pxt.IntType(), nullable=True),
             'req_array_col': pxt.ArrayType((5, None, 3), dtype=pxt.IntType(), nullable=False),
+            'gen_array_col': pxt.ArrayType(dtype=pxt.FloatType(), nullable=True),
+            'req_gen_array_col': pxt.ArrayType(dtype=pxt.FloatType(), nullable=False),
+            'full_gen_array_col': pxt.ArrayType(nullable=True),
+            'req_full_gen_array_col': pxt.ArrayType(nullable=False),
             'img_col': pxt.ImageType(nullable=True),
             'req_img_col': pxt.ImageType(nullable=False),
             'spec_img_col': pxt.ImageType(width=300, height=300, mode='RGB', nullable=True),
@@ -452,6 +460,10 @@ class TestTable:
             'Required[Json]',
             'Array[(5, None, 3), Int]',
             'Required[Array[(5, None, 3), Int]]',
+            'Array[Float]',
+            'Required[Array[Float]]',
+            'Array',
+            'Required[Array]',
             'Image',
             'Required[Image]',
             "Image[(300, 300), 'RGB']",
@@ -1053,7 +1065,24 @@ class TestTable:
         t = pxt.create_table(tbl_name, {'c5': pxt.Array[(2, 3), pxt.Int]})  # type: ignore[misc]
         with pytest.raises(excs.Error) as exc_info:
             t.insert(c5=np.ndarray((3, 2)))
-        assert 'expected ndarray((2, 3)' in str(exc_info.value)
+        assert 'expected numpy.ndarray((2, 3)' in str(exc_info.value)
+
+        # bad array literal
+        pxt.drop_table(tbl_name, if_not_exists='ignore')
+        t = pxt.create_table(tbl_name, {'c5': pxt.Array[pxt.Int]})  # type: ignore[misc]
+        with pytest.raises(excs.Error) as exc_info:
+            t.insert(c5=np.ndarray((3, 2), dtype=np.float32))
+        assert 'expected numpy.ndarray of dtype int64' in str(exc_info.value)
+
+        # bad array literal
+        pxt.drop_table(tbl_name, if_not_exists='ignore')
+        t = pxt.create_table(tbl_name, {'c5': pxt.Array})
+        with pytest.raises(excs.Error) as exc_info:
+            t.insert(c5=8)
+        assert 'expected numpy.ndarray, got' in str(exc_info.value)
+        with pytest.raises(excs.Error) as exc_info:
+            t.insert(c5=np.ndarray((3, 2), dtype=np.complex128))  # unsupported dtype
+        assert 'unsupported dtype' in str(exc_info.value)
 
         # test that insert skips expression evaluation for
         # any columns that are not part of the current schema.
@@ -2246,3 +2275,34 @@ class TestTable:
         with pytest.raises(excs.Error) as exc_info:
             t.revert()
         assert expected_err_msg in str(exc_info.value).lower()
+
+    def test_array_columns(self, reset_db: None, reload_tester: ReloadTester) -> None:
+        schema = {
+            'fixed_shape': pxt.Array[(3, None, 5), pxt.Int],  # type: ignore[misc]
+            'gen_shape': pxt.Array[pxt.Float],  # type: ignore[misc]
+            'gen': pxt.Array
+        }
+        t = pxt.create_table('array_tbl', schema)
+        rows = [
+            {
+                'fixed_shape': np.ones((3, 2, 5), dtype=np.int64),
+                'gen_shape': np.ones((1, 2, 3, 4), dtype=np.float32),
+                'gen': np.array(['a', 'b', 'c'])
+            },
+            {
+                'fixed_shape': np.zeros((3, 7, 5), dtype=np.int64),
+                'gen_shape': np.zeros((2, 6), dtype=np.float32),
+                'gen': np.array([[1, 7, 3], [2, 4, 5]])
+            }
+        ]
+        t.insert(rows)
+        results = reload_tester.run_query(t.select())
+        for row, result in zip(rows, results):
+            for key in row:
+                a1 = row[key]
+                a2 = result[key]
+                assert isinstance(a1, np.ndarray)
+                assert isinstance(a2, np.ndarray)
+                assert np.array_equal(a1, a2)
+
+        reload_tester.run_reload_test()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -100,14 +100,17 @@ class TestTypes:
             Float: (FloatType(nullable=False), 'Float'),
             Bool: (BoolType(nullable=False), 'Bool'),
             Timestamp: (TimestampType(nullable=False), 'Timestamp'),
-            Image: (ImageType(height=None, width=None, mode=None, nullable=False), 'Image'),
+            Array: (ArrayType(nullable=False), 'Array'),
             Json: (JsonType(nullable=False), 'Json'),
+            Image: (ImageType(height=None, width=None, mode=None, nullable=False), 'Image'),
             Video: (VideoType(nullable=False), 'Video'),
             Audio: (AudioType(nullable=False), 'Audio'),
             Document: (DocumentType(nullable=False), 'Document'),
 
             # Pixeltable types with specialized parameters
+            Array[Int]: (ArrayType(dtype=IntType(), nullable=False), 'Array[Int]'),  # type: ignore[misc]
             Array[(None,), Int]: (ArrayType((None,), dtype=IntType(), nullable=False), 'Array[(None,), Int]'),  # type: ignore[misc]
+            Array[(5,), Bool]: (ArrayType((5,), dtype=BoolType(), nullable=False), 'Array[(5,), Bool]'),  # type: ignore[misc]
             Array[(5, None, 3), Float]: (ArrayType((5, None, 3), dtype=FloatType(), nullable=False), 'Array[(5, None, 3), Float]'),  # type: ignore[misc]
             Image[(100, 200)]: (ImageType(width=100, height=200, mode=None, nullable=False), 'Image[(100, 200)]'),  # type: ignore[misc]
             Image[(100, None)]: (ImageType(width=100, height=None, mode=None, nullable=False), 'Image[(100, None)]'),  # type: ignore[misc]
@@ -141,9 +144,11 @@ class TestTypes:
             (BoolType(), FloatType(), FloatType()),
             (IntType(), StringType(), None),
             (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((3, 2, 1), dtype=IntType()), ArrayType((None, 2, None), dtype=IntType())),
-            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((1, 2), dtype=IntType()), None),
+            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((1, 2), dtype=IntType()), ArrayType(dtype=IntType())),
             (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((3, 2, 1), dtype=FloatType()), ArrayType((None, 2, None), dtype=FloatType())),
-            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((3, 2, 1), dtype=StringType()), None),
+            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((3, 2, 1), dtype=StringType()), ArrayType()),
+            (ArrayType((1, 2, 3), dtype=IntType()), ArrayType((1, 2), dtype=StringType()), ArrayType()),
+            (ArrayType(), IntType(), None),
             (ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=200, mode='RGB')),
             (ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=200, mode='RGBA'), ImageType(height=100, width=200, mode=None)),
             (ImageType(height=100, width=200, mode='RGB'), ImageType(height=100, width=300, mode='RGB'), ImageType(height=100, width=None, mode='RGB')),
@@ -161,8 +166,8 @@ class TestTypes:
                     t1n = t1.copy(nullable=n1)
                     t2n = t2.copy(nullable=n2)
                     expectedn = None if expected is None else expected.copy(nullable=(n1 or n2))
-                    assert t1n.supertype(t2n) == expectedn
-                    assert t2n.supertype(t1n) == expectedn
+                    assert t1n.supertype(t2n) == expectedn, (t1n, t2n)
+                    assert t2n.supertype(t1n) == expectedn, (t1n, t2n)
 
     def test_json_schemas(self, init_env) -> None:
         skip_test_if_not_installed('pydantic')


### PR DESCRIPTION
Allows `pxt.Array[Int]` types specifying only a dtype (and not a shape), as well as a bare `pxt.Array` that permits any array.