### PR TITLE
Introduce `pxtf.map()` as a replacement for >> to create JsonMappers

### DIFF
--- a/pixeltable/__init__.py
+++ b/pixeltable/__init__.py
@@ -4,7 +4,6 @@ from .__version__ import __version__, __version_tuple__
 from .catalog import Column, InsertableTable, Table, UpdateStatus, View
 from .dataframe import DataFrame
 from .exceptions import Error, PixeltableWarning
-from .exprs import RELATIVE_PATH_ROOT
 from .func import Aggregator, Function, expr_udf, query, uda, udf
 from .globals import (
     array,

--- a/pixeltable/exprs/__init__.py
+++ b/pixeltable/exprs/__init__.py
@@ -14,7 +14,7 @@ from .in_predicate import InPredicate
 from .inline_expr import InlineArray, InlineDict, InlineList
 from .is_null import IsNull
 from .json_mapper import JsonMapper
-from .json_path import RELATIVE_PATH_ROOT, JsonPath
+from .json_path import JsonPath
 from .literal import Literal
 from .method_ref import MethodRef
 from .object_ref import ObjectRef

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -592,10 +592,6 @@ class Expr(abc.ABC):
                 # Return the `MethodRef` object itself; it requires arguments to become a `FunctionCall`
                 return method_ref
 
-    def __rshift__(self, other: object) -> 'exprs.Expr':
-        # Implemented here for type-checking purposes
-        raise excs.Error('The `>>` operator can only be applied to Json expressions')
-
     def __bool__(self) -> bool:
         raise TypeError(
             f'Pixeltable expressions cannot be used in conjunction with Python boolean operators (and/or/not)\n{self!r}'

--- a/pixeltable/exprs/json_mapper.py
+++ b/pixeltable/exprs/json_mapper.py
@@ -86,7 +86,7 @@ class JsonMapper(Expr):
         return self._src_expr.equals(other._src_expr) and self._target_expr.equals(other._target_expr)
 
     def __repr__(self) -> str:
-        return f'{str(self._src_expr)} >> {str(self._target_expr)}'
+        return f'map({str(self._src_expr)}, lambda R: {str(self._target_expr)})'
 
     @property
     def _src_expr(self) -> Expr:

--- a/pixeltable/exprs/json_path.py
+++ b/pixeltable/exprs/json_path.py
@@ -98,12 +98,6 @@ class JsonPath(Expr):
             return JsonPath(self._anchor, self.path_elements + [index])
         raise excs.Error(f'Invalid json list index: {index}')
 
-    def __rshift__(self, other: object) -> 'JsonMapper':
-        rhs_expr = Expr.from_object(other)
-        if rhs_expr is None:
-            raise excs.Error(f'>> requires an expression on the right-hand side, found {type(other)}')
-        return JsonMapper(self, rhs_expr)
-
     def default_column_name(self) -> Optional[str]:
         anchor_name = self._anchor.default_column_name() if self._anchor is not None else ''
         ret_name = f'{anchor_name}.{self._json_path()}'

--- a/pixeltable/func/tools.py
+++ b/pixeltable/func/tools.py
@@ -51,10 +51,10 @@ class Tool(pydantic.BaseModel):
     # The output of `tool_calls` must be a dict in standardized tool invocation format:
     # {tool_name: [{'args': {name1: value1, name2: value2, ...}}, ...], ...}
     def invoke(self, tool_calls: 'exprs.Expr') -> 'exprs.Expr':
-        from pixeltable import exprs
+        import pixeltable.functions as pxtf
 
         func_name = self.name or self.fn.name
-        return exprs.JsonMapper(tool_calls[func_name]['*'], self.__invoke_kwargs(exprs.RELATIVE_PATH_ROOT.args))
+        return pxtf.map(tool_calls[func_name]['*'], lambda x: self.__invoke_kwargs(x.args))
 
     def __invoke_kwargs(self, kwargs: 'exprs.Expr') -> 'exprs.FunctionCall':
         kwargs = {param.name: self.__extract_tool_arg(param, kwargs) for param in self.parameters.values()}

--- a/pixeltable/functions/__init__.py
+++ b/pixeltable/functions/__init__.py
@@ -24,7 +24,7 @@ from . import (
     vision,
     whisper,
 )
-from .globals import count, max, mean, min, sum
+from .globals import count, map, max, mean, min, sum
 
 __all__ = local_public_names(__name__, exclude=['globals']) + local_public_names(globals.__name__)
 

--- a/pixeltable/functions/globals.py
+++ b/pixeltable/functions/globals.py
@@ -1,14 +1,13 @@
 import builtins
 import typing
-
-from typing import _GenericAlias  # type: ignore[attr-defined]  # isort: skip
 from typing import Any, Callable, Optional, Union
 
 import sqlalchemy as sql
 
-import pixeltable.type_system as ts
-from pixeltable import exprs, func
+from pixeltable import exceptions as excs, exprs, func, type_system as ts
 from pixeltable.utils.code import local_public_names
+
+from typing import _GenericAlias  # type: ignore[attr-defined]  # isort: skip
 
 
 # TODO: remove and replace calls with astype()
@@ -169,7 +168,14 @@ def _(val: sql.ColumnElement) -> Optional[sql.ColumnElement]:
 
 
 def map(expr: exprs.Expr, fn: Callable[[exprs.Expr], Any]) -> exprs.Expr:
-    target_expr = exprs.Expr.from_object(fn(exprs.json_path.RELATIVE_PATH_ROOT))
+    target_expr: exprs.Expr
+    try:
+        target_expr = exprs.Expr.from_object(fn(exprs.json_path.RELATIVE_PATH_ROOT))
+    except Exception as e:
+        raise excs.Error(
+            'Failed to evaluate map function. '
+            '(The `fn` argument to `map()` must produce a valid Pixeltable expression.)'
+        ) from e
     return exprs.JsonMapper(expr, target_expr)
 
 

--- a/pixeltable/functions/globals.py
+++ b/pixeltable/functions/globals.py
@@ -1,7 +1,7 @@
 import builtins
 import typing
 
-from typing import _GenericAlias  # type: ignore[attr-defined]  # isort: skip
+from typing import _GenericAlias, Any, Callable  # type: ignore[attr-defined]  # isort: skip
 from typing import Optional, Union
 
 import sqlalchemy as sql
@@ -166,6 +166,11 @@ class mean(func.Aggregator, typing.Generic[T]):
 @mean.to_sql
 def _(val: sql.ColumnElement) -> Optional[sql.ColumnElement]:
     return sql.sql.func.avg(val)
+
+
+def map(expr: exprs.Expr, fn: Callable[[exprs.Expr], Any]) -> exprs.Expr:
+    target_expr = exprs.Expr.from_object(fn(exprs.RELATIVE_PATH_ROOT))
+    return exprs.JsonMapper(expr, target_expr)
 
 
 __all__ = local_public_names(__name__)

--- a/pixeltable/functions/globals.py
+++ b/pixeltable/functions/globals.py
@@ -1,8 +1,8 @@
 import builtins
 import typing
 
-from typing import _GenericAlias, Any, Callable  # type: ignore[attr-defined]  # isort: skip
-from typing import Optional, Union
+from typing import _GenericAlias  # type: ignore[attr-defined]  # isort: skip
+from typing import Any, Callable, Optional, Union
 
 import sqlalchemy as sql
 
@@ -169,7 +169,7 @@ def _(val: sql.ColumnElement) -> Optional[sql.ColumnElement]:
 
 
 def map(expr: exprs.Expr, fn: Callable[[exprs.Expr], Any]) -> exprs.Expr:
-    target_expr = exprs.Expr.from_object(fn(exprs.RELATIVE_PATH_ROOT))
+    target_expr = exprs.Expr.from_object(fn(exprs.json_path.RELATIVE_PATH_ROOT))
     return exprs.JsonMapper(expr, target_expr)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import pixeltable as pxt
 import pixeltable.functions as pxtf
 from pixeltable import catalog, exprs, func
 from pixeltable.env import Env
-from pixeltable.exprs import RELATIVE_PATH_ROOT as R
 from pixeltable.functions.huggingface import clip, sentence_transformer
 from pixeltable.metadata import SystemInfo, create_system_info
 from pixeltable.metadata.schema import Dir, Function, Table, TableSchemaVersion, TableVersion
@@ -132,7 +131,7 @@ def test_tbl_exprs(test_tbl: catalog.Table) -> list[exprs.Expr]:
         ~(t.c2 > 5),
         (t.c2 > 5) & (t.c1 == 'test'),
         (t.c2 > 5) | (t.c1 == 'test'),
-        t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]],
+        pxtf.map(t.c7['*'].f5, lambda x: [x[3], x[2], x[1], x[0]]),
         t.c8[0, 1:],
         t.c2.isin([1, 2, 3]),
         t.c2.isin(t.c6.f5),

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -634,22 +634,22 @@ class TestExprs:
         t = test_tbl
 
         # top-level is dict
