### PR TITLE
Test suite improvement: Use pytest fixtures for Hugging Face embedding models

### DIFF
--- a/tests/functions/test_huggingface.py
+++ b/tests/functions/test_huggingface.py
@@ -17,7 +17,7 @@ from ..utils import (
 )
 
 
-@pytest.mark.flaky(reruns=1, reruns_delay=8)  # Guard against connection errors downloading models
+@pytest.mark.flaky(reruns=3, reruns_delay=15)  # Guard against connection errors downloading models
 class TestHuggingface:
     def test_hf_function(self, reset_db) -> None:
         skip_test_if_not_installed('sentence_transformers')

--- a/tests/io/test_hf_datasets.py
+++ b/tests/io/test_hf_datasets.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @pytest.mark.skipif(
     sysconfig.get_platform() == 'linux-aarch64', reason='libsndfile.so is missing on Linux ARM instances in CI'
 )
-@pytest.mark.flaky(reruns=3, only_rerun='HfHubHTTPError')
+@pytest.mark.flaky(reruns=3, reruns_delay=15)  # Guard against connection errors downloading datasets
 class TestHfDatasets:
     def test_import_hf_dataset(self, reset_db, tmp_path: pathlib.Path) -> None:
         skip_test_if_not_installed('datasets')

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -9,14 +9,13 @@ import PIL.Image
 import pytest
 
 import pixeltable as pxt
