### PR TITLE
Bugfix related to chained tool calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 *.iml
 dist
 docs/local
+local
 site
 target

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -514,7 +514,7 @@ class Expr(abc.ABC):
 
     @classmethod
     def _from_dict(cls, d: dict, components: list[Expr]) -> Self:
-        raise AssertionError('not implemented')
+        raise AssertionError(f'not implemented: {cls.__name__}')
 
     def isin(self, value_set: Any) -> 'exprs.InPredicate':
         from .in_predicate import InPredicate

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -90,14 +90,28 @@ class Expr(abc.ABC):
                 result = c_scope
         return result
 
-    def bind_rel_paths(self, mapper: Optional['exprs.JsonMapper'] = None) -> None:
+    def bind_rel_paths(self) -> None:
         """
         Binds relative JsonPaths to mapper.
         This needs to be done in a separate phase after __init__(), because RelativeJsonPath()(-1) cannot be resolved
         by the immediately containing JsonMapper during initialization.
         """
+        self._bind_rel_paths()
+        assert not self._has_relative_path, self._expr_tree()
+
+    def _bind_rel_paths(self, mapper: Optional['exprs.JsonMapper'] = None) -> None:
         for c in self.components:
-            c.bind_rel_paths(mapper)
+            c._bind_rel_paths(mapper)
+
+    def _expr_tree(self) -> str:
+        buf: list[str] = []
+        self._expr_tree_r(0, buf)
+        return '\n'.join(buf)
+
+    def _expr_tree_r(self, indent: int, buf: list[str]) -> None:
+        buf.append(f'{" " * indent}{type(self).__name__}: {self}'.replace('\n', '\\n'))
+        for c in self.components:
+            c._expr_tree_r(indent + 2, buf)
 
     def default_column_name(self) -> Optional[str]:
         """
@@ -354,6 +368,10 @@ class Expr(abc.ABC):
             return True
         except StopIteration:
             return False
+
+    @property
+    def _has_relative_path(self) -> bool:
+        return any(c._has_relative_path for c in self.components)
 
     def tbl_ids(self) -> set[UUID]:
         """Returns table ids referenced by this expr."""

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -104,6 +104,7 @@ class Expr(abc.ABC):
             c._bind_rel_paths(mapper)
 
     def _expr_tree(self) -> str:
+        """Returns a string representation of this expression as a multi-line tree. Useful for debugging."""
         buf: list[str] = []
         self._expr_tree_r(0, buf)
         return '\n'.join(buf)

--- a/pixeltable/exprs/function_call.py
+++ b/pixeltable/exprs/function_call.py
@@ -12,7 +12,6 @@ from pixeltable import catalog, exceptions as excs, func, type_system as ts
 
 from .data_row import DataRow
 from .expr import Expr
-from .json_mapper import JsonMapper
 from .literal import Literal
 from .row_builder import RowBuilder
 from .rowid_ref import RowidRef
@@ -361,10 +360,7 @@ class FunctionCall(Expr):
             return
         args, kwargs = args_kwargs
 
-        if isinstance(self.fn, func.CallableFunction) and not self.fn.is_batched:
-            # optimization: avoid additional level of indirection we'd get from calling Function.exec()
-            data_row[self.slot_idx] = self.fn.py_fn(*args, **kwargs)
-        elif self.is_window_fn_call:
+        if self.is_window_fn_call:
             assert isinstance(self.fn, func.AggregateFunction)
             agg_cls = self.fn.agg_class
             if self.has_group_by():

--- a/pixeltable/exprs/function_call.py
+++ b/pixeltable/exprs/function_call.py
@@ -12,6 +12,7 @@ from pixeltable import catalog, exceptions as excs, func, type_system as ts
 
 from .data_row import DataRow
 from .expr import Expr
+from .json_mapper import JsonMapper
 from .literal import Literal
 from .row_builder import RowBuilder
 from .rowid_ref import RowidRef

--- a/pixeltable/exprs/json_mapper.py
+++ b/pixeltable/exprs/json_mapper.py
@@ -48,9 +48,9 @@ class JsonMapper(Expr):
         scope_anchor = ObjectRef(self.target_expr_scope, self)
         self.components.append(scope_anchor)
 
-    def bind_rel_paths(self, mapper: Optional[JsonMapper] = None) -> None:
-        self._src_expr.bind_rel_paths(mapper)
-        self._target_expr.bind_rel_paths(self)
+    def _bind_rel_paths(self, mapper: Optional[JsonMapper] = None) -> None:
+        self._src_expr._bind_rel_paths(mapper)
+        self._target_expr._bind_rel_paths(self)
         self.parent_mapper = mapper
         parent_scope = _GLOBAL_SCOPE if mapper is None else mapper.target_expr_scope
         self.target_expr_scope.parent = parent_scope

--- a/pixeltable/exprs/json_path.py
+++ b/pixeltable/exprs/json_path.py
@@ -80,11 +80,16 @@ class JsonPath(Expr):
     def is_relative_path(self) -> bool:
         return self._anchor is None
 
-    def bind_rel_paths(self, mapper: Optional['JsonMapper'] = None) -> None:
-        if not self.is_relative_path():
-            return
-        # TODO: take scope_idx into account
-        self.set_anchor(mapper.scope_anchor)
+    @property
+    def _has_relative_path(self) -> bool:
+        return self.is_relative_path() or super()._has_relative_path
+
+    def _bind_rel_paths(self, mapper: Optional['JsonMapper'] = None) -> None:
+        if self.is_relative_path():
+            # TODO: take scope_idx into account
+            self.set_anchor(mapper.scope_anchor)
+        else:
+            self._anchor._bind_rel_paths(mapper)
 
     def __call__(self, *args: object, **kwargs: object) -> 'JsonPath':
         """