-        res = reload_tester.run_query(t.select(input=t.c6.f5, output=t.c6.f5['*'] >> (R + 1)))
+        res = reload_tester.run_query(t.select(input=t.c6.f5, output=pxtf.map(t.c6.f5['*'], lambda x: x + 1)))
         for row in res:
             assert row['output'] == [x + 1 for x in row['input']]
 
         # top-level is list of dicts; subsequent json path element references the dicts
-        res = reload_tester.run_query(t.select(input=t.c7, output=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]))
+        res = reload_tester.run_query(t.select(input=t.c7, output=pxtf.map(t.c7['*'].f5, lambda x: [x[3], x[2], x[1], x[0]])))
         for row in res:
             assert row['output'] == [[d['f5'][3], d['f5'][2], d['f5'][1], d['f5'][0]] for d in row['input']]
 
         # target expr contains global-scope dependency
-        res = reload_tester.run_query(t.select(input=t.c6, output=t.c6.f5['*'] >> (R * t.c6.f5[1])))
+        res = reload_tester.run_query(t.select(input=t.c6, output=pxtf.map(t.c6.f5['*'], lambda x: x * t.c6.f5[1])))
         for row in res:
             assert row['output'] == [x * row['input']['f5'][1] for x in row['input']['f5']]
 
         # test it as a computed column
