### PR TITLE
docs: add product updates changelog with version history and release notes

### DIFF
--- a/docs/mintlify/docs/changelog/product-updates.mdx
+++ b/docs/mintlify/docs/changelog/product-updates.mdx
@@ -4,6 +4,17 @@ description: 'Keep track of changes'
 icon: 'newspaper'
 ---
 
+<Update label="2025-06-03" description="v0.3.15">
+### Highlights
+* Added UDFs for Google Imagen and Veo
+* Added support for Tool Calling in Gemini
+* Improved handling of base table merging when pulling replicas
+
+### Enhancements
+* Enhanced consistency when merging different versions of base tables during replica pulls
+
+</Update>
+
 <Update label="2025-05-05" description="v0.3.13">
 ### Highlights
 * Added AWS Bedrock Adapter for expanded LLM integration options


### PR DESCRIPTION
i've added the v0.3.15 release information to the changelog.

Highlights
Added UDFs for Google Imagen and Veo
Added support for Tool Calling in Gemini
Improved handling of base table merging when pulling replicas

Enhancements
Enhanced consistency when merging different versions of base tables during replica pulls