### PR TITLE
Improve import documentation

### DIFF
--- a/docs/mintlify/docs/datastore/bringing-data.mdx
+++ b/docs/mintlify/docs/datastore/bringing-data.mdx
@@ -8,6 +8,71 @@ icon: 'file-import'
 
 Pixeltable provides a unified interface for working with diverse data types - from structured tables to unstructured media files. This guide covers everything you need to know about bringing your data into Pixeltable.
 
+## Direct Import with Table Creation and Insertion
+
+Pixeltable supports importing data directly during table creation and insertion operations. This streamlines the process of loading data into Pixeltable tables from external sources.
+
+Pixeltable supports importing from a variety of data sources:
+- CSV files (`.csv`)
+- Excel files (`.xls`, `.xlsx`)
+- Parquet files (`.parquet`, `.pq`, `.parq`)
+- JSON files (`.json`)
+- Pandas DataFrames
+- Pixeltable DataFrames
+- Hugging Face datasets
+- Row data structures or Iterators
+
+### Creating Tables from External Sources
+
+You can create a table directly from an external data source using the `source` parameter in the `create_table` function. Pixeltable will automatically infer the schema from the source data.
+
+```python
+import pixeltable as pxt
+import pandas as pd
+
+# Create from CSV file
+table = pxt.create_table('from_csv', source='https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/world-population-data.csv')
+
+# Create from pandas DataFrame
+df = pd.DataFrame({
+    'col1': [1, 2, 3],
+    'col2': ['a', 'b', 'c']
+})
+table = pxt.create_table('from_df', source=df)
+```
+
+You can also provide schema overrides for more control:
+
+```python
+import pixeltable as pxt
+
+# With schema overrides
+table = pxt.create_table(
+    'from_csv_with_overrides', 
+    source='https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/world-population-data.csv',
+    schema_overrides={'pop_2023': pxt.Required[pxt.Int]}
+)
+```
+
+### Inserting Data from External Sources
+
+You can also insert data from external sources into existing tables using the `insert` method:
+
+```python
+import pixeltable as pxt
+import pandas as pd
+
+# Insert from CSV file
+table.insert('https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/world-population-data.csv')
+
+# Insert from pandas DataFrame
+df = pd.DataFrame({
+    'col1': [4, 5, 6],
+    'col2': ['d', 'e', 'f']
+})
+table.insert(df)
+```
+
 ## Supported Data Types & Formats
 
 <AccordionGroup>
@@ -252,7 +317,7 @@ Pixeltable provides a unified interface for working with diverse data types - fr
 
 </AccordionGroup>
 
-## Import Functions
+## Import Functions (Alternative Approach)
 
 <AccordionGroup>
   <Accordion title="CSV Import" icon="file-csv">
@@ -413,3 +478,6 @@ Pixeltable provides a unified interface for working with diverse data types - fr
 - Import functions support schema overrides to ensure correct type assignment
 - Use batch inserts for better performance when adding multiple rows
 - Cloud storage paths (s3://) require appropriate credentials to be configured
+- Tables can be created directly from CSV, Excel, Parquet files, and pandas DataFrames using the `source` parameter
+- Existing tables can import data directly from external sources using the `insert` method
+- Schema inference is automatic when importing from external sources, with optional schema overrides

--- a/docs/mintlify/docs/datastore/tables-and-operations.mdx
+++ b/docs/mintlify/docs/datastore/tables-and-operations.mdx
@@ -170,6 +170,44 @@ Column casting helps maintain data consistency and prevents type errors when pro
     ```
   </Card>
 
+  <Card title="Import from Source" icon="file-import">
+    Create tables or insert data directly from external sources:
+    ```python
+    import pixeltable as pxt
+    import pandas as pd
+    
+    # Create a table from a CSV file
+    table = pxt.create_table('world_population', source='https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/world-population-data.csv')
+    
+    # Create a table from a pandas DataFrame
+    df = pd.DataFrame({
+        'cca3': ['FRA', 'DEU', 'ITA'],
+        'country': ['France', 'Germany', 'Italy'],
+        'continent': ['Europe', 'Europe', 'Europe'],
+        'pop_2023': [68_000_000, 83_000_000, 59_000_000]
+    })
+    table = pxt.create_table('europe_population', source=df)
+    
+    # Insert data from a pandas DataFrame into an existing table
+    new_df = pd.DataFrame({
+        'cca3': ['ESP', 'GBR', 'POL'],
+        'country': ['Spain', 'United Kingdom', 'Poland'],
+        'continent': ['Europe', 'Europe', 'Europe'],
+        'pop_2023': [47_000_000, 67_000_000, 38_000_000]
+    })
+    table.insert(new_df)
+    ```
+    
+    Pixeltable supports importing from various data sources:
+    - CSV files (`.csv`)
+    - Excel files (`.xls`, `.xlsx`)
+    - Parquet files (`.parquet`, `.pq`, `.parq`)
+    - JSON files (`.json`)
+    - Pandas DataFrames
+    - Pixeltable DataFrames
+    - Hugging Face datasets
+  </Card>
+
   <Card title="Update Operations" icon="pen-to-square">
     Modify existing data:
     ```python


### PR DESCRIPTION
## Description

This PR enhances the documentation for importing data into Pixeltable by prioritizing the direct import approach using the `source` parameter and `insert` method. The changes make it clearer to users that this is the recommended way to bring data into Pixeltable.

## Changes Made

- Reorganized the "Bringing Data" documentation to place the "Direct Import with Table Creation and Insertion" section first, before the "Supported Data Types & Formats" section
- Added a comprehensive list of all supported data source types at the beginning of the section
- Updated examples to use the GitHub raw URL for world-population-data.csv, ensuring users can run the examples directly
- Added necessary import statements to all code examples and cleaned up unnecessary comments
- Added a new "Import from Source" card to the "Data Operations" section of the tables-and-operations.mdx file
- Ensured consistent examples using the world-population-data structure across all documentation
