### PR TITLE
fix building with llm link

### DIFF
--- a/docs/mintlify/docs/overview/building-pixeltable-with-llms.mdx
+++ b/docs/mintlify/docs/overview/building-pixeltable-with-llms.mdx
@@ -10,7 +10,7 @@ You can use large language models (LLMs) to assist in building Pixeltable integr
 
 ## Plain text docs 
 
-You can access all of our documentation as plain text markdown files by adding `.md` to the end of any url. For example, you can find the plain text version of this page itself at [https://docs.pixeltable.com/libraries/building-on-pixeltable.md](https://docs.pixeltable.com/libraries/building-on-pixeltable.md).
+You can access all of our documentation as plain text markdown files by adding `.md` to the end of any url. For example, you can find the plain text version of this page itself at [https://docs.pixeltable.com/docs/overview/building-pixeltable-with-llms.md](https://docs.pixeltable.com/docs/overview/building-pixeltable-with-llms.md).
 
 This helps AI tools and agents consume our content and allows you to copy and paste the entire contents of a doc into an LLM. This format is preferable to scraping or copying from our HTML and JavaScript-rendered pages because:
 


### PR DESCRIPTION
changed building with llms link from:
https://docs.pixeltable.com/libraries/building-on-pixeltable.md

to:
https://docs.pixeltable.com/docs/overview/building-pixeltable-with-llms.md

Tested locally and url routes to the expected page.