### PR TITLE
Improvements and fixes for Table._descriptors()

### DIFF
--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -228,3 +228,14 @@ class InsertableTable(Table):
         """
         with Env.get().begin_xact():
             return self._tbl_version.get().delete(where=where)
+
+    @property
+    def _base_table(self) -> Optional['Table']:
+        return None
+
+    @property
+    def _effective_base_versions(self) -> list[Optional[int]]:
+        return []
+
+    def _table_descriptor(self) -> str:
+        return f'Table {self._path()!r}'

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -109,7 +109,7 @@ class Table(SchemaObject):
         self._check_is_dropped()
         with env.Env.get().begin_xact():
             md = super().get_metadata()
-            md['base'] = self._base._path() if self._base is not None else None
+            md['base'] = self._base_table._path() if self._base_table is not None else None
             md['schema'] = self._schema
             md['is_replica'] = self._tbl_version.get().is_replica
             md['version'] = self._version
@@ -255,27 +255,26 @@ class Table(SchemaObject):
         return {c.name: c.col_type for c in self._tbl_version_path.columns()}
 
     @property
-    def _base(self) -> Optional['Table']:
-        """
-        The base table of this `Table`. If this table is a view, returns the `Table`
-        from which it was derived. Otherwise, returns `None`.
-        """
-        if self._tbl_version_path.base is None:
-            return None
-        base_id = self._tbl_version_path.base.tbl_version.id
-        return catalog.Catalog.get().get_table_by_id(base_id)
+    @abc.abstractmethod
+    def _base_table(self) -> Optional['Table']:
+        """The base's Table instance"""
+        ...
 
     @property
-    def _bases(self) -> list['Table']:
-        """
-        The ancestor list of bases of this table, starting with its immediate base.
-        """
+    def _base_tables(self) -> list['Table']:
+        """The ancestor list of bases of this table, starting with its immediate base."""
         bases = []
-        base = self._base
+        base = self._base_table
         while base is not None:
             bases.append(base)
-            base = base._base
+            base = base._base_table
         return bases
+
+    @property
+    @abc.abstractmethod
+    def _effective_base_versions(self) -> list[Optional[int]]:
+        """The effective versions of the ancestor bases, starting with its immediate base."""
+        ...
 
     @property
     def _comment(self) -> str:
@@ -300,7 +299,7 @@ class Table(SchemaObject):
         Constructs a list of descriptors for this table that can be pretty-printed.
         """
         helper = DescriptionHelper()
-        helper.append(self._title_descriptor())
+        helper.append(self._table_descriptor())
         helper.append(self._col_descriptor())
         idxs = self._index_descriptor()
         if not idxs.empty:
@@ -312,14 +311,8 @@ class Table(SchemaObject):
             helper.append(f'COMMENT: {self._comment}')
         return helper
 
-    def _title_descriptor(self) -> str:
-        title: str
-        if self._base is None:
-            title = f'Table\n{self._path()!r}'
-        else:
-            title = f'View\n{self._path()!r}'
-            title += f'\n(of {self.__bases_to_desc()})'
-        return title
+    @abc.abstractmethod
+    def _table_descriptor(self) -> str: ...
 
     def _col_descriptor(self, columns: Optional[list[str]] = None) -> pd.DataFrame:
         return pd.DataFrame(
@@ -331,14 +324,6 @@ class Table(SchemaObject):
             for col in self._tbl_version_path.columns()
             if columns is None or col.name in columns
         )
-
-    def __bases_to_desc(self) -> str:
-        bases = self._bases
-        assert len(bases) >= 1
-        if len(bases) <= 2:
-            return ', '.join(repr(b._path()) for b in bases)
-        else:
-            return f'{bases[0]._path()!r}, ..., {bases[-1]._path()!r}'
 
     def _index_descriptor(self, columns: Optional[list[str]] = None) -> pd.DataFrame:
         from pixeltable import index

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -277,12 +277,11 @@ class View(Table):
 
     @property
     def _effective_base_versions(self) -> list[Optional[int]]:
-        effective_base_version = (
-            self._tbl_version.effective_version
-            if self._snapshot_only
-            else self._tbl_version_path.base.tbl_version.effective_version
-        )
-        return [effective_base_version, *self._base_table._effective_base_versions]
+        effective_versions = [tv.effective_version for tv in self._tbl_version_path.get_tbl_versions()]
+        if self._snapshot_only:
+            return effective_versions
+        else:
+            return effective_versions[1:]
 
     def _table_descriptor(self) -> str:
         display_name = 'Snapshot' if self._snapshot_only else 'View'

--- a/pixeltable/func/udf.py
+++ b/pixeltable/func/udf.py
@@ -262,7 +262,7 @@ def from_table(
     """
     from pixeltable import exprs
 