+from pixeltable import func
 from pixeltable.functions.huggingface import clip
 
 from .utils import (
     ReloadTester,
     assert_img_eq,
     assert_resultset_eq,
-    clip_embed,
-    e5_embed,
     get_sentences,
     reload_catalog,
     skip_test_if_not_installed,
@@ -37,7 +36,9 @@ class TestIndex:
     def bad_embed2(x: str) -> pxt.Array[(None,), pxt.Float]:
         return np.zeros(10)
 
-    def test_similarity_multiple_index(self, multi_idx_img_tbl: pxt.Table, reload_tester: ReloadTester) -> None:
+    def test_similarity_multiple_index(
+        self, multi_idx_img_tbl: pxt.Table, clip_embed: func.Function, reload_tester: ReloadTester
+    ) -> None:
         skip_test_if_not_installed('transformers')
         t = multi_idx_img_tbl
         sample_img = t.select(t.img).head(1)[0, 'img']
@@ -71,7 +72,12 @@ class TestIndex:
 
     @pytest.mark.parametrize('use_index_name,use_separate_embeddings', [(False, False), (True, False), (False, True)])
     def test_similarity(
-        self, use_index_name: bool, use_separate_embeddings: bool, small_img_tbl: pxt.Table, reload_tester: ReloadTester
+        self,
+        use_index_name: bool,
+        use_separate_embeddings: bool,
+        small_img_tbl: pxt.Table,
+        clip_embed: func.Function,
+        reload_tester: ReloadTester,
     ) -> None:
         skip_test_if_not_installed('transformers')
         t = small_img_tbl
@@ -111,7 +117,7 @@ class TestIndex:
 
             t.drop_embedding_index(column='img')
 
-    def test_query(self, reset_db) -> None:
+    def test_query(self, reset_db, clip_embed: func.Function) -> None:
         skip_test_if_not_installed('transformers')
         queries = pxt.create_table('queries', {'query_text': pxt.String})
         query_rows = [
@@ -152,7 +158,7 @@ class TestIndex:
         # insert more rows in order to run the query function
         validate_update_status(queries.insert(query_rows))
 
-    def test_search_fn(self, small_img_tbl: pxt.Table) -> None:
+    def test_search_fn(self, small_img_tbl: pxt.Table, clip_embed: func.Function) -> None:
         skip_test_if_not_installed('transformers')
         t = small_img_tbl
         sample_img = t.select(t.img).head(1)[0, 'img']
@@ -167,7 +173,9 @@ class TestIndex:
 
         res = list(t.select(img=t.img.localpath, matches=img_matches(t.img)).head(1))
 
-    def test_similarity_errors(self, indexed_img_tbl: pxt.Table, small_img_tbl: pxt.Table) -> None:
+    def test_similarity_errors(
+        self, indexed_img_tbl: pxt.Table, small_img_tbl: pxt.Table, clip_embed: func.Function
+    ) -> None:
         skip_test_if_not_installed('transformers')
         t = indexed_img_tbl
         with pytest.raises(pxt.Error) as exc_info:
@@ -205,7 +213,7 @@ class TestIndex:
             _ = t.order_by(t.split.similarity(sample_img)).limit(1).collect()
         assert 'does not have an image embedding' in str(exc_info.value).lower()
 
-    def test_add_index_after_drop(self, small_img_tbl: pxt.Table) -> None:
+    def test_add_index_after_drop(self, small_img_tbl: pxt.Table, clip_embed: func.Function) -> None:
         """Test that an index with the same name can be added after the previous one is dropped"""
         skip_test_if_not_installed('transformers')
         t = small_img_tbl
@@ -262,7 +270,9 @@ class TestIndex:
         )
         assert_resultset_eq(orig_res, res, True)
 
-    def test_add_embedding_index_if_exists(self, small_img_tbl: pxt.Table, reload_tester: ReloadTester) -> None:
+    def test_add_embedding_index_if_exists(
+        self, small_img_tbl: pxt.Table, reload_tester: ReloadTester, clip_embed: func.Function
+    ) -> None:
         skip_test_if_not_installed('transformers')
         t = small_img_tbl
         sample_img = t.select(t.img).head(1)[0, 'img']
@@ -335,7 +345,15 @@ class TestIndex:
         # sanity check persistence
         reload_tester.run_reload_test()
 
-    def test_embedding_basic(self, img_tbl: pxt.Table, test_tbl: pxt.Table, reload_tester: ReloadTester) -> None:
+    def test_embedding_basic(
+        self,
+        img_tbl: pxt.Table,
+        test_tbl: pxt.Table,
+        clip_embed: func.Function,
+        e5_embed: func.Function,
+        all_mpnet_embed: func.Function,
+        reload_tester: ReloadTester,
+    ) -> None:
         skip_test_if_not_installed('transformers')
         img_t = img_tbl
         rows = list(img_t.select(img=img_t.img.fileurl, category=img_t.category, split=img_t.split).collect())
@@ -468,9 +486,7 @@ class TestIndex:
         t = pxt.create_table('t1', {'s': pxt.String})
         sents = get_sentences(3)
         status = t.insert({'s': s} for s in sents)
-        t.add_embedding_index(
-            's', string_embed=pxt.functions.huggingface.sentence_transformer.using(model_id='all-mpnet-base-v2')
-        )
+        t.add_embedding_index('s', string_embed=all_mpnet_embed)
         df = t.select(sim=t.s.similarity(sents[1]))
         res1 = df.collect()
         _ = reload_tester.run_query(t.select())
@@ -480,16 +496,10 @@ class TestIndex:
         t = pxt.create_table('t2', {'s': pxt.String})
         status = t.insert({'s': s} for s in sents)
         v = pxt.create_view('v', t)
-        v.add_embedding_index(
-            's', string_embed=pxt.functions.huggingface.sentence_transformer.using(model_id='all-mpnet-base-v2')
-        )
+        v.add_embedding_index('s', string_embed=all_mpnet_embed)
         # should work irrespective of whether the column is passed by name or reference
-        v.add_embedding_index(
-            v.s, string_embed=pxt.functions.huggingface.sentence_transformer.using(model_id='all-mpnet-base-v2')
-        )
-        v.add_embedding_index(
-            t.s, string_embed=pxt.functions.huggingface.sentence_transformer.using(model_id='all-mpnet-base-v2')
-        )
+        v.add_embedding_index(v.s, string_embed=all_mpnet_embed)
+        v.add_embedding_index(t.s, string_embed=all_mpnet_embed)
         # Expected to verify the following:
         # df = v.select(sim=v.s.similarity(sents[1]))
         # res2 = df.collect()
@@ -511,7 +521,7 @@ class TestIndex:
 
         reload_tester.run_reload_test()
 
-    def test_embedding_errors(self, small_img_tbl: pxt.Table, test_tbl: pxt.Table) -> None:
+    def test_embedding_errors(self, small_img_tbl: pxt.Table, test_tbl: pxt.Table, clip_embed: func.Function) -> None:
         skip_test_if_not_installed('transformers')
         img_t = small_img_tbl
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -4,9 +4,9 @@ import numpy as np
 import pytest
 
 import pixeltable as pxt
-import pixeltable.exceptions as excs
+from pixeltable import exceptions as excs, func
 
-from .utils import ReloadTester, assert_resultset_eq, clip_embed, create_img_tbl, create_test_tbl, reload_catalog
+from .utils import ReloadTester, assert_resultset_eq, create_img_tbl, create_test_tbl, reload_catalog
 
 
 class TestSnapshot:
@@ -196,7 +196,7 @@ class TestSnapshot:
         assert s1._id == id_before['test_snap_t']
         assert s2._id == id_before['test_snap_v']
 
-    def test_errors(self, reset_db) -> None:
+    def test_errors(self, reset_db, clip_embed: func.Function) -> None:
         tbl = create_test_tbl()
         snap = pxt.create_snapshot('snap', tbl)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -14,7 +14,7 @@ from jsonschema.exceptions import ValidationError
 
 import pixeltable as pxt
 import pixeltable.functions as pxtf
-from pixeltable import catalog, exceptions as excs
+from pixeltable import catalog, exceptions as excs, func
 from pixeltable.exprs import ColumnRef
 from pixeltable.func import Batch
 from pixeltable.io.external_store import MockProject
@@ -2076,7 +2076,7 @@ class TestTable:
             'func_r': pxt.StringType(nullable=False),
         }
 