-        validate_update_status(t.add_computed_column(output=t.c6.f5['*'] >> (R * t.c6.f5[1])), 100)
+        validate_update_status(t.add_computed_column(output=pxtf.map(t.c6.f5['*'], lambda x: x * t.c6.f5[1])), 100)
         res2 = reload_tester.run_query(t.select(t.output))
         for row, row2 in zip(res, res2):
             assert row['output'] == row2['output']
@@ -659,9 +659,9 @@ class TestExprs:
     def test_multi_json_mapper(self, reset_db, reload_tester: ReloadTester) -> None:
         # Workflow with multiple JsonMapper instances
         t = pxt.create_table('test', {'jcol': pxt.Json})
-        t.add_computed_column(outputx=t.jcol.x['*'] >> (R + 1))
-        t.add_computed_column(outputy=t.jcol.y['*'] >> (R + 2))
-        t.add_computed_column(outputz=t.jcol.z['*'] >> (R + 3))
+        t.add_computed_column(outputx=pxtf.map(t.jcol.x['*'], lambda x: x + 1))
+        t.add_computed_column(outputy=pxtf.map(t.jcol.y['*'], lambda x: x + 2))
+        t.add_computed_column(outputz=pxtf.map(t.jcol.z['*'], lambda x: x + 3))
         for i in range(8):
             data = {}
             if (i & 1) != 0:
