### PR TITLE
Add get_view and get_snapshot as aliases for get_table

### DIFF
--- a/pixeltable/__init__.py
+++ b/pixeltable/__init__.py
@@ -4,7 +4,7 @@ from .exceptions import Error
 from .exprs import RELATIVE_PATH_ROOT
 from .func import Aggregator, Function, expr_udf, query, uda, udf
 from .globals import (array, configure_logging, create_dir, create_snapshot, create_table, create_view, drop_dir,
-                      drop_table, get_table, init, list_dirs, list_functions, list_tables, move, tool, tools)
+                      drop_table, get_table, get_view, get_snapshot, init, list_dirs, list_functions, list_tables, move, tool, tools)
 from .type_system import (Array, ArrayType, Audio, AudioType, Bool, BoolType, ColumnType, Document, DocumentType, Float,
                           FloatType, Image, ImageType, Int, IntType, Json, JsonType, Required, String, StringType,
                           Timestamp, TimestampType, Video, VideoType)

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -420,6 +420,8 @@ def get_table(path: str) -> catalog.Table:
     assert isinstance(obj, catalog.Table)
     return obj
 
+get_view = get_table
+get_snapshot = get_table
 
 def move(path: str, new_path: str) -> None:
     """Move a schema object to a new directory and/or rename a schema object.


### PR DESCRIPTION
As a user, I get confused when i want to pull a view or snapshot from storage with `get_table`. The functionality works but it causes confusion in my code.

I propose a minimally invasive yet readable solution by creating two alias for get_table. These aliases are modular function names: `get_view` and `get_snapshot`.

This extends the global functions to provide additional ways to retrieve views and snapshots using the existing get_table implementation without confusion the developer.