### PR TITLE
Linting for `ext`, `func`, `share`, and `utils` packages

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -179,7 +179,7 @@ jobs:
         run: mkdocs build --strict
       - name: Lint
         if: ${{ matrix.test-category == 'lint' }}
-        run: ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata
+        run: ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
       - name: Validate links in notebooks
         if: ${{ matrix.test-category == 'lint' }}
         run: ./scripts/lint-notebooks.sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -179,7 +179,7 @@ jobs:
         run: mkdocs build --strict
       - name: Lint
         if: ${{ matrix.test-category == 'lint' }}
-        run: ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/func pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
+        run: ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/func pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share pixeltable/utils
       - name: Validate links in notebooks
         if: ${{ matrix.test-category == 'lint' }}
         run: ./scripts/lint-notebooks.sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -179,7 +179,7 @@ jobs:
         run: mkdocs build --strict
       - name: Lint
         if: ${{ matrix.test-category == 'lint' }}
-        run: ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
+        run: ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/func pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
       - name: Validate links in notebooks
         if: ${{ matrix.test-category == 'lint' }}
         run: ./scripts/lint-notebooks.sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -179,7 +179,7 @@ jobs:
         run: mkdocs build --strict
       - name: Lint
         if: ${{ matrix.test-category == 'lint' }}
