### PR TITLE
Add make_video examples to documentation

### DIFF
--- a/docs/mintlify/docs/datastore/iterators.mdx
+++ b/docs/mintlify/docs/datastore/iterators.mdx
@@ -262,6 +262,31 @@ Iterators are powerful tools for processing large media files. They work seamles
     chunks.add_computed_column(text=whisper_transcribe(chunks.audio_chunk))
     ```
   </Accordion>
+
+  <Accordion title="Video Generation" icon="film-simple">
+    ```python
+    from pixeltable.functions.video import make_video
+    
+    # Extract frames at 1 FPS
+    frames = pxt.create_view(
+        'video.frames',
+        videos_table,
+        iterator=FrameIterator.create(
+            video=videos_table.video,
+            fps=1.0
+        )
+    )
+    
+    # Process frames (e.g., apply a filter)
+    frames.add_computed_column(processed=frames.frame.filter('BLUR'))
+    
+    # Create new videos from processed frames
+    processed_videos = frames.select(
+        frames.video_id,
+        make_video(frames.pos, frames.processed)  # Default fps is 25
+    ).group_by(frames.video_id).collect()
+    ```
+  </Accordion>
 </AccordionGroup>
 
 ## Best Practices

--- a/docs/mintlify/docs/examples/search/video.mdx
+++ b/docs/mintlify/docs/examples/search/video.mdx
@@ -158,6 +158,13 @@ Pixeltable lets you build comprehensive video search workflows combining both au
             fps=1
         )
     )
+    
+    # Optionally, create new videos from processed frames
+    from pixeltable.functions.video import make_video
+    processed_videos = frames_view.select(
+        frames_view.video_id,
+        make_video(frames_view.pos, frames_view.frame)  # Default fps is 25
+    ).group_by(frames_view.video_id).collect()
     ```
   </Card>
 


### PR DESCRIPTION
The changes include subtle mentions of the `make_video` functionality in both files, with examples that match the usage pattern found in the object-detection-in-videos.ipynb notebook. 
