### PR TITLE
Bugfix when drop_dir() is the first operation after a catalog load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,16 +145,16 @@ lint: install
 .PHONY: formattest
 formattest: install
 	@echo "Running ruff format --check ..."
-	@ruff format --check
+	@ruff format --check pixeltable tests tool
 	@echo "Running ruff check --select I ..."
-	@ruff check --select I
+	@ruff check --select I pixeltable tests tool
 
 .PHONY: format
 format: install
 	@echo "Running ruff format ..."
-	@ruff format
+	@ruff format pixeltable tests tool
 	@echo "Running ruff check --select I --fix ..."
-	@ruff check --select I --fix
+	@ruff check --select I --fix pixeltable tests tool
 
 .PHONY: release
 release: install

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -413,7 +413,7 @@ class Catalog:
     def get_table(self, path: Path) -> Table:
         obj = Catalog.get()._get_schema_object(path, expected=Table, raise_if_not_exists=True)
         assert isinstance(obj, Table)
-        obj.ensure_md_loaded()
+        obj._tbl_version.get().ensure_md_loaded()
         return obj
 
     @_retry_loop

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -369,11 +369,6 @@ class Table(SchemaObject):
             pd_rows.append(row)
         return pd.DataFrame(pd_rows)
 
-    def ensure_md_loaded(self) -> None:
-        """Ensure that table metadata is loaded."""
-        for col in self._tbl_version.get().cols_by_id.values():
-            _ = col.value_expr
-
     def describe(self) -> None:
         """
         Print the table schema.

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -177,10 +177,6 @@ class TableVersion:
         # Init external stores (this needs to happen after the schema is created)
         self._init_external_stores(tbl_md)
 
-        # Force column metadata to load, in order to surface any invalid metadata now (as warnings)
-        for col in self.cols_by_id.values():
-            _ = col.value_expr
-
     def __hash__(self) -> int:
         return hash(self.id)
 
@@ -457,6 +453,11 @@ class TableVersion:
                     tbl_id=self.id, schema_version=self.schema_version, md=dataclasses.asdict(schema_version_md)
                 )
             )
+
+    def ensure_md_loaded(self) -> None:
+        """Ensure that table metadata is loaded."""
+        for col in self.cols_by_id.values():
+            _ = col.value_expr
 
     def _store_idx_name(self, idx_id: int) -> str:
         """Return name of index in the store, which needs to be globally unique"""

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -249,8 +249,7 @@ class TestFunction:
 
     def test_query2(self, reset_db) -> None:
         schema = {'query_text': pxt.String, 'i': pxt.Int}
-        pxt.create_dir('test')
-        queries = pxt.create_table('test.queries', schema)
+        queries = pxt.create_table('queries', schema)
         query_rows = [
             {'query_text': 'how much is the stock of AI companies up?', 'i': 1},
             {'query_text': 'what happened to the term machine learning?', 'i': 2},
@@ -284,7 +283,7 @@ class TestFunction:
         assert all(len(c) == 2 for c in res['chunks'])
 
         reload_catalog()
-        queries = pxt.get_table('test.queries')
+        queries = pxt.get_table('queries')
         res = queries.select(queries.chunks).collect()
         assert all(len(c) == 2 for c in res['chunks'])
         validate_update_status(queries.insert(query_rows), expected_rows=len(query_rows))

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -12,7 +12,6 @@ import pixeltable.exceptions as excs
 import pixeltable.functions as pxtf
 from pixeltable import catalog, func
 from pixeltable.func import Batch, Function, FunctionRegistry
-from pixeltable.iterators.document import DocumentSplitter
 
 from .utils import SAMPLE_IMAGE_URL, ReloadTester, assert_resultset_eq, reload_catalog, validate_update_status
 
@@ -295,9 +294,7 @@ class TestFunction:
     def test_query_over_view(self, reset_db) -> None:
         pxt.create_dir('test')
         docs = pxt.create_table('test.docs', {'document': pxt.Document})
-        chunks = pxt.create_view(
-            'test.chunks', docs, iterator=DocumentSplitter.create(document=docs.document, separators='sentence')
-        )
+        chunks = pxt.create_view('test.chunks', docs, additional_columns={'text': pxt.String})
 
         @pxt.query
         def search_documents(text: str):

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -292,15 +292,15 @@ class TestFunction:
 
     def test_query_over_view(self, reset_db) -> None:
         pxt.create_dir('test')
-        docs = pxt.create_table('test.docs', {'document': pxt.Document})
-        chunks = pxt.create_view('test.chunks', docs, additional_columns={'text': pxt.String})
+        t = pxt.create_table('test.tbl', {'a': pxt.String})
+        v = pxt.create_view('test.view', t, additional_columns={'text': pxt.String})
 
         @pxt.query
-        def search_documents(text: str):
-            return chunks.select(chunks.text).limit(20)
+        def retrieve():
+            return v.select(v.text).limit(20)
 
-        t = pxt.create_table('test.retrieval', {'text': pxt.String})
-        t.add_computed_column(result=search_documents(t.text))
+        t = pxt.create_table('test.retrieval', {'n': pxt.Int})
+        t.add_computed_column(result=retrieve())
 
         # This tests a specific edge case where calling drop_dir() as the first action after a catalog reload can lead
         # to a circular initialization failure.


### PR DESCRIPTION
This rolls back a regression that was introduced in 0.3.8, along with some slight refactoring and an additional unit test.