@@ -1447,8 +1447,8 @@ class TestExprs:
             # JsonPath
             (t.c_json.f2.f5[2:4][3], 'c_json.f2.f5[2:4][3]'),
             # JsonPath with relative root (with and without a succeeding path)
-            (t.c_json.f2.f5['*'] >> R, 'c_json.f2.f5[*] >> R'),
-            (t.c_json.f2.f5['*'] >> R.abcd, 'c_json.f2.f5[*] >> R.abcd'),
+            (pxtf.map(t.c_json.f2.f5['*'], lambda x: x), 'map(c_json.f2.f5[*], lambda R: R)'),
+            (pxtf.map(t.c_json.f2.f5['*'], lambda x: x.abcd), 'map(c_json.f2.f5[*], lambda R: R.abcd)'),
             # MethodRef
             (t.c_image.resize((100, 100)), 'c_image.resize([100, 100])'),
             # TypeCast

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -662,6 +662,9 @@ class TestExprs:
             assert row2['output'] == row_col['out2']
             assert row3['output'] == row_col['out3']
 
+        with pytest.raises(excs.Error, match='Failed to evaluate map function.'):
+            pxtf.map(t.c6.f5['*'], lambda x: x and False)
+
         reload_tester.run_reload_test()
 
     def test_multi_json_mapper(self, reset_db, reload_tester: ReloadTester) -> None:

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -17,7 +17,7 @@ import pixeltable as pxt
 import pixeltable.exceptions as excs
 import pixeltable.functions as pxtf
 from pixeltable import catalog, exprs
-from pixeltable.exprs import RELATIVE_PATH_ROOT as R, ColumnRef, Expr, Literal
+from pixeltable.exprs import ColumnRef, Expr, Literal
 from pixeltable.functions.globals import cast
 from pixeltable.iterators import FrameIterator
 
@@ -639,7 +639,9 @@ class TestExprs:
             assert row['output'] == [x + 1 for x in row['input']]
 
         # top-level is list of dicts; subsequent json path element references the dicts
-        res = reload_tester.run_query(t.select(input=t.c7, output=pxtf.map(t.c7['*'].f5, lambda x: [x[3], x[2], x[1], x[0]])))
+        res = reload_tester.run_query(
+            t.select(input=t.c7, output=pxtf.map(t.c7['*'].f5, lambda x: [x[3], x[2], x[1], x[0]]))
+        )
         for row in res:
             assert row['output'] == [[d['f5'][3], d['f5'][2], d['f5'][1], d['f5'][0]] for d in row['input']]
 

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -652,7 +652,9 @@ class TestExprs:
 
         # test it as a computed column
         validate_update_status(t.add_computed_column(out1=pxtf.map(t.c6.f5['*'], lambda x: x + 1)), 100)
-        validate_update_status(t.add_computed_column(out2=pxtf.map(t.c7['*'].f5, lambda x: [x[3], x[2], x[1], x[0]])), 100)
+        validate_update_status(
+            t.add_computed_column(out2=pxtf.map(t.c7['*'].f5, lambda x: [x[3], x[2], x[1], x[0]])), 100
+        )
         validate_update_status(t.add_computed_column(out3=pxtf.map(t.c6.f5['*'], lambda x: x * t.c6.f5[1])), 100)
         res_col = reload_tester.run_query(t.select(t.out1, t.out2, t.out3))
         for row1, row2, row3, row_col in zip(res1, res2, res3, res_col):


### PR DESCRIPTION
This introduces a `pxtf.map()` operator that uses lambdas to construct JsonMappers. In particular, the following:

```python
pxtf.map(my_expr, lambda x: x + 1)
```
has the identical meaning to:
```python
from exprs import RELATIVE_PATH_ROOT as R
my_expr >> R + 1
```

With this change, `RELATIVE_PATH_ROOT` becomes a purely internal implementation detail, no longer exposed to the user.