### PR TITLE
Remove extraneous reload_catalog() in test_packager

### DIFF
--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -195,7 +195,6 @@ class TestPackager:
         """
         restorer = TableRestorer(tbl_name)
         restorer.restore(bundle_info.bundle_path)
-        reload_catalog()  # TODO: This shouldn't be necessary.
         self.__check_table(bundle_info, tbl_name)
 
     def __check_table(self, bundle_info: 'TestPackager.BundleInfo', tbl_name: str) -> None:


### PR DESCRIPTION
This was fixed as a byproduct of the latest round of concurrency changes.