### PR TITLE
Archive Pixeltable logs from every test run

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -181,6 +181,14 @@ jobs:
       - name: Validate links in notebooks
         if: ${{ matrix.test-category == 'lint' }}
         run: ./scripts/lint-notebooks.sh
+      - name: Archive log files
+        # Archive the log files even if a preceding step failed. Currently we do this only on ubuntu runners.
+        if: ${{ always() && startsWith(matrix.os, 'ubuntu') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pixeltable-pytest-logs-${{ matrix.os }}-${{ matrix.python-version }}-${{
+            matrix.test-category }}${{ matrix.poetry-options }}
+          path: /tmp/pytest-of-runner/pytest-0/base0/.pixeltable/logs
       - name: Print utilization info
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+from typing import Iterator
 
 import pytest
 from filelock import FileLock
@@ -23,7 +24,7 @@ from .utils import (
 _logger = logging.getLogger('pixeltable')
 
 @pytest.fixture(autouse=True)
-def pxt_test_harness():
+def pxt_test_harness() -> Iterator[None]:
     current_test = os.environ.get('PYTEST_CURRENT_TEST')
     _logger.info(f'Running Pixeltable test: {current_test}')
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,14 @@ from .utils import (
     create_all_datatypes_tbl, create_img_tbl, create_test_tbl, reload_catalog, skip_test_if_not_installed, ReloadTester
 )
 
+_logger = logging.getLogger('pixeltable')
+
+@pytest.fixture(autouse=True)
+def pxt_test_harness():
+    current_test = os.environ.get('PYTEST_CURRENT_TEST')
+    _logger.info(f'Running Pixeltable test: {current_test}')
+    yield
+    _logger.info(f'Finished Pixeltable test: {current_test}')
 
 @pytest.fixture(scope='session')
 def init_env(tmp_path_factory, worker_id) -> None:


### PR DESCRIPTION
Adds a step to our CI workflow to archive Pixeltable logs from every test run. The logs will be archived whether or not the run succeeds. The archived logs will be posted at the bottom of each actions summary page, with download links.

Also adds some additional logging to make the testing logs more navigable.