### PR TITLE
Tables as UDFs

### DIFF
--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -425,7 +425,7 @@ class DataFrame:
             nl = '\n'
             # [-1:0:-1]: leave out entry 0 and reverse order, so that the most recent frame is at the top
             msg += f'\nStack:\n{nl.join(stack_trace[-1:1:-1])}'
-        raise excs.Error(msg)
+        raise excs.Error(msg) from e
 
     def _output_row_iterator(self, conn: Optional[sql.engine.Connection] = None) -> Iterator[list]:
         try:

--- a/pixeltable/exprs/arithmetic_expr.py
+++ b/pixeltable/exprs/arithmetic_expr.py
@@ -100,13 +100,13 @@ class ArithmeticExpr(Expr):
         op2_val = data_row[self._op2.slot_idx]
 
         # if one or both columns is JsonTyped, we need a dynamic check that they are numeric
-        if self._op1.col_type.is_json_type() and not isinstance(op1_val, int) and not isinstance(op1_val, float):
+        if self._op1.col_type.is_json_type() and op1_val is not None and not isinstance(op1_val, (int, float)):
             raise excs.Error(
-                f'{self.operator} requires numeric type, but {self._op1} has type {type(op1_val).__name__}'
+                f'{self.operator} requires numeric types, but {self._op1} has type {type(op1_val).__name__}'
             )
-        if self._op2.col_type.is_json_type() and not isinstance(op2_val, int) and not isinstance(op2_val, float):
+        if self._op2.col_type.is_json_type() and op2_val is not None and not isinstance(op2_val, (int, float)):
             raise excs.Error(
-                f'{self.operator} requires numeric type, but {self._op2} has type {type(op2_val).__name__}'
+                f'{self.operator} requires numeric types, but {self._op2} has type {type(op2_val).__name__}'
             )
 
         # if either operand is None, always return None

--- a/pixeltable/func/expr_template_function.py
+++ b/pixeltable/func/expr_template_function.py
@@ -25,7 +25,7 @@ class ExprTemplate:
         self.expr = expr
         self.signature = signature
 
-        self.param_exprs = list(set(expr.subexprs(expr_class=exprs.Variable)))
+        self.param_exprs = list(exprs.ExprSet(expr.subexprs(expr_class=exprs.Variable)))
         # make sure there are no duplicate names
         assert len(self.param_exprs) == len(set(p.name for p in self.param_exprs))
         self.param_exprs_by_name = {p.name: p for p in self.param_exprs}

--- a/pixeltable/func/expr_template_function.py
+++ b/pixeltable/func/expr_template_function.py
@@ -17,7 +17,7 @@ class ExprTemplate:
 
     expr: 'pixeltable.exprs.Expr'
     signature: Signature
-    param_exprs: list['pixeltable.exprs.Variable']
+    param_exprs: dict[str, 'pixeltable.exprs.Variable']
 
     def __init__(self, expr: 'pixeltable.exprs.Expr', signature: Signature):
         from pixeltable import exprs
@@ -25,17 +25,18 @@ class ExprTemplate:
         self.expr = expr
         self.signature = signature
 
-        self.param_exprs = list(exprs.ExprSet(expr.subexprs(expr_class=exprs.Variable)))
-        # make sure there are no duplicate names
-        assert len(self.param_exprs) == len(set(p.name for p in self.param_exprs))
-        self.param_exprs_by_name = {p.name: p for p in self.param_exprs}
+        self.param_exprs = {name: exprs.Variable(name, param.col_type) for name, param in signature.parameters.items()}
+
+        # validate that all variables in the expression are parameters
+        for var in expr.subexprs(expr_class=exprs.Variable):
+            assert var.name in self.param_exprs, f"Variable '{var.name}' in expression is not a parameter"
 
         # verify default values
         self.defaults: dict[str, exprs.Literal] = {}  # key: param name, value: default value converted to a Literal
         for param in self.signature.parameters.values():
             if param.default is inspect.Parameter.empty:
                 continue
-            param_expr = self.param_exprs_by_name[param.name]
+            param_expr = self.param_exprs[param.name]
             try:
                 literal_default = exprs.Literal(param.default, col_type=param_expr.col_type)
                 self.defaults[param.name] = literal_default
@@ -77,7 +78,7 @@ class ExprTemplateFunction(Function):
         result = template.expr.copy()
         arg_exprs: dict[exprs.Expr, exprs.Expr] = {}
         for param_name, arg in bound_args.items():
-            param_expr = template.param_exprs_by_name[param_name]
+            param_expr = template.param_exprs[param_name]
             if not isinstance(arg, exprs.Expr):
                 # TODO: use the available param_expr.col_type
                 arg_expr = exprs.Expr.from_object(arg)

--- a/pixeltable/func/udf.py
+++ b/pixeltable/func/udf.py
@@ -16,6 +16,7 @@ from .signature import Parameter, Signature
 if TYPE_CHECKING:
     from pixeltable import exprs
 
+
 # Decorator invoked without parentheses: @pxt.udf
 @overload
 def udf(decorated_fn: Callable) -> CallableFunction: ...
@@ -37,12 +38,7 @@ def udf(
 
 # pxt.udf() called explicitly on a Table:
 @overload
-def udf(
-    table: catalog.Table,
-    /,
-    *,
-    return_value: Optional['exprs.Expr'],
-) -> ExprTemplateFunction: ...
+def udf(table: catalog.Table, /, *, return_value: Optional['exprs.Expr'] = None) -> ExprTemplateFunction: ...
 
 
 def udf(*args, **kwargs):
@@ -232,16 +228,16 @@ def expr_udf(*args: Any, **kwargs: Any) -> Any:
         assert len(args) == 0 and len(kwargs) == 1 and 'param_types' in kwargs
         return lambda py_fn: make_expr_template(py_fn, kwargs['param_types'])
 
+
 def from_table(tbl: catalog.Table, return_value: Optional['exprs.Expr']) -> ExprTemplateFunction:
-    """
-    """
+    """ """
     from pixeltable import exprs
     from pixeltable.exprs.expr_dict import ExprDict
 
     ancestors = [tbl] + tbl._bases
     ancestors.reverse()  # We must traverse the ancestors in order from base to derived
 
-    subst: ExprDict[exprs.Expr] = ExprDict()
+    subst: dict[exprs.Expr, exprs.Expr] = {}
     result_dict: dict[str, exprs.Expr] = {}
     params: list[Parameter] = []
 


### PR DESCRIPTION
Allows a Table to be cast as a UDF via

`tbl_udf = pxt.udf(tbl)`

`tbl_udf` will have one parameter per data column of `tbl`, and its output will be a `dict` with one entry per column of `tbl` (including both data columns and computed columns).