-        run: ruff check pixeltable/*.py pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata
+        run: ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata
       - name: Validate links in notebooks
         if: ${{ matrix.test-category == 'lint' }}
         run: ./scripts/lint-notebooks.sh

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ docstest: install
 .PHONY: lint
 lint: install
 	@echo "Running ruff check ..."
-	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata
+	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
 
 .PHONY: formattest
 formattest: install

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ docstest: install
 .PHONY: lint
 lint: install
 	@echo "Running ruff check ..."
-	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
+	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/func pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
 
 .PHONY: formattest
 formattest: install

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ docstest: install
 .PHONY: lint
 lint: install
 	@echo "Running ruff check ..."
-	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/func pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
+	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/func pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share pixeltable/utils
 
 .PHONY: formattest
 formattest: install

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ docstest: install
 .PHONY: lint
 lint: install
 	@echo "Running ruff check ..."
-	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
+	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/ext pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata pixeltable/share
 
 .PHONY: formattest
 formattest: install

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ docstest: install
 .PHONY: lint
 lint: install
 	@echo "Running ruff check ..."
-	@ruff check pixeltable/*.py pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata
+	@ruff check pixeltable/*.py pixeltable/exprs pixeltable/functions pixeltable/index pixeltable/iterators pixeltable/metadata
 
 .PHONY: formattest
 formattest: install

--- a/pixeltable/exprs/__init__.py
+++ b/pixeltable/exprs/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401
+
 from .arithmetic_expr import ArithmeticExpr
 from .array_slice import ArraySlice
 from .column_property_ref import ColumnPropertyRef

--- a/pixeltable/exprs/array_slice.py
+++ b/pixeltable/exprs/array_slice.py
@@ -41,7 +41,7 @@ class ArraySlice(Expr):
         return self.index == other.index
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('index', self.index)]
+        return [*super()._id_attrs(), ('index', self.index)]
 
     def sql_expr(self, _: SqlElementCache) -> Optional[sql.ColumnElement]:
         return None

--- a/pixeltable/exprs/column_property_ref.py
+++ b/pixeltable/exprs/column_property_ref.py
@@ -40,7 +40,7 @@ class ColumnPropertyRef(Expr):
         return self.prop == other.prop
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('prop', self.prop.value)]
+        return [*super()._id_attrs(), ('prop', self.prop.value)]
 
     @property
     def _col_ref(self) -> ColumnRef:
@@ -52,7 +52,7 @@ class ColumnPropertyRef(Expr):
         return f'{self._col_ref}.{self.prop.name.lower()}'
 
     def is_error_prop(self) -> bool:
-        return self.prop == self.Property.ERRORTYPE or self.prop == self.Property.ERRORMSG
+        return self.prop in {self.Property.ERRORTYPE, self.Property.ERRORMSG}
 
     def sql_expr(self, sql_elements: SqlElementCache) -> Optional[sql.ColumnElement]:
         if not self._col_ref.col.is_stored:
@@ -95,7 +95,7 @@ class ColumnPropertyRef(Expr):
             else:
                 data_row[self.slot_idx] = str(exc)
         else:
-            assert False
+            raise AssertionError()
 
     def _as_dict(self) -> dict:
         return {'prop': self.prop.value, **super()._as_dict()}

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -6,9 +6,7 @@ from uuid import UUID
 import sqlalchemy as sql
 
 import pixeltable as pxt
-import pixeltable.catalog as catalog
-import pixeltable.exceptions as excs
-import pixeltable.iterators as iters
+from pixeltable import catalog, exceptions as excs, iterators as iters
 
 from ..utils.description_helper import DescriptionHelper
 from .data_row import DataRow
@@ -84,7 +82,8 @@ class ColumnRef(Expr):
         assert len(self.iter_arg_ctx.target_slot_idxs) == 1  # a single inline dict
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [
+        return [
+            *super()._id_attrs(),
             ('tbl_id', self.col.tbl.id),
             ('col_id', self.col.id),
             ('perform_validation', self.perform_validation),

--- a/pixeltable/exprs/comparison.py
+++ b/pixeltable/exprs/comparison.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 import sqlalchemy as sql
 
@@ -14,9 +14,6 @@ from .globals import ComparisonOperator
 from .literal import Literal
 from .row_builder import RowBuilder
 from .sql_element_cache import SqlElementCache
-
-if TYPE_CHECKING:
-    from pixeltable import index
 
 
 class Comparison(Expr):
@@ -62,7 +59,7 @@ class Comparison(Expr):
         return self.operator == other.operator
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('operator', self.operator.value)]
+        return [*super()._id_attrs(), ('operator', self.operator.value)]
 
     @property
     def _op1(self) -> Expr:

--- a/pixeltable/exprs/expr_dict.py
+++ b/pixeltable/exprs/expr_dict.py
@@ -1,8 +1,8 @@
 from typing import Generic, Iterable, Iterator, Optional, TypeVar
 
-T = TypeVar('T')
-
 from .expr import Expr
+
+T = TypeVar('T')
 
 
 class ExprDict(Generic[T]):
@@ -47,7 +47,7 @@ class ExprDict(Generic[T]):
         self._data.clear()
 
     def keys(self) -> Iterator[Expr]:
-        return self.__iter__()
+        return iter(self)
 
     def values(self) -> Iterator[T]:
         return (value for _, value in self._data.values())

--- a/pixeltable/exprs/expr_set.py
+++ b/pixeltable/exprs/expr_set.py
@@ -46,7 +46,7 @@ class ExprSet(Generic[T]):
 
     def __getitem__(self, index: object) -> Optional[T]:
         """Indexed lookup by slot_idx or Expr.id."""
-        assert isinstance(index, int) or isinstance(index, Expr)
+        assert isinstance(index, (int, Expr))
         if isinstance(index, int):
             # return expr with matching slot_idx
             return self.exprs_by_idx.get(index)

--- a/pixeltable/exprs/globals.py
+++ b/pixeltable/exprs/globals.py
@@ -36,7 +36,7 @@ class ComparisonOperator(enum.Enum):
             return '>'
         if self == self.GE:
             return '>='
-        assert False
+        raise AssertionError()
 
     def reverse(self) -> ComparisonOperator:
         if self == self.LT:
@@ -62,7 +62,7 @@ class LogicalOperator(enum.Enum):
             return '|'
         if self == self.NOT:
             return '~'
-        assert False
+        raise AssertionError()
 
 
 class ArithmeticOperator(enum.Enum):
@@ -86,4 +86,4 @@ class ArithmeticOperator(enum.Enum):
             return '%'
         if self == self.FLOORDIV:
             return '//'
-        assert False
+        raise AssertionError()

--- a/pixeltable/exprs/in_predicate.py
+++ b/pixeltable/exprs/in_predicate.py
@@ -71,7 +71,7 @@ class InPredicate(Expr):
         return self.value_list == other.value_list
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('value_list', self.value_list)]
+        return [*super()._id_attrs(), ('value_list', self.value_list)]
 
     def sql_expr(self, sql_elements: SqlElementCache) -> Optional[sql.ColumnElement]:
         lhs_sql_exprs = sql_elements.get(self.components[0])

--- a/pixeltable/exprs/inline_expr.py
+++ b/pixeltable/exprs/inline_expr.py
@@ -131,7 +131,7 @@ class InlineList(Expr):
     def as_literal(self) -> Optional[Literal]:
         if not all(isinstance(comp, Literal) for comp in self.components):
             return None
-        return Literal(list(c.as_literal().val for c in self.components), self.col_type)
+        return Literal([c.as_literal().val for c in self.components], self.col_type)
 
 
 class InlineDict(Expr):
@@ -166,7 +166,7 @@ class InlineDict(Expr):
         self.id = self._create_id()
 
     def __repr__(self) -> str:
-        item_strs = list(f"'{key}': {str(expr)}" for key, expr in zip(self.keys, self.components))
+        item_strs = [f"'{key}': {expr}" for key, expr in zip(self.keys, self.components)]
         return '{' + ', '.join(item_strs) + '}'
 
     def _equals(self, other: InlineDict) -> bool:
@@ -174,7 +174,7 @@ class InlineDict(Expr):
         return self.keys == other.keys
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('keys', self.keys)]
+        return [*super()._id_attrs(), ('keys', self.keys)]
 
     def sql_expr(self, _: SqlElementCache) -> Optional[sql.ColumnElement]:
         return None

--- a/pixeltable/exprs/is_null.py
+++ b/pixeltable/exprs/is_null.py
@@ -19,7 +19,7 @@ class IsNull(Expr):
         self.id = self._create_id()
 
     def __repr__(self) -> str:
-        return f'{str(self.components[0])} == None'
+        return f'{self.components[0]} == None'
 
     def _equals(self, other: IsNull) -> bool:
         return True

--- a/pixeltable/exprs/json_mapper.py
+++ b/pixeltable/exprs/json_mapper.py
@@ -81,12 +81,12 @@ class JsonMapper(Expr):
         """
         We override equals() because we need to avoid comparing our scope anchor.
         """
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
         return self._src_expr.equals(other._src_expr) and self._target_expr.equals(other._target_expr)
 
     def __repr__(self) -> str:
-        return f'{str(self._src_expr)} >> {str(self._target_expr)}'
+        return f'{self._src_expr} >> {self._target_expr}'
 
     @property
     def _src_expr(self) -> Expr:

--- a/pixeltable/exprs/literal.py
+++ b/pixeltable/exprs/literal.py
@@ -62,7 +62,7 @@ class Literal(Expr):
         return self.val == other.val
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('val', self.val)]
+        return [*super()._id_attrs(), ('val', self.val)]
 
     def sql_expr(self, _: SqlElementCache) -> Optional[sql.ColumnElement]:
         # Return a sql object so that constants can participate in SQL expressions

--- a/pixeltable/exprs/method_ref.py
+++ b/pixeltable/exprs/method_ref.py
@@ -53,13 +53,13 @@ class MethodRef(Expr):
         return self.base_expr.id == other.base_expr.id and self.method_name == other.method_name
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('method_name', self.method_name)]
+        return [*super()._id_attrs(), ('method_name', self.method_name)]
 
     def sql_expr(self, _: SqlElementCache) -> Optional[sql.ColumnElement]:
         return None
 
     def eval(self, data_row: DataRow, row_builder: RowBuilder) -> None:
-        assert False, 'MethodRef cannot be evaluated directly'
+        raise AssertionError('MethodRef cannot be evaluated directly')
 
     def __repr__(self) -> str:
         return f'{self.base_expr}.{self.method_name}'

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -8,9 +8,7 @@ from uuid import UUID
 
 import numpy as np
 
-import pixeltable.catalog as catalog
-import pixeltable.exceptions as excs
-import pixeltable.utils as utils
+from pixeltable import catalog, exceptions as excs, utils
 from pixeltable.env import Env
 from pixeltable.utils.media_store import MediaStore
 
@@ -366,8 +364,8 @@ class RowBuilder:
     def set_exc(self, data_row: DataRow, slot_idx: int, exc: Exception) -> None:
         """Record an exception in data_row and propagate it to dependents"""
         data_row.set_exc(slot_idx, exc)
-        for slot_idx in self._exc_dependents[slot_idx]:
-            data_row.set_exc(slot_idx, exc)
+        for idx in self._exc_dependents[slot_idx]:
+            data_row.set_exc(idx, exc)
 
     def eval(
         self,

--- a/pixeltable/exprs/rowid_ref.py
+++ b/pixeltable/exprs/rowid_ref.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import Any, Optional, cast
 from uuid import UUID
 
 import sqlalchemy as sql
 
-import pixeltable.catalog as catalog
-import pixeltable.type_system as ts
+from pixeltable import catalog, type_system as ts
 
 from .data_row import DataRow
 from .expr import Expr
 from .row_builder import RowBuilder
 from .sql_element_cache import SqlElementCache
-
-if TYPE_CHECKING:
-    from pixeltable import store
 
 
 class RowidRef(Expr):
@@ -68,7 +64,8 @@ class RowidRef(Expr):
         )
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [
+        return [
+            *super()._id_attrs(),
             ('normalized_base_id', self.normalized_base_id),
             ('idx', self.rowid_component_idx),
         ]

--- a/pixeltable/exprs/similarity_expr.py
+++ b/pixeltable/exprs/similarity_expr.py
@@ -62,14 +62,14 @@ class SimilarityExpr(Expr):
         return f'{self.components[0]}.similarity({self.components[1]})'
 
     def _id_attrs(self):
-        return super()._id_attrs() + [('idx_name', self.idx_info.name)]
+        return [*super()._id_attrs(), ('idx_name', self.idx_info.name)]
 
     def default_column_name(self) -> str:
         return 'similarity'
 
     def sql_expr(self, _: SqlElementCache) -> Optional[sql.ColumnElement]:
         if not isinstance(self.components[1], Literal):
-            raise excs.Error(f'similarity(): requires a string or a PIL.Image.Image object, not an expression')
+            raise excs.Error('similarity(): requires a string or a PIL.Image.Image object, not an expression')
         item = self.components[1].val
         from pixeltable import index
 
@@ -78,7 +78,7 @@ class SimilarityExpr(Expr):
 
     def as_order_by_clause(self, is_asc: bool) -> Optional[sql.ColumnElement]:
         if not isinstance(self.components[1], Literal):
-            raise excs.Error(f'similarity(): requires a string or a PIL.Image.Image object, not an expression')
+            raise excs.Error('similarity(): requires a string or a PIL.Image.Image object, not an expression')
         item = self.components[1].val
         from pixeltable import index
 
@@ -87,14 +87,14 @@ class SimilarityExpr(Expr):
 
     def eval(self, data_row: DataRow, row_builder: RowBuilder) -> None:
         # this should never get called
-        assert False
+        raise AssertionError()
 
     def _as_dict(self) -> dict:
         return {'idx_name': self.idx_info.name, **super()._as_dict()}
 
     @classmethod
     def _from_dict(cls, d: dict, components: list[Expr]) -> 'SimilarityExpr':
-        iname = d['idx_name'] if 'idx_name' in d else None
+        iname = d.get('idx_name')
         assert len(components) == 2
         assert isinstance(components[0], ColumnRef)
         return cls(components[0], components[1], idx_name=iname)

--- a/pixeltable/exprs/sql_element_cache.py
+++ b/pixeltable/exprs/sql_element_cache.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Union, cast
+from typing import Iterable, Optional
 
 import sqlalchemy as sql
 

--- a/pixeltable/exprs/type_cast.py
+++ b/pixeltable/exprs/type_cast.py
@@ -1,9 +1,8 @@
-from typing import Any, Optional, Union
+from typing import Optional
 
 import sqlalchemy as sql
 
-import pixeltable.exprs as exprs
-import pixeltable.type_system as ts
+from pixeltable import type_system as ts
 
 from .expr import DataRow, Expr
 from .literal import Literal

--- a/pixeltable/exprs/variable.py
+++ b/pixeltable/exprs/variable.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, NoReturn
 
-import pixeltable.type_system as ts
+from pixeltable import type_system as ts
 
 from .data_row import DataRow
 from .expr import Expr
@@ -22,7 +22,7 @@ class Variable(Expr):
         self.id = self._create_id()
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        return super()._id_attrs() + [('name', self.name)]
+        return [*super()._id_attrs(), ('name', self.name)]
 
     def default_column_name(self) -> NoReturn:
         raise NotImplementedError()

--- a/pixeltable/ext/__init__.py
+++ b/pixeltable/ext/__init__.py
@@ -4,6 +4,8 @@ are not intended for production use. Long-term support cannot be guaranteed, usu
 have dependencies whose future support is unclear.
 """
 
+# ruff: noqa: F401
+
 from pixeltable.utils.code import local_public_names
 
 from . import functions

--- a/pixeltable/ext/functions/__init__.py
+++ b/pixeltable/ext/functions/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401
+
 from pixeltable.utils.code import local_public_names
 
 from . import whisperx, yolox

--- a/pixeltable/ext/functions/yolox.py
+++ b/pixeltable/ext/functions/yolox.py
@@ -111,10 +111,10 @@ def _images_to_tensors(images: Iterable[PIL.Image.Image], exp: 'Exp') -> Iterato
     import torch
     from yolox.data import ValTransform  # type: ignore[import-untyped]
 
-    _val_transform = ValTransform(legacy=False)
+    val_transform = ValTransform(legacy=False)
     for image in images:
-        image = normalize_image_mode(image)
-        image_transform, _ = _val_transform(np.array(image), None, exp.test_size)
+        normalized_image = normalize_image_mode(image)
+        image_transform, _ = val_transform(np.array(normalized_image), None, exp.test_size)
         yield torch.from_numpy(image_transform)
 
 

--- a/pixeltable/func/__init__.py
+++ b/pixeltable/func/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F401
+
 from .aggregate_function import AggregateFunction, Aggregator, uda
 from .callable_function import CallableFunction
 from .expr_template_function import ExprTemplateFunction

--- a/pixeltable/func/aggregate_function.py
+++ b/pixeltable/func/aggregate_function.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Sequence, overload
 
 import pixeltable.exceptions as excs
 import pixeltable.type_system as ts
@@ -16,11 +16,12 @@ if TYPE_CHECKING:
 
 
 class Aggregator(abc.ABC):
-    def update(self, *args: Any, **kwargs: Any) -> None:
-        pass
 
-    def value(self) -> Any:
-        pass
+    @abc.abstractmethod
+    def update(self, *args: Any, **kwargs: Any) -> None: ...
+
+    @abc.abstractmethod
+    def value(self) -> Any: ...
 
 
 class AggregateFunction(Function):
@@ -32,9 +33,9 @@ class AggregateFunction(Function):
     allows_window: if True, the aggregate function can be used with a window
     """
 
-    ORDER_BY_PARAM = 'order_by'
-    GROUP_BY_PARAM = 'group_by'
-    RESERVED_PARAMS = {ORDER_BY_PARAM, GROUP_BY_PARAM}
+    ORDER_BY_PARAM: ClassVar[str] = 'order_by'
+    GROUP_BY_PARAM: ClassVar[str] = 'group_by'
+    RESERVED_PARAMS: ClassVar[set[str]] = {ORDER_BY_PARAM, GROUP_BY_PARAM}
 
     agg_classes: list[type[Aggregator]]  # classes for each signature, in signature order
     init_param_names: list[list[str]]  # names of the __init__ parameters for each signature
@@ -124,7 +125,7 @@ class AggregateFunction(Function):
             )
             for i, p in enumerate(py_init_params)
         ]
-        duplicate_params = set(p.name for p in init_params) & set(p.name for p in update_params)
+        duplicate_params = {p.name for p in init_params} & {p.name for p in update_params}
         if len(duplicate_params) > 0:
             raise excs.Error(
                 f'__init__() and update() cannot have parameters with the same name: {", ".join(duplicate_params)}'

--- a/pixeltable/func/aggregate_function.py
+++ b/pixeltable/func/aggregate_function.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
 
 class Aggregator(abc.ABC):
-
     @abc.abstractmethod
     def update(self, *args: Any, **kwargs: Any) -> None: ...
 

--- a/pixeltable/func/callable_function.py
+++ b/pixeltable/func/callable_function.py
@@ -98,11 +98,10 @@ class CallableFunction(Function):
                 result = self.py_fn(*batched_args, **constant_kwargs, **batched_kwargs)
             assert len(result) == 1
             return result[0]
+        elif inspect.iscoroutinefunction(self.py_fn):
+            return asyncio.run(self.py_fn(*args, **kwargs))
         else:
-            if inspect.iscoroutinefunction(self.py_fn):
-                return asyncio.run(self.py_fn(*args, **kwargs))
-            else:
-                return self.py_fn(*args, **kwargs)
+            return self.py_fn(*args, **kwargs)
 
     async def aexec_batch(self, *args: Any, **kwargs: Any) -> list:
         """Execute the function with the given arguments and return the result.

--- a/pixeltable/func/expr_template_function.py
+++ b/pixeltable/func/expr_template_function.py
@@ -1,8 +1,6 @@
-import inspect
 from typing import Any, Optional, Sequence
 
-import pixeltable
-import pixeltable.exceptions as excs
+from pixeltable import exceptions as excs, exprs
 
 from .function import Function
 from .signature import Signature
@@ -15,13 +13,11 @@ class ExprTemplate:
     `CallableFunction`.)
     """
 
-    expr: 'pixeltable.exprs.Expr'
+    expr: 'exprs.Expr'
     signature: Signature
-    param_exprs: dict[str, 'pixeltable.exprs.Variable']
+    param_exprs: dict[str, 'exprs.Variable']
 
-    def __init__(self, expr: 'pixeltable.exprs.Expr', signature: Signature):
-        from pixeltable import exprs
-
+    def __init__(self, expr: 'exprs.Expr', signature: Signature):
         self.expr = expr
         self.signature = signature
 
@@ -59,9 +55,7 @@ class ExprTemplateFunction(Function):
         assert not self.is_polymorphic
         return self.templates[0]
 
-    def instantiate(self, args: Sequence[Any], kwargs: dict[str, Any]) -> 'pixeltable.exprs.Expr':
-        from pixeltable import exprs
-
+    def instantiate(self, args: Sequence[Any], kwargs: dict[str, Any]) -> 'exprs.Expr':
         assert not self.is_polymorphic
         template = self.template
         bound_args = self.signature.py_signature.bind(*args, **kwargs).arguments
@@ -86,14 +80,12 @@ class ExprTemplateFunction(Function):
         return result
 
     def _docstring(self) -> Optional[str]:
-        from pixeltable import exprs
-
         if isinstance(self.templates[0].expr, exprs.FunctionCall):
             return self.templates[0].expr.fn._docstring()
         return None
 
     def exec(self, args: Sequence[Any], kwargs: dict[str, Any]) -> Any:
-        from pixeltable import exec, exprs
+        from pixeltable import exec
 
         assert not self.is_polymorphic
         expr = self.instantiate(args, kwargs)
@@ -130,7 +122,5 @@ class ExprTemplateFunction(Function):
         if 'expr' not in d:
             return super()._from_dict(d)
         assert 'signature' in d and 'name' in d
-        import pixeltable.exprs as exprs
-
         template = ExprTemplate(exprs.Expr.from_dict(d['expr']), Signature.from_dict(d['signature']))
         return cls([template], name=d['name'])

--- a/pixeltable/func/function_registry.py
+++ b/pixeltable/func/function_registry.py
@@ -9,9 +9,7 @@ from uuid import UUID
 
 import sqlalchemy as sql
 
-import pixeltable.env as env
-import pixeltable.exceptions as excs
-import pixeltable.type_system as ts
+from pixeltable import env, exceptions as excs, type_system as ts
 from pixeltable.metadata import schema
 
 from .function import Function

--- a/pixeltable/func/query_template_function.py
+++ b/pixeltable/func/query_template_function.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, Optional, overload
 
-import sqlalchemy as sql
-
-import pixeltable.exceptions as excs
-import pixeltable.type_system as ts
-from pixeltable import exprs
+from pixeltable import exprs, type_system as ts
 
 from .function import Function
 from .signature import Signature

--- a/pixeltable/func/tools.py
+++ b/pixeltable/func/tools.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 
 import pydantic
 
@@ -69,7 +69,7 @@ class Tool(pydantic.BaseModel):
             return _extract_float_tool_arg(kwargs, param_name=param.name)
         if param.col_type.is_bool_type():
             return _extract_bool_tool_arg(kwargs, param_name=param.name)
-        assert False
+        raise AssertionError()
 
 
 class ToolChoice(pydantic.BaseModel):
@@ -113,7 +113,7 @@ class Tools(pydantic.BaseModel):
                 )
                 tool_name = tool_obj.name or tool_obj.fn.name
             except StopIteration:
-                raise excs.Error(f'That tool is not in the specified list of tools: {tool}')
+                raise excs.Error(f'That tool is not in the specified list of tools: {tool}') from None
         return ToolChoice(auto=auto, required=required, tool=tool_name, parallel_tool_calls=parallel_tool_calls)
 
 

--- a/pixeltable/func/udf.py
+++ b/pixeltable/func/udf.py
@@ -146,7 +146,8 @@ def make_function(
             raise excs.Error(f'Cannot specify both `is_method` and `is_property` (in function `{function_name}`)')
         if is_property and len(sig.parameters) != 1:
             raise excs.Error(
-                f'`is_property=True` expects a UDF with exactly 1 parameter, but `{function_name}` has {len(sig.parameters)}'
+                '`is_property=True` expects a UDF with exactly 1 parameter, but '
+                f'`{function_name}` has {len(sig.parameters)}'
             )
         if (is_method or is_property) and function_path is None:
             raise excs.Error('Stored functions cannot be declared using `is_method` or `is_property`')
@@ -205,6 +206,8 @@ def expr_udf(*, param_types: Optional[list[ts.ColumnType]] = None) -> Callable[[
 
 def expr_udf(*args: Any, **kwargs: Any) -> Any:
     def make_expr_template(py_fn: Callable, param_types: Optional[list[ts.ColumnType]]) -> ExprTemplateFunction:
+        from pixeltable import exprs
+
         if py_fn.__module__ != '__main__' and py_fn.__name__.isidentifier():
             # this is a named function in a module
             function_path = f'{py_fn.__module__}.{py_fn.__qualname__}'
@@ -216,7 +219,6 @@ def expr_udf(*args: Any, **kwargs: Any) -> Any:
 
         # construct Signature from the function signature
         sig = Signature.create(py_fn=py_fn, param_types=param_types, return_type=ts.InvalidType())
-        import pixeltable.exprs as exprs
 
         var_exprs = [exprs.Variable(param.name, param.col_type) for param in sig.parameters.values()]
         # call the function with the parameter expressions to construct an Expr with parameters
@@ -260,7 +262,7 @@ def from_table(
     """
     from pixeltable import exprs
 
-    ancestors = [tbl] + tbl._bases
+    ancestors = [tbl, *tbl._bases]
     ancestors.reverse()  # We must traverse the ancestors in order from base to derived
 
     subst: dict[exprs.Expr, exprs.Expr] = {}

--- a/pixeltable/share/__init__.py
+++ b/pixeltable/share/__init__.py
@@ -1,1 +1,3 @@
+# ruff: noqa: F401
+
 from .publish import publish_snapshot

--- a/pixeltable/share/packager.py
+++ b/pixeltable/share/packager.py
@@ -66,8 +66,8 @@ class TablePackager:
                 'tables': [
                     {
                         'table_id': str(t._tbl_version.id),
-                        # These are temporary; will replace with a better solution once the concurrency changes to catalog have
-                        # been merged
+                        # These are temporary; will replace with a better solution once the concurrency
+                        # changes to catalog have been merged
                         'table_md': dataclasses.asdict(t._tbl_version.get()._create_tbl_md()),
                         'table_version_md': dataclasses.asdict(
                             t._tbl_version.get()._create_version_md(datetime.now().timestamp())
@@ -98,7 +98,7 @@ class TablePackager:
             for t in ancestors:
                 _logger.info(f"Exporting table '{t._path}'.")
                 self.__export_table(t)
-        _logger.info(f'Building archive.')
+        _logger.info('Building archive.')
         bundle_path = self.__build_tarball()
         _logger.info(f'Packaging complete: {bundle_path}')
         return bundle_path

--- a/pixeltable/share/publish.py
+++ b/pixeltable/share/publish.py
@@ -1,16 +1,14 @@
-import dataclasses
 import os
 import sys
 import urllib.parse
 import urllib.request
-from datetime import datetime
 from pathlib import Path
 
 import requests
 from tqdm import tqdm
 
 import pixeltable as pxt
-from pixeltable import exceptions as excs, metadata
+from pixeltable import exceptions as excs
 from pixeltable.env import Env
 from pixeltable.utils import sha256sum
 
@@ -46,7 +44,7 @@ def publish_snapshot(dest_tbl_uri: str, src_tbl: pxt.Table) -> str:
     else:
         raise excs.Error(f'Unsupported destination: {destination_uri}')
 
-    Env.get().console_logger.info(f'Finalizing snapshot ...')
+    Env.get().console_logger.info('Finalizing snapshot ...')
 
     finalize_request_json = {
         'upload_id': upload_id,
@@ -83,7 +81,7 @@ def _upload_bundle_to_s3(bundle: Path, parsed_location: urllib.parse.ParseResult
     upload_args = {'ChecksumAlgorithm': 'SHA256'}
 
     progress_bar = tqdm(
-        desc=f'Uploading',
+        desc='Uploading',
         total=bundle.stat().st_size,
         unit='B',
         unit_scale=True,

--- a/pixeltable/utils/coco.py
+++ b/pixeltable/utils/coco.py
@@ -103,7 +103,7 @@ def write_coco_dataset(df: pxt.DataFrame, dest_path: Path) -> Path:
         # create annotation records for this image
         for annotation in input_dict['annotations']:
             ann_id += 1
-            x, y, w, h = annotation['bbox']
+            _, _, w, h = annotation['bbox']
             category = annotation['category']
             categories.add(category)
             annotations.append(
@@ -119,7 +119,7 @@ def write_coco_dataset(df: pxt.DataFrame, dest_path: Path) -> Path:
             )
 
     # replace category names with ids
-    category_ids = {category: id for id, category in enumerate(sorted(list(categories)))}
+    category_ids = {category: id for id, category in enumerate(sorted(categories))}
     for annotation in annotations:
         annotation['category_id'] = category_ids[annotation['category_id']]
 
@@ -129,8 +129,8 @@ def write_coco_dataset(df: pxt.DataFrame, dest_path: Path) -> Path:
         'categories': [{'id': id, 'name': category} for category, id in category_ids.items()],
     }
     output_path = dest_path / 'data.json'
-    with open(output_path, 'w') as f:
-        json.dump(result, f)
+    with open(output_path, 'w', encoding='utf-8') as fp:
+        json.dump(result, fp)
     return output_path
 
 

--- a/pixeltable/utils/console_output.py
+++ b/pixeltable/utils/console_output.py
@@ -34,9 +34,7 @@ class ConsoleOutputHandler(logging.StreamHandler):
 
 class ConsoleMessageFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
-        if hasattr(record, 'user_visible') and record.user_visible:
-            return True
-        return False
+        return getattr(record, 'user_visible', False)
 
 
 class ConsoleLogger(logging.LoggerAdapter):

--- a/pixeltable/utils/description_helper.py
+++ b/pixeltable/utils/description_helper.py
@@ -80,7 +80,7 @@ class DescriptionHelper:
             if styler is None:
                 styler = descriptor.body.style
             styler = styler.set_properties(None, **{'white-space': 'pre-wrap', 'text-align': 'left'}).set_table_styles(
-                [dict(selector='th', props=[('text-align', 'left')])]
+                [{'selector': 'th', 'props': [('text-align', 'left')]}]
             )
             if not descriptor.show_header:
                 styler = styler.hide(axis='columns')

--- a/pixeltable/utils/documents.py
+++ b/pixeltable/utils/documents.py
@@ -95,8 +95,8 @@ def get_markdown_handle(path: str) -> Optional[dict]:
 
 def get_txt(path: str) -> Optional[str]:
     try:
-        with open(path, 'r') as f:
-            doc = f.read()
-        return doc if doc != '' else None
+        with open(path, 'r', encoding='utf-8') as fp:
+            doc = fp.read()
+        return doc or None  # replace '' with None
     except Exception:
         return None

--- a/pixeltable/utils/formatter.py
+++ b/pixeltable/utils/formatter.py
@@ -8,8 +8,7 @@ from typing import Any, Callable, Optional
 
 import av
 import numpy as np
-import PIL
-import PIL.Image as Image
+from PIL import Image
 
 import pixeltable.type_system as ts
 from pixeltable.utils.http_server import get_file_uri
@@ -213,7 +212,7 @@ class Formatter:
                 inner_element = f"""
                     <img style="object-fit: contain; border: 1px solid black;" src="{img_src}" />
                 """
-            except:
+            except Exception:
                 logging.warning(f'Failed to produce PDF thumbnail {file_path}. Make sure you have PyMuPDF installed.')
 
         return f"""

--- a/pixeltable/utils/media_store.py
+++ b/pixeltable/utils/media_store.py
@@ -69,7 +69,7 @@ class MediaStore:
                 assert matched is not None
                 tbl_id, col_id = UUID(hex=matched[1]), int(matched[2])
                 file_info = os.stat(p)
-                t = d[(tbl_id, col_id)]
+                t = d[tbl_id, col_id]
                 t[0] += 1
                 t[1] += file_info.st_size
         result = [(tbl_id, col_id, num_files, size) for (tbl_id, col_id), (num_files, size) in d.items()]

--- a/pixeltable/utils/pytorch.py
+++ b/pixeltable/utils/pytorch.py
@@ -32,7 +32,7 @@ class PixeltablePytorchDataset(torch.utils.data.IterableDataset):
 
         self.path = path
         self.image_format = image_format
-        assert image_format in ['np', 'pt']
+        assert image_format in {'np', 'pt'}
         column_type_path = path / '.pixeltable.column_types.json'
         assert column_type_path.exists(), f'missing {column_type_path}'
         with column_type_path.open() as f:

--- a/pixeltable/utils/sql.py
+++ b/pixeltable/utils/sql.py
@@ -5,7 +5,7 @@ from sqlalchemy.dialects import postgresql
 
 
 def log_stmt(logger: logging.Logger, stmt) -> None:
-    logger.debug(f'executing {str(stmt.compile(dialect=postgresql.dialect()))}')
+    logger.debug(f'executing {stmt.compile(dialect=postgresql.dialect())}')
 
 
 def log_explain(logger: logging.Logger, stmt: sql.sql.ClauseElement, conn: sql.engine.Connection) -> None:
@@ -13,7 +13,7 @@ def log_explain(logger: logging.Logger, stmt: sql.sql.ClauseElement, conn: sql.e
         # don't set dialect=Env.get().engine.dialect: x % y turns into x %% y, which results in a syntax error
         stmt_str = str(stmt.compile(compile_kwargs={'literal_binds': True}))
         explain_result = conn.execute(sql.text(f'EXPLAIN {stmt_str}'))
-        explain_str = '\n'.join([str(row) for row in explain_result])
+        explain_str = '\n'.join(str(row) for row in explain_result)
         logger.debug(f'SqlScanNode explain:\n{explain_str}')
-    except Exception as e:
-        logger.warning(f'EXPLAIN failed')
+    except Exception:
+        logger.warning('EXPLAIN failed')

--- a/pixeltable/utils/transactional_directory.py
+++ b/pixeltable/utils/transactional_directory.py
@@ -14,7 +14,8 @@ def transactional_directory(folder_path: Path) -> Generator[Path, Any, Any]:
 
     Yields:
         A pathlib.Path to a hidden temporary folder, which can be used to accumulate changes.
-        If everything succeeds, the changes are committed via an atomic move operation upon exiting the 'with' block (os.replace)
+        If everything succeeds, the changes are committed via an atomic move operation upon
+        exiting the 'with' block (os.replace)
         If an exception occurred, no changes are visible in the original folder.
 
     Example:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,17 +209,17 @@ exclude = ["*.ipynb"]  # For now, exclude notebooks
 line-length = 120
 
 [tool.ruff.lint]
-select = ["F", "E", "W", "C", "N", "B", "ICN", "PYI", "SIM", "TD002", "PL", "RUF"]  # everything except "I"
+select = ["B", "C", "E", "F", "ICN", "N", "PL", "PYI", "RUF", "SIM", "TD002", "W"]
 ignore = [
     "B023",  # Function definition does not bind to loop variable (appears to generate false positives)
     # A bunch of rules that are just plain fussy about code complexity:
     "C901", "PLR0904", "PLR0911", "PLR0912", "PLR0913", "PLR0914", "PLR0915", "PLR0916", "PLR0917", "PLR1702",
     "E711",  # None comparison (x == None); needed for Pandas/Pixeltable expressions
     "N801",  # Class name should use CapWords convention (we intentionally violate this for aggregate functions)
-    "PLC0415",
+    "PLC0415",  # Allow imports within functions (I don't see how this linting rule could ever work)
     "PLC2701",  # Allow private name imports
     "PLE0605",  # Invalid format for __all__ (appears to generate false positives)
-    "PLR2004",
+    "PLR2004",  # Permit "magic values" (numbers that are not defined as constants)
     "PLR6301",  # Class method (not sure what to do yet)
     "PLW3201",  # Dunder method has no special meaning (conflicts with _repr_html_)
     "SIM108",  # Don't prefer use of ternary if/else operator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ ignore = [
     "PLE0605",  # Invalid format for __all__ (appears to generate false positives)
     "PLR2004",  # Permit "magic values" (numbers that are not defined as constants)
     "PLR6301",  # Class method (not sure what to do yet)
+    "PLW0108",  # Lambda may be unnecessary (gives false positives, e.g., for an arity-reducing lambda)
     "PLW3201",  # Dunder method has no special meaning (conflicts with _repr_html_)
     "SIM108",  # Don't prefer use of ternary if/else operator
     "TD002"  # Don't require author for TODOs


### PR DESCRIPTION
This leaves only `catalog`, `exec`, and `io` remaining.