-    def test_repr(self, test_tbl: catalog.Table) -> None:
+    def test_repr(self, test_tbl: catalog.Table, all_mpnet_embed: func.Function) -> None:
         skip_test_if_not_installed('sentence_transformers')
 
         v = pxt.create_view('test_view', test_tbl)
@@ -2084,9 +2084,7 @@ class TestTable:
         v2 = pxt.create_view('test_subview', v, comment='This is an intriguing table comment.')
         fn = lambda x: np.full((3, 4), x)
         v2.add_computed_column(computed1=v2.c2.apply(fn, col_type=pxt.Array[(3, 4), pxt.Int]))  # type: ignore[misc]
-        v2.add_embedding_index(
-            'c1', string_embed=pxt.functions.huggingface.sentence_transformer.using(model_id='all-mpnet-base-v2')
-        )
+        v2.add_embedding_index('c1', string_embed=all_mpnet_embed)
         v2._link_external_store(MockProject.create(v2, 'project', {}, {}))
         v2.describe()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import os
 import random
 import urllib.parse
 from pathlib import Path
-from typing import Any, Hashable, Optional
+from typing import Any, Optional
 
 import more_itertools
 import numpy as np
@@ -14,9 +14,8 @@ import PIL.Image
 import pytest
 
 import pixeltable as pxt
-import pixeltable.exceptions as excs
 import pixeltable.utils.s3 as s3_util
-from pixeltable import catalog, exprs, func
+from pixeltable import catalog, exceptions as excs
 from pixeltable.catalog.globals import UpdateStatus
 from pixeltable.dataframe import DataFrameResultSet
 from pixeltable.env import Env

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,11 +16,10 @@ import pytest
 import pixeltable as pxt
 import pixeltable.exceptions as excs
 import pixeltable.utils.s3 as s3_util
-from pixeltable import catalog, exprs
+from pixeltable import catalog, exprs, func
 from pixeltable.catalog.globals import UpdateStatus
 from pixeltable.dataframe import DataFrameResultSet
 from pixeltable.env import Env
-from pixeltable.functions.huggingface import clip, sentence_transformer
 from pixeltable.io import SyncStatus
 
 
@@ -511,10 +510,6 @@ def assert_img_eq(img1: PIL.Image.Image, img2: PIL.Image.Image, context: str) ->
 def reload_catalog() -> None:
     catalog.Catalog.clear()
     pxt.init()
-
-
-clip_embed = clip.using(model_id='openai/clip-vit-base-patch32')
-e5_embed = sentence_transformer.using(model_id='intfloat/e5-large-v2')
 
 
 # Mock UDF for testing LLM tool invocations


### PR DESCRIPTION
Factors out the HF embedding models as pytest fixtures and adds retries, which should harden another point of failure in CI.