### PR TITLE
Remove unused code from arrow.py

### DIFF
--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -95,8 +95,7 @@ class Env:
         cls._instance = env
 
     def __init__(self):
-        if self._instance is not None:
-            raise excs.Error('Env is a singleton; use Env.get() to access the instance')
+        assert self._instance is None, 'Env is a singleton; use Env.get() to access the instance'
 
         self._home = None
         self._media_dir = None  # computed media files

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -95,6 +95,9 @@ class Env:
         cls._instance = env
 
     def __init__(self):
+        if self._instance is not None:
+            raise excs.Error('Env is a singleton; use Env.get() to access the instance')
+
         self._home = None
         self._media_dir = None  # computed media files
         self._file_cache_dir = None  # cached media files with external URL

--- a/pixeltable/io/hf_datasets.py
+++ b/pixeltable/io/hf_datasets.py
@@ -13,7 +13,7 @@ from pixeltable import exceptions as excs
 if typing.TYPE_CHECKING:
     import datasets  # type: ignore[import-untyped]
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger('pixeltable')
 
 # use 100MB as the batch size limit for loading a huggingface dataset into pixeltable.
 # The primary goal is to bound memory use, regardless of dataset size.

--- a/pixeltable/io/parquet.py
+++ b/pixeltable/io/parquet.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
     import pyarrow as pa
     import pixeltable as pxt
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger('pixeltable')
 
 
 def _write_batch(value_batch: dict[str, deque], schema: pa.Schema, output_path: Path) -> None:

--- a/pixeltable/utils/arrow.py
+++ b/pixeltable/utils/arrow.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Iterator, Optional, Union
 
 import numpy as np
@@ -6,11 +5,7 @@ import pyarrow as pa
 import datetime
 
 import pixeltable.type_system as ts
-from pixeltable.env import Env
 
-_tz_def = Env().get().default_time_zone
-
-_logger = logging.getLogger(__name__)
 
 _pa_to_pt: dict[pa.DataType, ts.ColumnType] = {
     pa.string(): ts.StringType(nullable=True),

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -59,7 +59,7 @@ class TestParquet:
         t.insert([  {'c1': 1, 'c2': 'row1', 'c3': datetime.datetime(2012, 1, 1, 12, 0, 0, 25, tz)},
                     {'c1': 2, 'c2': 'row2', 'c3': datetime.datetime(2012, 2, 1, 12, 0, 0, 25, tz)}])
 
-        tz_default = Env().get().default_time_zone
+        tz_default = Env.get().default_time_zone
 
         print("test_export_parquet_simple with tz: ", tz, "and default tz: ", tz_default)
 


### PR DESCRIPTION
Removes unused code from pixeltable/utils/arrow.py. This fixes debug logging in pytest (the unused code was causing a phantom Env to be instantiated as a side effect, overriding the log settings).

Also adds a guard to `Env.__init__()` to enforce that `Env` is a singleton.