### PR TITLE
Collect more information on ins, del, upd operations. Freeze UpdateStatus.

### DIFF
--- a/pixeltable/catalog/globals.py
+++ b/pixeltable/catalog/globals.py
@@ -37,8 +37,13 @@ class RowCountStats:
     ins_rows: int = 0  # rows inserted
     del_rows: int = 0  # rows deleted
     upd_rows: int = 0  # rows updated
-    exc_rows: int = 0  # rows that had exceptions during the operation
     num_excs: int = 0  # total number of exceptions
+    # TODO: disambiguate what this means: # of slots computed or # of columns computed?
+    computed_values: int = 0  # number of computed values (e.g., computed columns) affected by the operation
+
+    @property
+    def num_rows(self) -> int:
+        return self.ins_rows + self.del_rows + self.upd_rows
 
     def insert_to_update(self) -> 'RowCountStats':
         """
@@ -49,8 +54,8 @@ class RowCountStats:
             ins_rows=0,
             del_rows=self.del_rows,
             upd_rows=self.upd_rows + self.ins_rows,
-            exc_rows=self.exc_rows,
             num_excs=self.num_excs,
+            computed_values=self.computed_values,
         )
 
     def __add__(self, other: 'RowCountStats') -> 'RowCountStats':
@@ -61,21 +66,17 @@ class RowCountStats:
             ins_rows=self.ins_rows + other.ins_rows,
             del_rows=self.del_rows + other.del_rows,
             upd_rows=self.upd_rows + other.upd_rows,
-            exc_rows=self.exc_rows + other.exc_rows,
             num_excs=self.num_excs + other.num_excs,
+            computed_values=self.computed_values + other.computed_values,
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class UpdateStatus:
     """
     Information about updates that resulted from a table operation.
     """
 
-    num_rows: int = 0
-    # TODO: disambiguate what this means: # of slots computed or # of columns computed?
-    num_computed_values: int = 0
-    num_excs: int = 0
     updated_cols: list[str] = dataclasses.field(default_factory=list)
     cols_with_excs: list[str] = dataclasses.field(default_factory=list)
 
@@ -85,15 +86,24 @@ class UpdateStatus:
     # stats for changes cascaded to other tables
     cascade_row_count_stats: RowCountStats = dataclasses.field(default_factory=lambda: RowCountStats())
 
+    @property
+    def num_rows(self) -> int:
+        return self.row_count_stats.num_rows + self.cascade_row_count_stats.num_rows
+
+    @property
+    def num_excs(self) -> int:
+        return self.row_count_stats.num_excs + self.cascade_row_count_stats.num_excs
+
+    @property
+    def num_computed_values(self) -> int:
+        return self.row_count_stats.computed_values + self.cascade_row_count_stats.computed_values
+
     def insert_to_update(self) -> 'UpdateStatus':
         """
         Convert the update status from an insert operation to an update operation.
         This is used when an insert operation is treated as an update.
         """
         return UpdateStatus(
-            num_rows=self.num_rows,
-            num_computed_values=self.num_computed_values,
-            num_excs=self.num_excs,
             updated_cols=self.updated_cols,
             cols_with_excs=self.cols_with_excs,
             row_count_stats=self.row_count_stats.insert_to_update(),
@@ -106,9 +116,6 @@ class UpdateStatus:
         This is used when an operation cascades changes to other tables.
         """
         return UpdateStatus(
-            num_rows=self.num_rows,
-            num_computed_values=self.num_computed_values,
-            num_excs=self.num_excs,
             updated_cols=self.updated_cols,
             cols_with_excs=self.cols_with_excs,
             row_count_stats=RowCountStats(),
@@ -120,9 +127,6 @@ class UpdateStatus:
         Add the update status from two UpdateStatus objects together.
         """
         return UpdateStatus(
-            num_rows=self.num_rows + other.num_rows,
-            num_computed_values=self.num_computed_values + other.num_computed_values,
-            num_excs=self.num_excs + other.num_excs,
             updated_cols=list(dict.fromkeys(self.updated_cols + other.updated_cols)),
             cols_with_excs=list(dict.fromkeys(self.cols_with_excs + other.cols_with_excs)),
             row_count_stats=self.row_count_stats + other.row_count_stats,

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -753,7 +753,7 @@ class TableVersion:
                 if excs_per_col > 0:
                     cols_with_excs.append(col)
                     num_excs += excs_per_col
-                computed_values += row_count
+                computed_values += plan.ctx.num_computed_exprs * row_count
             finally:
                 # Ensure cleanup occurs if an exception or keyboard interruption happens during `load_column()`.
                 def cleanup_on_error() -> None:
@@ -778,11 +778,10 @@ class TableVersion:
             plan.ctx.profile.print(num_rows=row_count)
 
         # TODO: what to do about system columns with exceptions?
-        row_counts = RowCountStats(upd_rows=row_count, num_excs=num_excs)  # add_columns
+        row_counts = RowCountStats(
+            upd_rows=row_count, num_excs=num_excs, computed_values=computed_values
+        )  # add_columns
         return UpdateStatus(
-            num_rows=row_count,
-            num_computed_values=computed_values,
-            num_excs=num_excs,
             cols_with_excs=[f'{col.tbl.name}.{col.name}' for col in cols_with_excs if col.name is not None],
             row_count_stats=row_counts,
         )
@@ -927,7 +926,7 @@ class TableVersion:
         cols_with_excs, result = self.store_tbl.insert_rows(
             exec_plan, v_min=self.version, rowids=rowids, abort_on_exc=abort_on_exc
         )
-        result.cols_with_excs = [f'{self.name}.{self.cols_by_id[cid].name}' for cid in cols_with_excs]
+        result += UpdateStatus(cols_with_excs=[f'{self.name}.{self.cols_by_id[cid].name}' for cid in cols_with_excs])
         self._write_md(new_version=True, new_version_ts=timestamp, new_schema_version=False)
 
         # update views
@@ -939,7 +938,7 @@ class TableVersion:
             result += status.to_cascade()
 
         if print_stats:
-            plan.ctx.profile.print(num_rows=status.num_rows)  # This is the net rows after all propagations
+            plan.ctx.profile.print(num_rows=result.num_rows)  # This is the net rows after all propagations
         _logger.info(f'TableVersion {self.name}: new version {self.version}')
         return result
 
@@ -979,7 +978,7 @@ class TableVersion:
             cascade=cascade,
             show_progress=True,
         )
-        result.updated_cols = updated_cols
+        result += UpdateStatus(updated_cols=updated_cols)
         return result
 
     def batch_update(
@@ -1006,15 +1005,15 @@ class TableVersion:
         result = self.propagate_update(
             plan, delete_where_clause, recomputed_cols, base_versions=[], timestamp=time.time(), cascade=cascade
         )
-        result.updated_cols = [c.qualified_name for c in updated_cols]
+        result += UpdateStatus(updated_cols=[c.qualified_name for c in updated_cols])
 
         unmatched_rows = row_update_node.unmatched_rows()
         if len(unmatched_rows) > 0:
             if error_if_not_exists:
                 raise excs.Error(f'batch_update(): {len(unmatched_rows)} row(s) not found')
             if insert_if_not_exists:
-                status = self.insert(unmatched_rows, None, print_stats=False, fail_on_exception=False)
-                result += status.to_cascade()
+                insert_status = self.insert(unmatched_rows, None, print_stats=False, fail_on_exception=False)
+                result += insert_status.to_cascade()
         return result
 
     def _validate_update_spec(
@@ -1077,17 +1076,20 @@ class TableVersion:
         cascade: bool,
         show_progress: bool = True,
     ) -> UpdateStatus:
-        result = UpdateStatus()
         if plan is not None:
             # we're creating a new version
             self.version += 1
             cols_with_excs, status = self.store_tbl.insert_rows(plan, v_min=self.version, show_progress=show_progress)
-            result += status.insert_to_update()
-            result.cols_with_excs = [f'{self.name}.{self.cols_by_id[cid].name}' for cid in cols_with_excs]
+            result = status.insert_to_update()
+            result += UpdateStatus(
+                cols_with_excs=[f'{self.name}.{self.cols_by_id[cid].name}' for cid in cols_with_excs]
+            )
             self.store_tbl.delete_rows(
                 self.version, base_versions=base_versions, match_on_vmin=True, where_clause=where_clause
             )
             self._write_md(new_version=True, new_version_ts=timestamp, new_schema_version=False)
+        else:
+            result = UpdateStatus()
 
         if cascade:
             base_versions = [None if plan is None else self.version, *base_versions]  # don't update in place
@@ -1153,7 +1155,7 @@ class TableVersion:
             self.version + 1, base_versions=base_versions, match_on_vmin=False, where_clause=sql_where_clause
         )
         row_counts = RowCountStats(del_rows=del_rows)  # delete
-        result = UpdateStatus(num_rows=del_rows, row_count_stats=row_counts)
+        result = UpdateStatus(row_count_stats=row_counts)
         if del_rows > 0:
             # we're creating a new version
             self.version += 1

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -1095,7 +1095,7 @@ class TableVersion:
             cascade=cascade,
             show_progress=True,
         )
-        result.updated_cols = updated_cols
+        result += UpdateStatus(updated_cols=updated_cols)
         return result
 
     def propagate_update(

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -602,8 +602,7 @@ class Planner:
         row_builder.set_slot_idxs(select_list, remove_duplicates=False)
         for i, col in enumerate(all_base_cols):
             plan.row_builder.add_table_column(col, select_list[i].slot_idx)
-
-        ctx = exec.ExecContext(row_builder)
+        ctx = exec.ExecContext(row_builder, num_computed_exprs=len(recomputed_exprs))
         # we're returning everything to the user, so we might as well do it in a single batch
         ctx.batch_size = 0
         plan.set_ctx(ctx)

--- a/pixeltable/store.py
+++ b/pixeltable/store.py
@@ -382,13 +382,11 @@ class StoreBase:
                     conn.execute(sql.insert(self.sa_tbl), table_rows)
             if progress_bar is not None:
                 progress_bar.close()
-            row_counts = RowCountStats(ins_rows=num_rows, num_excs=num_excs)  # insert (StoreBase)
-            return cols_with_excs, UpdateStatus(
-                num_rows=num_rows,
-                num_excs=num_excs,
-                num_computed_values=exec_plan.ctx.num_computed_exprs * num_rows,
-                row_count_stats=row_counts,
-            )
+            computed_values = exec_plan.ctx.num_computed_exprs * num_rows
+            row_counts = RowCountStats(
+                ins_rows=num_rows, num_excs=num_excs, computed_values=computed_values
+            )  # insert (StoreBase)
+            return cols_with_excs, UpdateStatus(row_count_stats=row_counts)
         finally:
             exec_plan.close()
 


### PR DESCRIPTION
    - Modify history test to also show collected UpdateStatus.
    - Plumb and correct all things related to UpdateStatus - pass tests.
    - Complete plumbing new row count stats everywhere.
    - Pass tests with parallel num_rows(x) and RowCountStats.
    - Replace UpdateStatus.num_excs with num_excsx.
    - Replace UpdateStatus.num_computed_values with UpdateStatus.num_computed_valuesx.
    - Fix num_excs property.
    - Remove obsolete fields from UpdateStatus.
    - Fix merge of catalog/globals.py.