### PR TITLE
Performance improvements in add_computed_column

### DIFF
--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -741,12 +741,12 @@ class TableVersion:
             # populate the column
             from pixeltable.plan import Planner
 
-            plan, value_expr_slot_idx = Planner.create_add_column_plan(self.path, col)
+            plan = Planner.create_add_column_plan(self.path, col)
             plan.ctx.num_rows = row_count
             try:
                 plan.open()
                 try:
-                    excs_per_col = self.store_tbl.load_column(col, plan, value_expr_slot_idx, on_error == 'abort')
+                    excs_per_col = self.store_tbl.load_column(col, plan, on_error == 'abort')
                 except sql.exc.DBAPIError as exc:
                     # Wrap the DBAPIError in an excs.Error to unify processing in the subsequent except block
                     raise excs.Error(f'SQL error during execution of computed column `{col.name}`:\n{exc}') from exc

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -746,7 +746,7 @@ class TableVersion:
             try:
                 plan.open()
                 try:
-                    excs_per_col = self.store_tbl.load_column(col, plan, value_expr_slot_idx, on_error)
+                    excs_per_col = self.store_tbl.load_column(col, plan, value_expr_slot_idx, on_error == 'abort')
                 except sql.exc.DBAPIError as exc:
                     # Wrap the DBAPIError in an excs.Error to unify processing in the subsequent except block
                     raise excs.Error(f'SQL error during execution of computed column `{col.name}`:\n{exc}') from exc

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -436,7 +436,7 @@ class RowBuilder:
                         expr, f'expression {expr}', data_row.get_exc(expr.slot_idx), exc_tb, input_vals, 0
                     ) from exc
 