-    ancestors = [tbl, *tbl._bases]
+    ancestors = [tbl, *tbl._base_tables]
     ancestors.reverse()  # We must traverse the ancestors in order from base to derived
 
     subst: dict[exprs.Expr, exprs.Expr] = {}

--- a/pixeltable/io/label_studio.py
+++ b/pixeltable/io/label_studio.py
@@ -412,8 +412,8 @@ class LabelStudioProject(Project):
             # TODO(aaron-siegel): Simplify this once propagation is properly implemented in batch_update
             ancestor = t
             while local_annotations_col not in ancestor._tbl_version.get().cols:
-                assert ancestor._base is not None
-                ancestor = ancestor._base
+                assert ancestor._base_table is not None
+                ancestor = ancestor._base_table
             update_status = ancestor.batch_update(updates)
             env.Env.get().console_logger.info(f'Updated annotation(s) from {len(updates)} task(s) in {self}.')
             return SyncStatus(pxt_rows_updated=update_status.num_rows, num_excs=update_status.num_excs)

--- a/pixeltable/share/packager.py
+++ b/pixeltable/share/packager.py
@@ -78,7 +78,7 @@ class TablePackager:
             json.dump(self.md, fp)
         self.iceberg_catalog = sqlite_catalog(self.tmp_dir / 'warehouse')
         with Env.get().begin_xact():
-            ancestors = (self.table, *self.table._bases)
+            ancestors = (self.table, *self.table._base_tables)
             for t in ancestors:
                 _logger.info(f"Exporting table '{t._path}'.")
                 self.__export_table(t)

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -93,8 +93,8 @@ class TestPackager:
     def __validate_metadata(self, md: dict, tbl: pxt.Table) -> None:
         assert md['pxt_version'] == pxt.__version__
         assert md['pxt_md_version'] == metadata.VERSION