--- a/pixeltable/func/callable_function.py
+++ b/pixeltable/func/callable_function.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import cloudpickle  # type: ignore[import-untyped]
 
 import pixeltable.exceptions as excs
+from pixeltable.utils.coroutine import run_coroutine_synchronously
 
 from .function import Function
 from .signature import Signature
@@ -93,13 +94,13 @@ class CallableFunction(Function):
             batched_kwargs = {k: [v] for k, v in kwargs.items() if k not in constant_param_names}
             result: list[Any]
             if inspect.iscoroutinefunction(self.py_fn):
-                result = asyncio.run(self.py_fn(*batched_args, **constant_kwargs, **batched_kwargs))
+                result = run_coroutine_synchronously(self.py_fn(*batched_args, **constant_kwargs, **batched_kwargs))
             else:
                 result = self.py_fn(*batched_args, **constant_kwargs, **batched_kwargs)
             assert len(result) == 1
             return result[0]
         elif inspect.iscoroutinefunction(self.py_fn):
-            return asyncio.run(self.py_fn(*args, **kwargs))
+            return run_coroutine_synchronously(self.py_fn(*args, **kwargs))
         else:
             return self.py_fn(*args, **kwargs)
 

--- a/pixeltable/func/callable_function.py
+++ b/pixeltable/func/callable_function.py
@@ -94,12 +94,14 @@ class CallableFunction(Function):
             batched_kwargs = {k: [v] for k, v in kwargs.items() if k not in constant_param_names}
             result: list[Any]
             if inspect.iscoroutinefunction(self.py_fn):
+                # TODO: This is temporary (see note in utils/coroutine.py)
                 result = run_coroutine_synchronously(self.py_fn(*batched_args, **constant_kwargs, **batched_kwargs))
             else:
                 result = self.py_fn(*batched_args, **constant_kwargs, **batched_kwargs)
             assert len(result) == 1
             return result[0]
         elif inspect.iscoroutinefunction(self.py_fn):
+            # TODO: This is temporary (see note in utils/coroutine.py)
             return run_coroutine_synchronously(self.py_fn(*args, **kwargs))
         else:
             return self.py_fn(*args, **kwargs)

--- a/pixeltable/utils/coroutine.py
+++ b/pixeltable/utils/coroutine.py
@@ -6,6 +6,11 @@ from typing import Any, Coroutine, TypeVar
 T = TypeVar('T')
 
 
