### PR TITLE
Update mint.json to use Kandinsky color theme

### DIFF
--- a/docs/mintlify/mint.json
+++ b/docs/mintlify/mint.json
@@ -7,15 +7,16 @@
   },
   "favicon": "/favicon.svg",
   "colors": {
-    "primary": "#19191B",
-    "light": "#71717A",
-    "dark": "#09080B",
+    "primary": "#1E5AA8",
+    "light": "#F1AE03",
+    "dark": "#020704",
     "anchors": {
-      "from": "#0A2F5C",
-      "to": "#404040"
+      "from": "#F1AE03",
+      "to": "#DC2404"
     },
     "background": {
-      "dark": "#08080B"
+      "light": "#FAF6F0",
+      "dark": "#020704"
     }
   },
   "font": {


### PR DESCRIPTION
- Updated primary color to vibrant blue (#1E5AA8) for better contrast
- Set light background to warm beige (#FAF6F0)
- Maintained Kandinsky yellow (#F1AE03) for highlights
- Updated anchor gradient from yellow to red
- Preserved dark theme with Kandinsky black (#020704)

This aligns the documentation theme with the website's Kandinsky color palette.