### PR TITLE
Load jfk index on MCP initialization

### DIFF
--- a/docs/sample-apps/jfk-files-mcp-server/README.md
+++ b/docs/sample-apps/jfk-files-mcp-server/README.md
@@ -111,8 +111,8 @@ Pixeltable is a declarative data infrastructure for multimodal AI applications t
 - **Minimal Code**: Achieve complex workflows with significantly less code than traditional approaches
 
 ### Powerful Data Management
-- **Persistent Storage**: All data and computed results are automatically stored and versioned without extra effort
-- **Computed Columns**: Define processing workflows that automatically execute on new data
+- **Persistent Storage**: All data and computed results are stored and versioned without extra effort
+- **Computed Columns**: Define processing workflows that execute on new data
 - **Multimodal Support**: Handle images, PDFs, videos, and text seamlessly in one unified interface
 - **Incremental Processing**: Documents are uploaded and processed asynchronously
 
@@ -122,11 +122,11 @@ Pixeltable is a declarative data infrastructure for multimodal AI applications t
 - **Automatic Orchestration**: Pixeltable handles model execution, ensuring results are stored, indexed, and accessible
 
 ### Enterprise-Ready
-- **Scalability**: Automatically scales to handle the complexity of processing and indexing large document collections
+- **Scalability**: Auto=scales to handle the complexity of processing and indexing large document collections
 - **Production-Ready**: Built to handle real-world data volumes
 - **MCP Integration**: Seamlessly connects with Model Context Protocol clients
 
-Pixeltable automatically handles the entire workflow from data ingest to search, allowing you to focus on building your application rather than managing infrastructure.
+Pixeltable handles the entire workflow from data ingest to search, allowing you to focus on building your application rather than managing infrastructure.
 
 ## Learn More
 

--- a/docs/sample-apps/jfk-files-mcp-server/initialize.py
+++ b/docs/sample-apps/jfk-files-mcp-server/initialize.py
@@ -1,9 +1,16 @@
 from config import DIRECTORY
 from mcp.server.fastmcp import FastMCP
 
-import pixeltable as pxt
+from load_data import populate_pixeltable
 
 mcp = FastMCP('JFK_Files')
+
+# You can load either all documents or a subset for testing
+# Uncomment the following line to load all JFK files (may take longer)
+# populate_pixeltable("jfk_files", load_all=True)
+
+# Load a smaller set of documents for quick testing and development
+documents = populate_pixeltable(DIRECTORY, num_docs=5)
 
 
 @mcp.tool()
@@ -24,9 +31,6 @@ def pxt_query_document(query_text: str, top_n: int = 5) -> str:
         A formatted string containing the search results with similarity scores
     """
     try:
-        # Load the document summaries table
-        documents = pxt.get_table(f'{DIRECTORY}.documents')
-
         # Calculate similarity between query and document summaries
         sim = documents.document_summary.similarity(query_text)
 

--- a/docs/sample-apps/jfk-files-mcp-server/load_data.py
+++ b/docs/sample-apps/jfk-files-mcp-server/load_data.py
@@ -153,3 +153,4 @@ def populate_pixeltable(directory: str, num_docs: int = 2, load_all: bool = Fals
     # 1. Generate summaries using Mistral AI
     # 2. Create embeddings for semantic search
     documents.insert({'document_url': pdf} for pdf in pdf_links)
+    return documents

--- a/docs/sample-apps/jfk-files-mcp-server/server.py
+++ b/docs/sample-apps/jfk-files-mcp-server/server.py
@@ -4,14 +4,12 @@
 import argparse
 
 import uvicorn
-from config import DIRECTORY
-from load_data import populate_pixeltable
 from mcp.server import Server
 from mcp.server.sse import SseServerTransport
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.routing import Mount, Route
-from tools import mcp
+from initialize import mcp
 
 
 def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlette:
@@ -31,13 +29,6 @@ def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlett
 
 
 if __name__ == '__main__':
-    # You can load either all documents or a subset for testing
-    # Uncomment the following line to load all JFK files (may take longer)
-    # populate_pixeltable("jfk_files", load_all=True)
-
-    # Load a smaller set of documents for quick testing and development
-    populate_pixeltable(DIRECTORY, num_docs=5)
-
     # Initialize the MCP server for handling queries
     mcp_server = mcp._mcp_server
 


### PR DESCRIPTION
Update example so that we load documents on MCP initialization instead of each tool call