+# TODO This is a temporary hack to be able to run async UDFs in contexts that are not properly handled by the existing
+#   scheduler logic (e.g., inside the eval loop of a JsonMapper). Once the scheduler is fully general, it can be
+#   removed.
+
+
 def run_coroutine_synchronously(coroutine: Coroutine[Any, Any, T], timeout: float = 30) -> T:
     """
     Runs the given coroutine synchronously, even if called in the context of a running event loop.

--- a/pixeltable/utils/coroutine.py
+++ b/pixeltable/utils/coroutine.py
@@ -1,0 +1,36 @@
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar('T')
+
+
+def run_coroutine_synchronously(coroutine: Coroutine[Any, Any, T], timeout: float = 30) -> T:
+    """
+    Runs the given coroutine synchronously, even if called in the context of a running event loop.
+    """
+
+    def run_in_new_loop():
+        new_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(new_loop)
+        try:
+            return new_loop.run_until_complete(coroutine)
+        finally:
+            new_loop.close()
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No event loop; just call `asyncio.run()`
+        return asyncio.run(coroutine)
+
+    if threading.current_thread() is threading.main_thread():
+        if not loop.is_running():
+            return loop.run_until_complete(coroutine)
+        else:
+            with ThreadPoolExecutor() as pool:
+                future = pool.submit(run_in_new_loop)
+                return future.result(timeout=timeout)
+    else:
+        return asyncio.run_coroutine_threadsafe(coroutine, loop).result()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,11 @@ documentation = "https://docs.pixeltable.com/"
 
 [tool.poetry]
 exclude = [
-    ".pytype",
     ".pytest_cache",
-    "tests",
+    ".pytype",
     "docs",
+    "local",
+    "tests",
     "tool",
 ]
 requires-poetry = ">=2.0"

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -634,29 +634,38 @@ class TestExprs:
         t = test_tbl
 
         # top-level is dict
-        res1 = reload_tester.run_query(t.select(input=t.c6.f5, output=t.c6.f5['*'] >> (R + 1)))
+        res1 = reload_tester.run_query(t.select(input=t.c6.f5, output=t.c6.f5['*'] >> (R + 1)).order_by(t.c2))
         for row in res1:
             assert row['output'] == [x + 1 for x in row['input']]
 
         # top-level is list of dicts; subsequent json path element references the dicts
-        res2 = reload_tester.run_query(t.select(input=t.c7, output=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]))
+        res2 = reload_tester.run_query(t.select(input=t.c7, output=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]).order_by(t.c2))
         for row in res2:
             assert row['output'] == [[d['f5'][3], d['f5'][2], d['f5'][1], d['f5'][0]] for d in row['input']]
 
         # target expr contains global-scope dependency
-        res3 = reload_tester.run_query(t.select(input=t.c6, output=t.c6.f5['*'] >> (R * t.c6.f5[1])))
+        res3 = reload_tester.run_query(t.select(input=t.c6, output=t.c6.f5['*'] >> (R * t.c6.f5[1])).order_by(t.c2))
         for row in res3:
             assert row['output'] == [x * row['input']['f5'][1] for x in row['input']['f5']]
+
+        # mapper appears inside the anchor of a JsonPath
+        res4 = reload_tester.run_query(t.select(input=t.c6, output=(t.c6.f5['*'] >> (R + 1))[0]).order_by(t.c2))
+        for row in res4:
+            assert row['output'] == row['input']['f5'][0] + 1
 
         # test it as a computed column
         validate_update_status(t.add_computed_column(out1=t.c6.f5['*'] >> (R + 1)), 100)
         validate_update_status(t.add_computed_column(out2=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]), 100)
         validate_update_status(t.add_computed_column(out3=t.c6.f5['*'] >> (R * t.c6.f5[1])), 100)
-        res_col = reload_tester.run_query(t.select(t.out1, t.out2, t.out3))
-        for row1, row2, row3, row_col in zip(res1, res2, res3, res_col):
+        validate_update_status(t.add_computed_column(out4=(t.c6.f5['*'] >> (R + 1))[0]), 100)
+
+        res_col = reload_tester.run_query(t.select(t.out1, t.out2, t.out3, t.out4).order_by(t.c2))
+
+        for row1, row2, row3, row4, row_col in zip(res1, res2, res3, res4, res_col):
             assert row1['output'] == row_col['out1']
             assert row2['output'] == row_col['out2']
             assert row3['output'] == row_col['out3']
+            assert row4['output'] == row_col['out4']
 
         reload_tester.run_reload_test()
 

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -639,7 +639,9 @@ class TestExprs:
             assert row['output'] == [x + 1 for x in row['input']]
 
         # top-level is list of dicts; subsequent json path element references the dicts
-        res2 = reload_tester.run_query(t.select(input=t.c7, output=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]).order_by(t.c2))
+        res2 = reload_tester.run_query(
+            t.select(input=t.c7, output=t.c7['*'].f5 >> [R[3], R[2], R[1], R[0]]).order_by(t.c2)
+        )
         for row in res2:
             assert row['output'] == [[d['f5'][3], d['f5'][2], d['f5'][1], d['f5'][0]] for d in row['input']]
 


### PR DESCRIPTION
Fixes a bug in `JsonMapper` evaluation that caused relative expressions to fail to bind when they appeared in the anchor of a `JsonPath`.

Also introduces a _workaround_ (not a proper fix) for a bug that causes `JsonMapper` evaluation to fail when the target expression involves an async UDF. The workaround forces the async UDF to be evaluated synchronously, which will give the correct output, but introduces a performance cliff when large numbers of rows are involved.