### PR TITLE
Use just-in-time initialization for spaCy, speeding up pxt.init()

### DIFF
--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -527,8 +527,6 @@ class Env:
         """Check for and start runtime services"""
         self._start_web_server()
         self.__register_packages()
-        if self.is_installed_package('spacy'):
-            self.__init_spacy()
 
     def __register_packages(self) -> None:
         """Declare optional packages that are utilized by some parts of the code."""
@@ -611,37 +609,6 @@ class Env:
                 f'To fix this, run: `pip install -U {package_info.library_name}`'
             )
 
-    def __init_spacy(self) -> None:
-        """
-        spaCy relies on a pip-installed model to operate. In order to avoid requiring the model as a separate
-        dependency, we install it programmatically here. This should cause no problems, since the model packages
-        have no sub-dependencies (in fact, this is how spaCy normally manages its model resources).
-        """
-        import spacy
-        from spacy.cli.download import get_model_filename
-
-        spacy_model = 'en_core_web_sm'
-        spacy_model_version = '3.7.1'
-        filename = get_model_filename(spacy_model, spacy_model_version, sdist=False)
-        url = f'{spacy.about.__download_url__}/{filename}'
-        # Try to `pip install` the model. We set check=False; if the pip command fails, it's not necessarily
-        # a problem, because the model have been installed on a previous attempt.
-        self._logger.info(f'Ensuring spaCy model is installed: {filename}')
-        ret = subprocess.run([sys.executable, '-m', 'pip', 'install', '-qU', url], check=False)
-        if ret.returncode != 0:
-            self._logger.warning(f'pip install failed for spaCy model: {filename}')
-        try:
-            self._logger.info(f'Loading spaCy model: {spacy_model}')
-            self._spacy_nlp = spacy.load(spacy_model)
-        except Exception as exc:
-            self._logger.warning(f'Failed to load spaCy model: {spacy_model}', exc_info=exc)
-            warnings.warn(
-                f"Failed to load spaCy model '{spacy_model}'. spaCy features will not be available.",
-                excs.PixeltableWarning,
-                stacklevel=1,
-            )
-            self.__optional_packages['spacy'].is_installed = False
-
     def clear_tmp_dir(self) -> None:
         for path in glob.glob(f'{self._tmp_dir}/*'):
             if os.path.isdir(path):
@@ -692,8 +659,35 @@ class Env:
     @property
     def spacy_nlp(self) -> spacy.Language:
         Env.get().require_package('spacy')
+        if self._spacy_nlp is None:
+            self.__init_spacy()
         assert self._spacy_nlp is not None
         return self._spacy_nlp
+
+    def __init_spacy(self) -> None:
+        """
+        spaCy relies on a pip-installed model to operate. In order to avoid requiring the model as a separate
+        dependency, we install it programmatically here. This should cause no problems, since the model packages
+        have no sub-dependencies (in fact, this is how spaCy normally manages its model resources).
+        """
+        import spacy
+        from spacy.cli.download import get_model_filename
+
+        spacy_model = 'en_core_web_sm'
+        spacy_model_version = '3.7.1'
+        filename = get_model_filename(spacy_model, spacy_model_version, sdist=False)
+        url = f'{spacy.about.__download_url__}/{filename}'
+        # Try to `pip install` the model. We set check=False; if the pip command fails, it's not necessarily
+        # a problem, because the model might have been installed on a previous attempt.
+        self._logger.info(f'Ensuring spaCy model is installed: {filename}')
+        ret = subprocess.run([sys.executable, '-m', 'pip', 'install', '-qU', url], check=False)
+        if ret.returncode != 0:
+            self._logger.warning(f'pip install failed for spaCy model: {filename}')
+        self._logger.info(f'Loading spaCy model: {spacy_model}')
+        try:
+            self._spacy_nlp = spacy.load(spacy_model)
+        except Exception as exc:
+            raise excs.Error(f'Failed to load spaCy model: {spacy_model}') from exc
 
 
 def register_client(name: str) -> Callable:

--- a/pixeltable/iterators/document.py
+++ b/pixeltable/iterators/document.py
@@ -215,7 +215,7 @@ class DocumentSplitter(ComponentIterator):
 
         # check dependencies at the end
         if Separator.SENTENCE in separators:
-            Env.get().require_package('spacy')
+            _ = Env.get().spacy_nlp
         if Separator.TOKEN_LIMIT in separators:
             Env.get().require_package('tiktoken')
 


### PR DESCRIPTION
Switches spaCy to use just-in-time initialization (rather than initializing when pxt.init() is called). This reduces the execution time of pxt.init() from 4 seconds to ~180 ms in my ad hoc measurement.

There will still be a performance penalty at the first invocation of spaCy; this will happen if `StringIterator` or `DocumentIterator` is invoked with sentence-boundary chunking, and it will happen during iterator initialization, a much less obtrusive time than pxt.init().