### PR TITLE
Bugfixes

### DIFF
--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -47,6 +47,7 @@ class Env:
     """
 
     _instance: Optional[Env] = None
+    __initializing: bool = False
     _log_fmt_str = '%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d: %(message)s'
 
     _media_dir: Optional[Path]
@@ -68,7 +69,6 @@ class Env:
     _httpd: Optional[http.server.HTTPServer]
     _http_address: Optional[str]
     _logger: logging.Logger
-    _console_logger: ConsoleLogger
     _default_log_level: int
     _logfilename: Optional[str]
     _log_to_stdout: bool
@@ -90,10 +90,13 @@ class Env:
 
     @classmethod
     def _init_env(cls, reinit_db: bool = False) -> None:
+        assert not cls.__initializing, 'Circular env initialization detected.'
+        cls.__initializing = True
         env = Env()
         env._set_up(reinit_db=reinit_db)
         env._upgrade_metadata()
         cls._instance = env
+        cls.__initializing = False
 
     def __init__(self):
         assert self._instance is None, 'Env is a singleton; use Env.get() to access the instance'

--- a/pixeltable/metadata/__init__.py
+++ b/pixeltable/metadata/__init__.py
@@ -1,5 +1,6 @@
 import dataclasses
 import importlib
+import logging
 import os
 import pkgutil
 from typing import Callable
@@ -7,7 +8,12 @@ from typing import Callable
 import sqlalchemy as sql
 from sqlalchemy import orm
 
+from pixeltable.utils.console_output import ConsoleLogger
+
 from .schema import SystemInfo, SystemInfoMd
+
+_console_logger = ConsoleLogger(logging.getLogger('pixeltable'))
+
 
 # current version of the metadata; this is incremented whenever the metadata schema changes
 VERSION = 30
@@ -52,9 +58,8 @@ def upgrade_md(engine: sql.engine.Engine) -> None:
         while md_version < VERSION:
             if md_version not in converter_cbs:
                 raise RuntimeError(f'No metadata converter for version {md_version}')
-            from pixeltable.env import Env
-
-            Env.get().console_logger.info(f'Converting metadata from version {md_version} to {md_version + 1}')
+            # We can't use the console logger in Env, because Env might not have been initialized yet.
+            _console_logger.info(f'Converting metadata from version {md_version} to {md_version + 1}')
             converter_cbs[md_version](engine)
             md_version += 1
         # update system info

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,9 @@ def init_env(tmp_path_factory, worker_id) -> None:
     # don't have several processes trying to initialize pgserver in parallel.
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
     with FileLock(str(root_tmp_dir / 'pxt-init.lock')):
+        # We need to call `Env._init_env()` with `reinit_db=True`. This is because if a previous test run was
+        # interrupted (e.g., by an inopportune Ctrl-C), there may be residual DB artifacts that interfere with
+        # initialization.
         Env._init_env(reinit_db=True)
         pxt.init()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def init_env(tmp_path_factory, worker_id) -> None:
     # don't have several processes trying to initialize pgserver in parallel.
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
     with FileLock(str(root_tmp_dir / 'pxt-init.lock')):
+        Env._init_env(reinit_db=True)
         pxt.init()
 
     Env.get().configure_logging(level=logging.DEBUG, to_stdout=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 import tenacity
 from filelock import FileLock
+from sqlalchemy import orm
 
 import pixeltable as pxt
 import pixeltable.functions as pxtf
@@ -80,23 +81,27 @@ def reset_db(init_env) -> None:
     FileCache.get().set_capacity(10 << 30)  # 10 GiB
 
 
-def clean_db(restore_tables: bool = True) -> None:
+def clean_db(restore_md_tables: bool = True) -> None:
     from pixeltable.env import Env
 
-    # UUID-named data tables will
-    # not be cleaned. If in the future it is desirable to clean out data tables as well,
-    # the commented lines may be used to drop ALL tables from the test db.
-    # sql_md = declarative_base().metadata
-    # sql_md.reflect(Env.get().engine)
-    # sql_md.drop_all(bind=Env.get().engine)
+    # Drop all tables from the DB, including data tables. Dropping the data tables is necessary for certain tests,
+    # such as test_db_migration, that may lead to UUID collisions if interrupted.
     engine = Env.get().engine
-    SystemInfo.__table__.drop(engine, checkfirst=True)
-    TableSchemaVersion.__table__.drop(engine, checkfirst=True)
-    TableVersion.__table__.drop(engine, checkfirst=True)
-    Table.__table__.drop(engine, checkfirst=True)
-    Function.__table__.drop(engine, checkfirst=True)
-    Dir.__table__.drop(engine, checkfirst=True)
-    if restore_tables:
+    sql_md = orm.declarative_base().metadata
+    sql_md.reflect(engine)
+    sql_md.drop_all(bind=engine)
+
+    # The following lines may be uncommented as a replacement for the above, if one wishes to drop only metadata
+    # tables for testing purposes.
+    # SystemInfo.__table__.drop(engine, checkfirst=True)
+    # TableSchemaVersion.__table__.drop(engine, checkfirst=True)
+    # TableVersion.__table__.drop(engine, checkfirst=True)
+    # Table.__table__.drop(engine, checkfirst=True)
+    # Function.__table__.drop(engine, checkfirst=True)
+    # Dir.__table__.drop(engine, checkfirst=True)
+
+    if restore_md_tables:
+        # Restore metadata tables and system info
         Dir.__table__.create(engine)
         Function.__table__.create(engine)
         Table.__table__.create(engine)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -57,7 +57,7 @@ class TestMigration:
             # SQLAlchemy, but command-line Postgres won't know how to interpret it.)
             db_url = env._db_server.get_uri(env._db_name)
             _logger.info(f'DB URL: {db_url}')
-            clean_db(restore_tables=False)
+            clean_db(restore_md_tables=False)
             with open(dump_file, 'rb') as dump:
                 gunzip_process = subprocess.Popen(['gunzip', '-c'], stdin=dump, stdout=subprocess.PIPE)
                 subprocess.run(


### PR DESCRIPTION
Fixes two Pixeltable bugs that occurred sporadically:
- Calls to `Env.console_logger` during metadata upgrades sometimes resulted in circular `Env` initialization
- Interrupting the `test_db_migration` unit test could lead to unresolvable failures on subsequent runs due to UUID collisions in table IDs