### PR TITLE
Fix bug in JsonPath serialization

### DIFF
--- a/pixeltable/catalog/column.py
+++ b/pixeltable/catalog/column.py
@@ -132,6 +132,7 @@ class Column:
             from pixeltable import exprs
 
             self._value_expr = exprs.Expr.from_dict(self.value_expr_dict)
+            self._value_expr.bind_rel_paths()
             if not self._value_expr.is_valid:
                 message = (
                     dedent(

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -177,6 +177,10 @@ class TableVersion:
         # Init external stores (this needs to happen after the schema is created)
         self._init_external_stores(tbl_md)
 
+        # Force column metadata to load, in order to surface any invalid metadata now (as warnings)
+        for col in self.cols_by_id.values():
+            _ = col.value_expr
+
     def __hash__(self) -> int:
         return hash(self.id)
 

--- a/pixeltable/exprs/json_path.py
+++ b/pixeltable/exprs/json_path.py
@@ -14,6 +14,7 @@ from .data_row import DataRow
 from .expr import Expr
 from .globals import print_slice
 from .json_mapper import JsonMapper
+from .object_ref import ObjectRef
 from .row_builder import RowBuilder
 from .sql_element_cache import SqlElementCache
 
@@ -50,8 +51,16 @@ class JsonPath(Expr):
         return f'{anchor_str}{"." if isinstance(self.path_elements[0], str) else ""}{self._json_path()}'
 
     def _as_dict(self) -> dict:
+        assert len(self.components) <= 1
+        components_dict: dict[str, Any]
+        if len(self.components) == 0 or isinstance(self.components[0], ObjectRef):
+            # If the anchor is an ObjectRef, it means this JsonPath is a bound relative path. We store it as a relative
+            # path, *not* a bound path (which has no meaning in the dict).
+            components_dict = {}
+        else:
+            components_dict = super()._as_dict()
         path_elements = [[el.start, el.stop, el.step] if isinstance(el, slice) else el for el in self.path_elements]
-        return {'path_elements': path_elements, 'scope_idx': self.scope_idx, **super()._as_dict()}
+        return {'path_elements': path_elements, 'scope_idx': self.scope_idx, **components_dict}
 
     @classmethod
     def _from_dict(cls, d: dict, components: list[Expr]) -> JsonPath:

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -634,25 +634,29 @@ class TestExprs:
         t = test_tbl
 
         # top-level is dict
-        res = reload_tester.run_query(t.select(input=t.c6.f5, output=t.c6.f5['*'] >> (R + 1)))
-        for row in res:
+        res1 = reload_tester.run_query(t.select(input=t.c6.f5, output=t.c6.f5['*'] >> (R + 1)))
+        for row in res1:
             assert row['output'] == [x + 1 for x in row['input']]
 
         # top-level is list of dicts; subsequent json path element references the dicts
-        res = reload_tester.run_query(t.select(input=t.c7, output=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]))
-        for row in res:
+        res2 = reload_tester.run_query(t.select(input=t.c7, output=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]))
+        for row in res2:
             assert row['output'] == [[d['f5'][3], d['f5'][2], d['f5'][1], d['f5'][0]] for d in row['input']]
 
         # target expr contains global-scope dependency
-        res = reload_tester.run_query(t.select(input=t.c6, output=t.c6.f5['*'] >> (R * t.c6.f5[1])))
-        for row in res:
+        res3 = reload_tester.run_query(t.select(input=t.c6, output=t.c6.f5['*'] >> (R * t.c6.f5[1])))
+        for row in res3:
             assert row['output'] == [x * row['input']['f5'][1] for x in row['input']['f5']]
 
         # test it as a computed column
-        validate_update_status(t.add_computed_column(output=t.c6.f5['*'] >> (R * t.c6.f5[1])), 100)
-        res2 = reload_tester.run_query(t.select(t.output))
-        for row, row2 in zip(res, res2):
-            assert row['output'] == row2['output']
+        validate_update_status(t.add_computed_column(out1=t.c6.f5['*'] >> (R + 1)), 100)
+        validate_update_status(t.add_computed_column(out2=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]), 100)
+        validate_update_status(t.add_computed_column(out3=t.c6.f5['*'] >> (R * t.c6.f5[1])), 100)
+        res_col = reload_tester.run_query(t.select(t.out1, t.out2, t.out3))
+        for row1, row2, row3, row_col in zip(res1, res2, res3, res_col):
+            assert row1['output'] == row_col['out1']
+            assert row2['output'] == row_col['out2']
+            assert row3['output'] == row_col['out3']
 
         reload_tester.run_reload_test()
 


### PR DESCRIPTION
Fixes a bug in JsonPath serialization involving expressions with a relative path root. Previously, such expressions inappropriately serialized an `ObjectRef` instance, which could not be deserialized. The new logic skips the `ObjectRef`, serializes the `JsonPath` as a relative path, and re-binds it after deserialization.

Also changes `TableVersion` initialization to force column metadata to load when the `TableVersion` is constructed. Previously, metadata loading happened only on a call to `get_table`. But `DataFrame` materialization from a dict (among other things) bypasses that code path.