-        assert len(md['md']['tables']) == len(tbl._bases) + 1
-        for t_md, t in zip(md['md']['tables'], (tbl, *tbl._bases)):
+        assert len(md['md']['tables']) == len(tbl._base_tables) + 1
+        for t_md, t in zip(md['md']['tables'], (tbl, *tbl._base_tables)):
             assert t_md['table_id'] == str(t._tbl_version.id)
 
     def __check_iceberg_tbl(

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -104,5 +104,7 @@ class TestReplica:
         r51 = Catalog.get().create_replica(Path('replica_s51'), s51_md, if_exists=IfExistsParam.ERROR)
 
         with Env.get().begin_xact():
-            assert len(r51._bases) == 4
-            assert len(r61._bases) == 5
+            print([t._path() for t in r51._base_tables])
+            print([t._path() for t in r61._base_tables])
+            assert len(r51._base_tables) == 4
+            assert len(r61._base_tables) == 6

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -104,7 +104,5 @@ class TestReplica:
         r51 = Catalog.get().create_replica(Path('replica_s51'), s51_md, if_exists=IfExistsParam.ERROR)
 
         with Env.get().begin_xact():
-            print([t._path() for t in r51._base_tables])
-            print([t._path() for t in r61._base_tables])
             assert len(r51._base_tables) == 4
             assert len(r61._base_tables) == 6

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2120,6 +2120,7 @@ class TestTable:
         v2._link_external_store(MockProject.create(v2, 'project', {}, {}))
         v2.describe()
 
+        # test case: view with additional columns
         r = repr(v2)
         assert strip_lines(r) == strip_lines(
             """View 'test_subview' (of 'test_view', 'test_tbl')
@@ -2147,12 +2148,58 @@ class TestTable:
         )
         _ = v2._repr_html_()  # TODO: Is there a good way to test this output?
 
-        s = pxt.create_snapshot('test_snap', test_tbl)
-        r = repr(s)
+        # test case: snapshot of view
+        s1 = pxt.create_snapshot('test_snap1', v2)
+        r = repr(s1)
         assert strip_lines(r) == strip_lines(
-            """Snapshot 'test_snap' (of 'test_tbl:2')
+            """Snapshot 'test_snap1' (of 'test_subview:2', 'test_view:0', 'test_tbl:2')
+            Where: ~(c1 == None)
 
             Column Name                          Type           Computed With
+              computed1  Required[Array[(3, 4), Int]]            <lambda>(c2)
+                     c1              Required[String]
+                    c1n                        String
+                     c2                 Required[Int]
+                     c3               Required[Float]
+                     c4                Required[Bool]
+                     c5           Required[Timestamp]
+                     c6                Required[Json]
+                     c7                Required[Json]
+                     c8  Required[Array[(2, 3), Int]]  [[1, 2, 3], [4, 5, 6]]
+
+            External Store         Type
+                   project  MockProject
+
+            COMMENT: This is an intriguing table comment."""
+        )
+
+
+        # test case: snapshot of base table
+        s2 = pxt.create_snapshot('test_snap2', test_tbl)
+        r = repr(s2)
+        assert strip_lines(r) == strip_lines(
+            """Snapshot 'test_snap2' (of 'test_tbl:2')
+
+            Column Name                          Type           Computed With
+                     c1              Required[String]
+                    c1n                        String
+                     c2                 Required[Int]
+                     c3               Required[Float]
+                     c4                Required[Bool]
+                     c5           Required[Timestamp]
+                     c6                Required[Json]
+                     c7                Required[Json]
+                     c8  Required[Array[(2, 3), Int]]  [[1, 2, 3], [4, 5, 6]]"""
+        )
+
+        # test case: snapshot with additional columns
+        s3 = pxt.create_snapshot('test_snap3', test_tbl, additional_columns={'computed1': test_tbl.c2 + test_tbl.c3})
+        r = repr(s3)
+        assert strip_lines(r) == strip_lines(
+            """View 'test_snap3' (of 'test_tbl:2')
+
+            Column Name                          Type           Computed With
+              computed1               Required[Float]                 c2 + c3
                      c1              Required[String]
                     c1n                        String
                      c2                 Required[Int]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2173,7 +2173,6 @@ class TestTable:
             COMMENT: This is an intriguing table comment."""
         )
 
-
         # test case: snapshot of base table
         s2 = pxt.create_snapshot('test_snap2', test_tbl)
         r = repr(s2)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -45,7 +45,7 @@ class TestView:
 
     def test_errors(self, reset_db: None) -> None:
         t = self.create_tbl()
-        assert t._base is None
+        assert t._base_table is None
 
         v = pxt.create_view('test_view', t)
         with pytest.raises(excs.Error) as exc_info:
@@ -66,7 +66,7 @@ class TestView:
 
     def test_basic(self, reset_db: None) -> None:
         t = self.create_tbl()
-        assert t._base is None
+        assert t._base_table is None
 
         # create view with filter and computed columns
         schema = {'v1': t.c3 * 2.0, 'v2': t.c6.f5}
@@ -85,7 +85,7 @@ class TestView:
         v.add_computed_column(v4=v.v2[0])
 
         def check_view(t: pxt.Table, v: pxt.Table) -> None:
-            assert v._base == t
+            assert v._base_table == t
             assert v.count() == t.where(t.c2 < 10).count()
             assert_resultset_eq(
                 v.select(v.v1).order_by(v.c2).collect(), t.select(t.c3 * 2.0).where(t.c2 < 10).order_by(t.c2).collect()


### PR DESCRIPTION
- output with less gratuitous vertical space
- now also prints view predicate
- correctly prints snapshot bases
