### PR TITLE
PXT-0456: Allow numpy.ndarray arrays to be used a Literal constants

### DIFF
--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -578,11 +578,9 @@ class DataFrame:
         # analyze select list; wrap literals with the corresponding expressions
         select_list: list[tuple[exprs.Expr, Optional[str]]] = []
         for raw_expr, name in base_list:
-            if isinstance(raw_expr, (np.ndarray, dict, list, tuple, exprs.Expr)):
-                select_list.append((exprs.Expr.from_object(raw_expr), name))
-            else:
-                select_list.append((exprs.Literal(raw_expr), name))
-            expr = select_list[-1][0]
+            expr = exprs.Expr.from_object(raw_expr)
+            if expr is None:
+                raise excs.Error(f'Invalid expression: {raw_expr}')
             if expr.col_type.is_invalid_type():
                 raise excs.Error(f'Invalid type: {raw_expr}')
             if not expr.is_bound_by(self._from_clause.tbls):
@@ -590,6 +588,7 @@ class DataFrame:
                     f"Expression '{expr}' cannot be evaluated in the context of this query's tables "
                     f'({",".join(tbl.tbl_name() for tbl in self._from_clause.tbls)})'
                 )
+            select_list.append((expr, name))
 
         # check user provided names do not conflict among themselves or with auto-generated ones
         seen: set[str] = set()

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -578,12 +578,8 @@ class DataFrame:
         # analyze select list; wrap literals with the corresponding expressions
         select_list: list[tuple[exprs.Expr, Optional[str]]] = []
         for raw_expr, name in base_list:
-            if isinstance(raw_expr, exprs.Expr):
-                select_list.append((raw_expr, name))
-            elif isinstance(raw_expr, (dict, list, tuple)):
+            if isinstance(raw_expr, (np.ndarray, dict, list, tuple, exprs.Expr)):
                 select_list.append((exprs.Expr.from_object(raw_expr), name))
-            elif isinstance(raw_expr, np.ndarray):
-                select_list.append((exprs.Expr.from_array(raw_expr), name))
             else:
                 select_list.append((exprs.Literal(raw_expr), name))
             expr = select_list[-1][0]

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -378,7 +378,15 @@ class Expr(abc.ABC):
 
     @classmethod
     def from_array(cls, elements: Iterable) -> Optional[Expr]:
+        import numpy as np
+
         from .inline_expr import InlineArray
+        from .literal import Literal
+
+        if isinstance(elements, np.ndarray):
+            pxttype = ts.ArrayType.from_literal(elements)
+            if pxttype is not None:
+                return Literal(elements, col_type=pxttype)
 
         inline_array = InlineArray(elements)
         return inline_array.maybe_literal()
@@ -398,6 +406,8 @@ class Expr(abc.ABC):
         """
         Try to turn a literal object into an Expr.
         """
+        import numpy as np
+
         from .inline_expr import InlineDict, InlineList
         from .literal import Literal
 
@@ -407,9 +417,13 @@ class Expr(abc.ABC):
         if isinstance(o, Literal):
             return o
 
-        if isinstance(o, (list, tuple, dict, Expr)):
+        if isinstance(o, (np.ndarray, list, tuple, dict, Expr)):
             expr: Expr
-            if isinstance(o, (list, tuple)):
+            if isinstance(o, np.ndarray):
+                pxttype = ts.ArrayType.from_literal(o)
+                if pxttype is not None:
+                    return Literal(o, col_type=pxttype)
+            elif isinstance(o, (list, tuple)):
                 expr = InlineList(o)
             elif isinstance(o, dict):
                 expr = InlineDict(o)

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -10,6 +10,7 @@ import typing
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional, TypeVar, Union, overload
 from uuid import UUID
 
+import numpy as np
 import sqlalchemy as sql
 from typing_extensions import Self, _AnnotatedAlias
 
@@ -378,8 +379,6 @@ class Expr(abc.ABC):
 
     @classmethod
     def from_array(cls, elements: Iterable) -> Optional[Expr]:
-        import numpy as np
-
         from .inline_expr import InlineArray
         from .literal import Literal
 
@@ -406,8 +405,6 @@ class Expr(abc.ABC):
         """
         Try to turn a literal object into an Expr.
         """
-        import numpy as np
-
         from .inline_expr import InlineDict, InlineList
         from .literal import Literal
 
@@ -417,13 +414,9 @@ class Expr(abc.ABC):
         if isinstance(o, Literal):
             return o
 