-    def create_table_row(self, data_row: DataRow, exc_col_ids: set[int], pk: tuple[int, ...]) -> tuple[list[Any], int]:
+    def create_table_row(self, data_row: DataRow, cols_with_excs: Optional[set[int]], pk: tuple[int, ...]) -> tuple[list[Any], int]:
         """Create a table row from the slots that have an output column assigned
 
         Return tuple[list of row values in `self.table_columns` order, # of exceptions]
@@ -449,7 +449,8 @@ class RowBuilder:
             if data_row.has_exc(slot_idx):
                 exc = data_row.get_exc(slot_idx)
                 num_excs += 1
-                exc_col_ids.add(col.id)
+                if cols_with_excs is not None:
+                    cols_with_excs.add(col.id)
                 table_row.append(None)
                 if col.records_errors:
                     # exceptions get stored in the errortype/-msg columns

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Callable, Iterable, Optional, Sequence
 from uuid import UUID
 
 import numpy as np
@@ -436,7 +436,7 @@ class RowBuilder:
                         expr, f'expression {expr}', data_row.get_exc(expr.slot_idx), exc_tb, input_vals, 0
                     ) from exc
 
-    def create_table_row(self, data_row: DataRow, exc_col_ids: set[int], pk: tuple[int, ...]) -> tuple[list[Any], int]:
+    def create_table_row(self, data_row: DataRow, exc_col_ids: set[int], pk: tuple[int, ...], abort_on_exc: bool = False, move_tmp_media_file: Optional[Callable] = None) -> tuple[list[Any], int]:
         """Create a table row from the slots that have an output column assigned
 
         Return tuple[list of row values in `self.table_columns` order, # of exceptions]
@@ -449,6 +449,10 @@ class RowBuilder:
             if data_row.has_exc(slot_idx):
                 exc = data_row.get_exc(slot_idx)
                 num_excs += 1
+                if abort_on_exc:
+                    raise excs.Error(
+                        f'Error while evaluating computed column {col.name!r}:\n{exc}'
+                    ) from exc
                 exc_col_ids.add(col.id)
                 table_row.append(None)
                 if col.records_errors:
@@ -460,6 +464,8 @@ class RowBuilder:
                     filepath = str(MediaStore.prepare_media_path(col.tbl.id, col.id, col.tbl.version))
                     data_row.flush_img(slot_idx, filepath)
                 val = data_row.get_stored_val(slot_idx, col.get_sa_col_type())
+                if move_tmp_media_file is not None and col.col_type.is_media_type():
+                    val = move_tmp_media_file(val, col, pk[-1])
                 table_row.append(val)
                 if col.records_errors:
                     table_row.extend((None, None))

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -1042,9 +1042,7 @@ class Planner:
         return Analyzer(FromClause(tbls=[tbl]), [], where_clause=where_clause)
 
     @classmethod
-    def create_add_column_plan(
-        cls, tbl: catalog.TableVersionPath, col: catalog.Column
-    ) -> tuple[exec.ExecNode, Optional[int]]:
+    def create_add_column_plan(cls, tbl: catalog.TableVersionPath, col: catalog.Column) -> exec.ExecNode:
         """Creates a plan for InsertableTable.add_column()
         Returns:
             plan: the plan to execute
@@ -1063,5 +1061,4 @@ class Planner:
         # we want to flush images
         if col.is_computed and col.is_stored and col.col_type.is_image_type():
             plan.set_stored_img_cols(row_builder.output_slot_idxs())
-        value_expr_slot_idx = row_builder.output_slot_idxs()[0].slot_idx if col.is_computed else None
-        return plan, value_expr_slot_idx
+        return plan

--- a/pixeltable/store.py
+++ b/pixeltable/store.py
@@ -249,47 +249,31 @@ class StoreBase:
         tmp_tbl = sql.Table(tmp_name, self.sa_md, *tmp_cols, prefixes=['TEMPORARY'])
         conn = Env.get().conn
         tmp_tbl.create(bind=conn)
+        tmp_col_names = [col.name for col in tmp_cols]
+
+        row_builder = exec_plan.row_builder
 
         try:
+            table_rows: list[tuple[Any]] = []
+
             # insert rows from exec_plan into temp table
-            # TODO: unify the table row construction logic with RowBuilder.create_table_row()
             for row_batch in exec_plan:
                 num_rows += len(row_batch)
-                tbl_rows: list[dict[str, Any]] = []
+                batch_table_rows: list[tuple[Any]] = []
+
                 for result_row in row_batch:
-                    tbl_row: dict[str, Any] = {}
-                    for pk_col, pk_val in zip(self.pk_columns(), result_row.pk):
-                        tbl_row[pk_col.name] = pk_val
+                    tbl_row, num_row_exc = row_builder.create_table_row(result_row, set(), result_row.pk, abort_on_exc=(on_error == 'abort'), move_tmp_media_file=self._move_tmp_media_file)
+                    num_excs += num_row_exc
+                    batch_table_rows.append(tuple(tbl_row))
 
-                    if col.is_computed:
-                        if result_row.has_exc(value_expr_slot_idx):
-                            num_excs += 1
-                            value_exc = result_row.get_exc(value_expr_slot_idx)
-                            if on_error == 'abort':
-                                raise excs.Error(
-                                    f'Error while evaluating computed column `{col.name}`:\n{value_exc}'
-                                ) from value_exc
-                            # we store a NULL value and record the exception/exc type
-                            error_type = type(value_exc).__name__
-                            error_msg = str(value_exc)
-                            tbl_row[col.sa_col.name] = None
-                            tbl_row[col.sa_errortype_col.name] = error_type
-                            tbl_row[col.sa_errormsg_col.name] = error_msg
-                        else:
-                            if col.col_type.is_image_type() and result_row.file_urls[value_expr_slot_idx] is None:
-                                # we have yet to store this image
-                                filepath = str(MediaStore.prepare_media_path(col.tbl.id, col.id, col.tbl.version))
-                                result_row.flush_img(value_expr_slot_idx, filepath)
-                            val = result_row.get_stored_val(value_expr_slot_idx, col.sa_col.type)
-                            if col.col_type.is_media_type():
-                                val = self._move_tmp_media_file(val, col, result_row.pk[-1])
-                            tbl_row[col.sa_col.name] = val
-                            if col.records_errors:
-                                tbl_row[col.sa_errortype_col.name] = None
-                                tbl_row[col.sa_errormsg_col.name] = None
+                table_rows.extend(batch_table_rows)
 
-                    tbl_rows.append(tbl_row)
-                conn.execute(sql.insert(tmp_tbl), tbl_rows)
+                if len(table_rows) >= self.__INSERT_BATCH_SIZE:
+                    self.sql_insert(tmp_tbl, tmp_col_names, table_rows)
+                    table_rows.clear()
+
+            if len(table_rows) > 0:
+                self.sql_insert(tmp_tbl, tmp_col_names, table_rows)
 
             # update store table with values from temp table
             update_stmt = sql.update(self.sa_tbl)
@@ -302,13 +286,14 @@ class StoreBase:
                 )
             log_explain(_logger, update_stmt, conn)
             conn.execute(update_stmt)
-        finally:
 
+        finally:
             def remove_tmp_tbl() -> None:
                 self.sa_md.remove(tmp_tbl)
                 tmp_tbl.drop(bind=conn)
 
             run_cleanup(remove_tmp_tbl, raise_error=True)
+
         return num_excs
 
     def insert_rows(
@@ -372,12 +357,12 @@ class StoreBase:
 
                 # if a batch is ready for insertion into the database, insert it
                 if len(table_rows) >= self.__INSERT_BATCH_SIZE:
-                    self.sql_insert(store_col_names, table_rows)
+                    self.sql_insert(self.sa_tbl, store_col_names, table_rows)
                     table_rows.clear()
 
             # insert any remaining rows
             if len(table_rows) > 0:
-                self.sql_insert(store_col_names, table_rows)
+                self.sql_insert(self.sa_tbl, store_col_names, table_rows)
 
             if progress_bar is not None:
                 progress_bar.close()
@@ -391,10 +376,11 @@ class StoreBase:
         finally:
             exec_plan.close()
 
-    def sql_insert(self, store_col_names: list[str], table_rows: list[tuple[Any]]) -> None:
+    @classmethod
+    def sql_insert(cls, sa_tbl: sql.Table, store_col_names: list[str], table_rows: list[tuple[Any]]) -> None:
         assert len(table_rows) > 0
         conn = Env.get().conn
-        conn.execute(sql.insert(self.sa_tbl), [dict(zip(store_col_names, table_row)) for table_row in table_rows])
+        conn.execute(sql.insert(sa_tbl), [dict(zip(store_col_names, table_row)) for table_row in table_rows])
 
         # TODO: Inserting directly via psycopg delivers a small performance benefit, but is somewhat fraught due to
         #     differences in the data representation that SQLAlchemy/psycopg expect. The below code will do the


### PR DESCRIPTION
Incorporates the recent performance improvements in `insert_rows` to `load_column`. Also unifies the row construction logic between the two code paths (resolving a longstanding TODO).

The performance gain is less pronounced, and the performance of `load_column` has a higher variance in general; the gain is anywhere from 10% to 35% in my trials. There may be additional performance gains available by optimizing the way temp tables are used; I haven't explored these.