### PR TITLE
remove default values from udf args in docs

### DIFF
--- a/docs/mintlify/docs/cookbooks/chat/tools.mdx
+++ b/docs/mintlify/docs/cookbooks/chat/tools.mdx
@@ -30,7 +30,7 @@ Pixeltable tool-calling apps work in two phases:
 
     # Define tools
     @pxt.udf
-    def search_news(keywords: str, max_results: int = 20) -> str:
+    def search_news(keywords: str, max_results: int) -> str:
         """Search news using DuckDuckGo and return results."""
         try:
             with DDGS() as ddgs:

--- a/docs/mintlify/docs/cookbooks/multimodal/PDF.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/PDF.mdx
@@ -58,7 +58,7 @@ Pixeltable PDF search works in two phases:
 
     # Define search query
     @pxt.query
-    def search_documents(query_text: str, limit: int = 5):
+    def search_documents(query_text: str, limit: int):
         sim = documents_chunks.text.similarity(query_text)
         return (
             documents_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/multimodal/PDF.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/PDF.mdx
@@ -235,8 +235,8 @@ Create specialized search functions:
 @pxt.query
 def search_with_metadata(
     query: str,
-    min_similarity: float = 0.7,
-    limit: int = 5
+    min_similarity: float,
+    limit: int
 ):
     sim = documents_chunks.text.similarity(query)
     return (

--- a/docs/mintlify/docs/cookbooks/multimodal/PDF.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/PDF.mdx
@@ -98,7 +98,7 @@ Pixeltable PDF search works in two phases:
 
     # Search documents
     @pxt.query
-    def find_relevant_text(query: str, top_k: int = 5):
+    def find_relevant_text(query: str, top_k: int):
         sim = documents_chunks.text.similarity(query)
         return (
             documents_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/multimodal/audio.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/audio.mdx
@@ -187,7 +187,7 @@ You can create custom search functions with different parameters:
 
 ```python
 @pxt.query
-def search_with_threshold(query_text: str, min_similarity: float = 0.7):
+def search_with_threshold(query_text: str, min_similarity: float):
     sim = sentences_view.text.similarity(query_text)
     return (
         sentences_view.where(sim >= min_similarity)

--- a/docs/mintlify/docs/cookbooks/multimodal/images.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/images.mdx
@@ -56,7 +56,7 @@ Pixeltable image search works in two phases:
 
     # Define search query
     @pxt.query
-    def search_images(query_text: str, limit: int = 10):
+    def search_images(query_text: str, limit: int):
         sim = img_t.image_description.similarity(query_text)
         return (
             img_t.order_by(sim, asc=False)
@@ -189,7 +189,7 @@ Create specialized search functions:
 
 ```python
 @pxt.query
-def search_with_threshold(query: str, min_similarity: float = 0.7):
+def search_with_threshold(query: str, min_similarity: float):
     sim = img_t.image_description.similarity(query)
     return (
         img_t.where(sim >= min_similarity)

--- a/docs/mintlify/docs/cookbooks/multimodal/images.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/images.mdx
@@ -96,7 +96,7 @@ Pixeltable image search works in two phases:
 
     # Search images
     @pxt.query
-    def find_images(query: str, top_k: int = 3):
+    def find_images(query: str, top_k: int):
         sim = img_t.image_description.similarity(query)
         return (
             img_t.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/multimodal/text.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/text.mdx
@@ -187,7 +187,7 @@ You can create custom search functions with different parameters:
 
 ```python
 @pxt.query
-def search_with_threshold(query_text: str, min_similarity: float = 0.7):
+def search_with_threshold(query_text: str, min_similarity: float):
     sim = sentences_view.text.similarity(query_text)
     return (
         sentences_view.where(sim >= min_similarity)

--- a/docs/mintlify/docs/cookbooks/multimodal/website.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/website.mdx
@@ -98,7 +98,7 @@ Pixeltable website search works in two phases:
 
     # Search content
     @pxt.query
-    def find_content(query: str, top_k: int = 5):
+    def find_content(query: str, top_k: int):
         sim = websites_chunks.text.similarity(query)
         return (
             websites_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/multimodal/website.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/website.mdx
@@ -247,8 +247,8 @@ Create specialized search functions:
 @pxt.query
 def search_with_metadata(
     query: str,
-    min_similarity: float = 0.7,
-    limit: int = 5
+    min_similarity: float,
+    limit: int
 ):
     sim = websites_chunks.text.similarity(query)
     return (

--- a/docs/mintlify/docs/cookbooks/multimodal/website.mdx
+++ b/docs/mintlify/docs/cookbooks/multimodal/website.mdx
@@ -58,7 +58,7 @@ Pixeltable website search works in two phases:
 
     # Define search query
     @pxt.query
-    def search_content(query_text: str, limit: int = 5):
+    def search_content(query_text: str, limit: int):
         sim = websites_chunks.text.similarity(query_text)
         return (
             websites_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/search/PDF.mdx
+++ b/docs/mintlify/docs/cookbooks/search/PDF.mdx
@@ -58,7 +58,7 @@ Pixeltable PDF search works in two phases:
 
     # Define search query
     @pxt.query
-    def search_documents(query_text: str, limit: int = 5):
+    def search_documents(query_text: str, limit: int):
         sim = documents_chunks.text.similarity(query_text)
         return (
             documents_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/search/PDF.mdx
+++ b/docs/mintlify/docs/cookbooks/search/PDF.mdx
@@ -235,8 +235,8 @@ Create specialized search functions:
 @pxt.query
 def search_with_metadata(
     query: str,
-    min_similarity: float = 0.7,
-    limit: int = 5
+    min_similarity: float,
+    limit: int
 ):
     sim = documents_chunks.text.similarity(query)
     return (

--- a/docs/mintlify/docs/cookbooks/search/PDF.mdx
+++ b/docs/mintlify/docs/cookbooks/search/PDF.mdx
@@ -98,7 +98,7 @@ Pixeltable PDF search works in two phases:
 
     # Search documents
     @pxt.query
-    def find_relevant_text(query: str, top_k: int = 5):
+    def find_relevant_text(query: str, top_k: int):
         sim = documents_chunks.text.similarity(query)
         return (
             documents_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/search/audio.mdx
+++ b/docs/mintlify/docs/cookbooks/search/audio.mdx
@@ -187,7 +187,7 @@ You can create custom search functions with different parameters:
 
 ```python
 @pxt.query
-def search_with_threshold(query_text: str, min_similarity: float = 0.7):
+def search_with_threshold(query_text: str, min_similarity: float):
     sim = sentences_view.text.similarity(query_text)
     return (
         sentences_view.where(sim >= min_similarity)

--- a/docs/mintlify/docs/cookbooks/search/images.mdx
+++ b/docs/mintlify/docs/cookbooks/search/images.mdx
@@ -56,7 +56,7 @@ Pixeltable image search works in two phases:
 
     # Define search query
     @pxt.query
-    def search_images(query_text: str, limit: int = 10):
+    def search_images(query_text: str, limit: int):
         sim = img_t.image_description.similarity(query_text)
         return (
             img_t.order_by(sim, asc=False)
@@ -189,7 +189,7 @@ Create specialized search functions:
 
 ```python
 @pxt.query
-def search_with_threshold(query: str, min_similarity: float = 0.7):
+def search_with_threshold(query: str, min_similarity: float):
     sim = img_t.image_description.similarity(query)
     return (
         img_t.where(sim >= min_similarity)

--- a/docs/mintlify/docs/cookbooks/search/images.mdx
+++ b/docs/mintlify/docs/cookbooks/search/images.mdx
@@ -96,7 +96,7 @@ Pixeltable image search works in two phases:
 
     # Search images
     @pxt.query
-    def find_images(query: str, top_k: int = 3):
+    def find_images(query: str, top_k: int):
         sim = img_t.image_description.similarity(query)
         return (
             img_t.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/search/website.mdx
+++ b/docs/mintlify/docs/cookbooks/search/website.mdx
@@ -98,7 +98,7 @@ Pixeltable website search works in two phases:
 
     # Search content
     @pxt.query
-    def find_content(query: str, top_k: int = 5):
+    def find_content(query: str, top_k: int):
         sim = websites_chunks.text.similarity(query)
         return (
             websites_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/cookbooks/search/website.mdx
+++ b/docs/mintlify/docs/cookbooks/search/website.mdx
@@ -247,8 +247,8 @@ Create specialized search functions:
 @pxt.query
 def search_with_metadata(
     query: str,
-    min_similarity: float = 0.7,
-    limit: int = 5
+    min_similarity: float,
+    limit: int
 ):
     sim = websites_chunks.text.similarity(query)
     return (

--- a/docs/mintlify/docs/cookbooks/search/website.mdx
+++ b/docs/mintlify/docs/cookbooks/search/website.mdx
@@ -58,7 +58,7 @@ Pixeltable website search works in two phases:
 
     # Define search query
     @pxt.query
-    def search_content(query_text: str, limit: int = 5):
+    def search_content(query_text: str, limit: int):
         sim = websites_chunks.text.similarity(query_text)
         return (
             websites_chunks.order_by(sim, asc=False)

--- a/docs/mintlify/docs/datastore/custom-functions.mdx
+++ b/docs/mintlify/docs/datastore/custom-functions.mdx
@@ -62,7 +62,7 @@ All UDFs require type hints for parameters and return values. This enables Pixel
 <CodeGroup>
 ```python Basic
 @pxt.udf
-def add_tax(price: float, rate: float = 0.1) -> float:
+def add_tax(price: float, rate: float) -> float:
     return price * (1 + rate)
 
 # Use in computed column

--- a/docs/mintlify/docs/datastore/embedding-index.mdx
+++ b/docs/mintlify/docs/datastore/embedding-index.mdx
@@ -214,7 +214,7 @@ The query phase allows you to search your indexed content using the `similarity(
   <Tab title="Basic Search">
     ```python
     @pxt.query
-    def semantic_search(query: str, k: int = 5):
+    def semantic_search(query: str, k: int):
         # Calculate similarity scores
         sim = docs.content.similarity(query)
         


### PR DESCRIPTION
We have examples with default values in a pixeltable udf arg. This throws an error. We need to remove it