-        if isinstance(o, (np.ndarray, list, tuple, dict, Expr)):
+        if isinstance(o, (list, tuple, dict, Expr)):
             expr: Expr
-            if isinstance(o, np.ndarray):
-                pxttype = ts.ArrayType.from_literal(o)
-                if pxttype is not None:
-                    return Literal(o, col_type=pxttype)
-            elif isinstance(o, (list, tuple)):
+            if isinstance(o, (list, tuple)):
                 expr = InlineList(o)
             elif isinstance(o, dict):
                 expr = InlineDict(o)

--- a/pixeltable/io/pandas.py
+++ b/pixeltable/io/pandas.py
@@ -185,20 +185,9 @@ def __np_dtype_to_pxt_type(np_dtype: np.dtype, data_col: pd.Series, nullable: bo
     """
     Infers a Pixeltable type based on a Numpy dtype.
     """
-    if np.issubdtype(np_dtype, np.integer):
-        return pxt.IntType(nullable=nullable)
-
-    if np.issubdtype(np_dtype, np.floating):
-        return pxt.FloatType(nullable=nullable)
-
-    if np.issubdtype(np_dtype, np.bool_):
-        return pxt.BoolType(nullable=nullable)
-
-    if np.issubdtype(np_dtype, np.character):
-        return pxt.StringType(nullable=nullable)
-
-    if np.issubdtype(np_dtype, np.datetime64):
-        return pxt.TimestampType(nullable=nullable)
+    pxttype = ts.ArrayType.from_np_dtype(np_dtype, nullable)
+    if pxttype is not None:
+        return pxttype
 
     if np_dtype == np.object_:
         # The `object_` dtype can mean all sorts of things; see if we can infer the Pixeltable type

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -83,9 +83,9 @@ class TestDataFrame:
         assert 'already specified' in str(exc_info.value)
 
         # invalid expr in select list: Callable is not a valid literal
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(excs.Error) as exc_info:
             _ = t.select(datetime.datetime.now).collect()
-        assert 'Not a valid literal' in str(exc_info.value)
+        assert 'Invalid expression' in str(exc_info.value)
 
         # catch invalid name in select list from user input
         # only check stuff that's not caught by python kwargs checker

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -519,8 +519,8 @@ class TestExprs:
         print(result.show(5))
         assert isinstance(result.select_list[0][0], Literal)
 
-        arr1 = np.array([1, 2, 3, 4, 5])
-        arr2 = np.array([[1, 2, 3], [4, 5, 6]])
+        arr1 = np.array([1, 2, 3, 4, 5], dtype=np.int64)
+        arr2 = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64)
 
         # r0 = t.select(None)
         # print(r0.show(5))
@@ -532,7 +532,7 @@ class TestExprs:
         r2 = t.select(arr3)
         print(r2.show(5))
 
-        arr4 = pxt.array(np.array([1, 2, 3, 4, 5]))
+        arr4 = pxt.array(np.array([1, 2, 3, 4, 5], dtype=np.int64))
         r3 = t.select(arr4)
         print(r3.show(5))
 

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -519,6 +519,23 @@ class TestExprs:
         print(result.show(5))
         assert isinstance(result.select_list[0][0], Literal)
 
+        arr1 = np.array([1, 2, 3, 4, 5])
+        arr2 = np.array([[1, 2, 3], [4, 5, 6]])
+
+        # r0 = t.select(None)
+        # print(r0.show(5))
+
+        r1 = t.select(pxt.array(arr1))
+        print(r1.show(5))
+
+        arr3 = pxt.array([1, 2, 3, 4, 5])
+        r2 = t.select(arr3)
+        print(r2.show(5))
+
+        arr4 = pxt.array(np.array([1, 2, 3, 4, 5]))
+        r3 = t.select(arr4)
+        print(r3.show(5))
+
         result = t.select(
             1,
             (100, 100),
@@ -529,6 +546,8 @@ class TestExprs:
             pxt.array(['a', 'b', 'c']),
             # This is an np.array, dtype='<U7' : col_type = StringType
             pxt.array(['abc', 'd', 'efghijk']),
+            arr1,
+            arr2,
             {'b': [4, 5]},
             {'c': {}},
             {'d': {'d': 6, 'e': [7, 8], 'f': {}, 'g': {'h': 9}}},


### PR DESCRIPTION
    Combine numpy.dtype to ColumnType.dtype determinations.
    Support conversation of numpy.ndarrays directly into Literals