### PR TITLE
Jw/docs move mcp server docs

### DIFF
--- a/docs/mintlify/docs/cookbooks/mcp/overview.mdx
+++ b/docs/mintlify/docs/cookbooks/mcp/overview.mdx
@@ -3,7 +3,7 @@ title: 'Model Context Protocol'
 description: 'Extending AI capabilities with Pixeltable MCP servers'
 ---
 
-<Card title="Pixeltable MCP servers" icon="github" href="https://github.com/pixeltable/mcp-server-pixeltable">
+<Card title="Pixeltable MCP servers" icon="github" href="https://github.com/pixeltable/pixeltable-mcp-server">
   View the source code and contribute to our Pixeltable MCP servers
 </Card>
 
@@ -214,11 +214,11 @@ We're actively working on enhancing our MCP servers with:
 
 ## Contributing
 
-We welcome contributions to our MCP server implementations! Please check our [GitHub repository](https://github.com/pixeltable/mcp-server-pixeltable) for contribution guidelines.
+We welcome contributions to our MCP server implementations! Please check our [GitHub repository](https://github.com/pixeltable/pixeltable-mcp-server) for contribution guidelines.
 
 ## Support
 
-- GitHub Issues: [Report bugs or request features](https://github.com/pixeltable/mcp-server-pixeltable/issues)
+- GitHub Issues: [Report bugs or request features](https://github.com/pixeltable/pixeltable-mcp-server/issues)
 - Discord: Join our [community](https://discord.gg/pixeltable)
 
 ## Learn More

--- a/docs/mintlify/mint.json
+++ b/docs/mintlify/mint.json
@@ -101,6 +101,7 @@
       "pages": [
         "docs/tutorials/fundamentals",
         "docs/tutorials/feature-guide",
+        "docs/cookbooks/mcp/overview",
         {
           "group": "Cookbooks",
           "pages": [
@@ -131,8 +132,7 @@
                 "docs/cookbooks/search/website",
                 "docs/cookbooks/search/video"
               ]
-            },
-              "docs/cookbooks/mcp/overview"          
+            }      
           ]
         }
       ]


### PR DESCRIPTION
We would like to move the MCP server documentation to tutorials.

I also renamed the github repo to pixeltable-mcp-server and as a result I need to update the links in this doc