### PR TITLE
Prepare to report more status in table.history()

### DIFF
--- a/pixeltable/catalog/__init__.py
+++ b/pixeltable/catalog/__init__.py
@@ -3,16 +3,7 @@
 from .catalog import Catalog
 from .column import Column
 from .dir import Dir
-from .globals import (
-    IfExistsParam,
-    IfNotExistsParam,
-    MediaValidation,
-    QColumnId,
-    RowCountStats,
-    UpdateStatus,
-    is_valid_identifier,
-    is_valid_path,
-)
+from .globals import IfExistsParam, IfNotExistsParam, MediaValidation, QColumnId, is_valid_identifier, is_valid_path
 from .insertable_table import InsertableTable
 from .named_function import NamedFunction
 from .path import Path
@@ -21,4 +12,5 @@ from .table import Table
 from .table_version import TableVersion
 from .table_version_handle import ColumnHandle, TableVersionHandle
 from .table_version_path import TableVersionPath
+from .update_status import RowCountStats, UpdateStatus
 from .view import View

--- a/pixeltable/catalog/globals.py
+++ b/pixeltable/catalog/globals.py
@@ -79,8 +79,10 @@ class RowCountStats:
 @dataclass(frozen=True)
 class UpdateStatus:
     """
-    Information about updates that resulted from a table operation.
+    Information about changes to table data or table schema
     """
+
+    comment: str = ''  # Note about this operation
 
     updated_cols: list[str] = dataclasses.field(default_factory=list)
     cols_with_excs: list[str] = dataclasses.field(default_factory=list)
@@ -109,6 +111,7 @@ class UpdateStatus:
         This is used when an insert operation is treated as an update.
         """
         return UpdateStatus(
+            comment=self.comment,
             updated_cols=self.updated_cols,
             cols_with_excs=self.cols_with_excs,
             row_count_stats=self.row_count_stats.insert_to_update(),
@@ -121,6 +124,7 @@ class UpdateStatus:
         This is used when an operation cascades changes to other tables.
         """
         return UpdateStatus(
+            comment=self.comment,
             updated_cols=self.updated_cols,
             cols_with_excs=self.cols_with_excs,
             row_count_stats=RowCountStats(),
@@ -132,6 +136,7 @@ class UpdateStatus:
         Add the update status from two UpdateStatus objects together.
         """
         return UpdateStatus(
+            comment=self.comment,  # comments are not added together
             updated_cols=list(dict.fromkeys(self.updated_cols + other.updated_cols)),
             cols_with_excs=list(dict.fromkeys(self.cols_with_excs + other.cols_with_excs)),
             row_count_stats=self.row_count_stats + other.row_count_stats,

--- a/pixeltable/catalog/globals.py
+++ b/pixeltable/catalog/globals.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
-import dataclasses
 import enum
 import itertools
 import logging
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from dataclasses import dataclass
+from typing import Optional
 from uuid import UUID
 
 import pixeltable.exceptions as excs
-
-if TYPE_CHECKING:
-    from IPython.lib.pretty import RepresentationPrinter
-
 
 _logger = logging.getLogger('pixeltable')
 
@@ -31,152 +26,6 @@ class QColumnId:
 
     tbl_id: UUID
     col_id: int
-
-
-@dataclass(frozen=True)
-class RowCountStats:
-    """
-    Statistics about the counts of rows affected by a table operation.
-    """
-
-    ins_rows: int = 0  # rows inserted
-    del_rows: int = 0  # rows deleted
-    upd_rows: int = 0  # rows updated
-    num_excs: int = 0  # total number of exceptions
-    # TODO: disambiguate what this means: # of slots computed or # of columns computed?
-    computed_values: int = 0  # number of computed values (e.g., computed columns) affected by the operation
-
-    @property
-    def num_rows(self) -> int:
-        return self.ins_rows + self.del_rows + self.upd_rows
-
-    def insert_to_update(self) -> 'RowCountStats':
-        """
-        Convert insert row count stats to update row count stats.
-        This is used when an insert operation is treated as an update.
-        """
-        return RowCountStats(
-            ins_rows=0,
-            del_rows=self.del_rows,
-            upd_rows=self.upd_rows + self.ins_rows,
-            num_excs=self.num_excs,
-            computed_values=self.computed_values,
-        )
-
-    def __add__(self, other: 'RowCountStats') -> 'RowCountStats':
-        """
-        Add the stats from two RowCountStats objects together.
-        """
-        return RowCountStats(
-            ins_rows=self.ins_rows + other.ins_rows,
-            del_rows=self.del_rows + other.del_rows,
-            upd_rows=self.upd_rows + other.upd_rows,
-            num_excs=self.num_excs + other.num_excs,
-            computed_values=self.computed_values + other.computed_values,
-        )
-
-
-@dataclass(frozen=True)
-class UpdateStatus:
-    """
-    Information about changes to table data or table schema
-    """
-
-    comment: str = ''  # Note about this operation
-
-    updated_cols: list[str] = dataclasses.field(default_factory=list)
-    cols_with_excs: list[str] = dataclasses.field(default_factory=list)
-
-    # stats for the rows affected by the operation
-    row_count_stats: RowCountStats = field(default_factory=RowCountStats)
-
-    # stats for changes cascaded to other tables
-    cascade_row_count_stats: RowCountStats = field(default_factory=RowCountStats)
-
-    @property
-    def num_rows(self) -> int:
-        return self.row_count_stats.num_rows + self.cascade_row_count_stats.num_rows
-
-    @property
-    def num_excs(self) -> int:
-        return self.row_count_stats.num_excs + self.cascade_row_count_stats.num_excs
-
-    @property
-    def num_computed_values(self) -> int:
-        return self.row_count_stats.computed_values + self.cascade_row_count_stats.computed_values
-
-    def insert_to_update(self) -> 'UpdateStatus':
-        """
-        Convert the update status from an insert operation to an update operation.
-        This is used when an insert operation is treated as an update.
-        """
-        return UpdateStatus(
-            comment=self.comment,
-            updated_cols=self.updated_cols,
-            cols_with_excs=self.cols_with_excs,
-            row_count_stats=self.row_count_stats.insert_to_update(),
-            cascade_row_count_stats=self.cascade_row_count_stats.insert_to_update(),
-        )
-
-    def to_cascade(self) -> 'UpdateStatus':
-        """
-        Convert the update status to a cascade update status.
-        This is used when an operation cascades changes to other tables.
-        """
-        return UpdateStatus(
-            comment=self.comment,
-            updated_cols=self.updated_cols,
-            cols_with_excs=self.cols_with_excs,
-            row_count_stats=RowCountStats(),
-            cascade_row_count_stats=self.cascade_row_count_stats + self.row_count_stats,
-        )
-
-    def __add__(self, other: 'UpdateStatus') -> UpdateStatus:
-        """
-        Add the update status from two UpdateStatus objects together.
-        """
-        return UpdateStatus(
-            comment=self.comment,  # comments are not added together
-            updated_cols=list(dict.fromkeys(self.updated_cols + other.updated_cols)),
-            cols_with_excs=list(dict.fromkeys(self.cols_with_excs + other.cols_with_excs)),
-            row_count_stats=self.row_count_stats + other.row_count_stats,
-            cascade_row_count_stats=self.cascade_row_count_stats + other.cascade_row_count_stats,
-        )
-
-    @property
-    def insert_msg(self) -> str:
-        """Return a message describing the results of an insert operation."""
-        if self.num_excs == 0:
-            cols_with_excs_str = ''
-        else:
-            cols_with_excs_str = (
-                f' across {len(self.cols_with_excs)} column{"" if len(self.cols_with_excs) == 1 else "s"}'
-            )
-            cols_with_excs_str += f' ({", ".join(self.cols_with_excs)})'
-        msg = (
-            f'Inserted {self.num_rows} row{"" if self.num_rows == 1 else "s"} '
-            f'with {self.num_excs} error{"" if self.num_excs == 1 else "s"}{cols_with_excs_str}.'
-        )
-        return msg
-
-    @classmethod
-    def __cnt_str(cls, cnt: int, item: str) -> str:
-        assert cnt > 0
-        return f'{cnt} {item}{"" if cnt == 1 else "s"}'
-
-    def _repr_pretty_(self, p: 'RepresentationPrinter', cycle: bool) -> None:
-        messages = []
-        if self.row_count_stats.ins_rows > 0:
-            messages.append(f'{self.__cnt_str(self.row_count_stats.ins_rows, "row")} inserted')
-        if self.row_count_stats.del_rows > 0:
-            messages.append(f'{self.__cnt_str(self.row_count_stats.del_rows, "row")} deleted')
-        if self.row_count_stats.upd_rows > 0:
-            messages.append(f'{self.__cnt_str(self.row_count_stats.upd_rows, "row")} updated')
-        if self.num_computed_values > 0:
-            messages.append(f'{self.__cnt_str(self.num_computed_values, "value")} computed')
-        if self.row_count_stats.num_excs > 0:
-            messages.append(self.__cnt_str(self.row_count_stats.num_excs, 'exception'))
-        p.text(', '.join(messages) + '.' if len(messages) > 0 else 'No rows affected.')
 
 
 class MediaValidation(enum.Enum):

--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -171,14 +171,14 @@ class InsertableTable(Table):
         from pixeltable.catalog import Catalog
         from pixeltable.io.table_data_conduit import DFTableDataConduit
 
-        status = pxt.UpdateStatus()
         with Catalog.get().begin_xact(tbl=self._tbl_version_path, for_write=True, lock_mutable_tree=True):
             if isinstance(data_source, DFTableDataConduit):
-                status = self._tbl_version.get().insert(
+                status = pxt.UpdateStatus(comment='insert DataFrame')
+                status += self._tbl_version.get().insert(
                     rows=None, df=data_source.pxt_df, print_stats=print_stats, fail_on_exception=fail_on_exception
                 )
             else:
-                status = UpdateStatus()
+                status = pxt.UpdateStatus(comment='insert data_source')
                 for row_batch in data_source.valid_row_batch():
                     status += self._tbl_version.get().insert(
                         rows=row_batch, df=None, print_stats=print_stats, fail_on_exception=fail_on_exception

--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -10,11 +10,12 @@ from pixeltable import exceptions as excs, type_system as ts
 from pixeltable.env import Env
 from pixeltable.utils.filecache import FileCache
 
-from .globals import MediaValidation, UpdateStatus
+from .globals import MediaValidation
 from .table import Table
 from .table_version import TableVersion
 from .table_version_handle import TableVersionHandle
 from .table_version_path import TableVersionPath
+from .update_status import UpdateStatus
 
 if TYPE_CHECKING:
     from pixeltable import exprs

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -29,13 +29,13 @@ from .globals import (
     IfExistsParam,
     IfNotExistsParam,
     MediaValidation,
-    UpdateStatus,
     is_system_column_name,
     is_valid_identifier,
 )
 from .schema_object import SchemaObject
 from .table_version_handle import TableVersionHandle
 from .table_version_path import TableVersionPath
+from .update_status import UpdateStatus
 
 if TYPE_CHECKING:
     import torch.utils.data

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -29,14 +29,8 @@ if TYPE_CHECKING:
 
 from ..func.globals import resolve_symbol
 from .column import Column
-from .globals import (
-    _POS_COLUMN_NAME,
-    _ROWID_COLUMN_NAME,
-    MediaValidation,
-    RowCountStats,
-    UpdateStatus,
-    is_valid_identifier,
-)
+from .globals import _POS_COLUMN_NAME, _ROWID_COLUMN_NAME, MediaValidation, is_valid_identifier
+from .update_status import RowCountStats, UpdateStatus
 
 if TYPE_CHECKING:
     from pixeltable import exec, store

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -782,6 +782,7 @@ class TableVersion:
             upd_rows=row_count, num_excs=num_excs, computed_values=computed_values
         )  # add_columns
         return UpdateStatus(
+            comment='add columns',
             cols_with_excs=[f'{col.tbl.name}.{col.name}' for col in cols_with_excs if col.name is not None],
             row_count_stats=row_counts,
         )
@@ -1108,11 +1109,12 @@ class TableVersion:
         cascade: bool,
         show_progress: bool = True,
     ) -> UpdateStatus:
+        result = UpdateStatus(comment='update')
         if plan is not None:
             # we're creating a new version
             self.version += 1
             cols_with_excs, status = self.store_tbl.insert_rows(plan, v_min=self.version, show_progress=show_progress)
-            result = status.insert_to_update()
+            result += status.insert_to_update()
             result += UpdateStatus(
                 cols_with_excs=[f'{self.name}.{self.cols_by_id[cid].name}' for cid in cols_with_excs]
             )
@@ -1187,7 +1189,7 @@ class TableVersion:
             self.version + 1, base_versions=base_versions, match_on_vmin=False, where_clause=sql_where_clause
         )
         row_counts = RowCountStats(del_rows=del_rows)  # delete
-        result = UpdateStatus(row_count_stats=row_counts)
+        result = UpdateStatus(comment='delete', row_count_stats=row_counts)
         if del_rows > 0:
             # we're creating a new version
             self.version += 1

--- a/pixeltable/catalog/update_status.py
+++ b/pixeltable/catalog/update_status.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from IPython.lib.pretty import RepresentationPrinter
+
+
+@dataclass(frozen=True)
+class RowCountStats:
+    """
+    Statistics about the counts of rows affected by a table operation.
+    """
+
+    ins_rows: int = 0  # rows inserted
+    del_rows: int = 0  # rows deleted
+    upd_rows: int = 0  # rows updated
+    num_excs: int = 0  # total number of exceptions
+    # TODO: disambiguate what this means: # of slots computed or # of columns computed?
+    computed_values: int = 0  # number of computed values (e.g., computed columns) affected by the operation
+
+    @property
+    def num_rows(self) -> int:
+        return self.ins_rows + self.del_rows + self.upd_rows
+
+    def insert_to_update(self) -> 'RowCountStats':
+        """
+        Convert insert row count stats to update row count stats.
+        This is used when an insert operation is treated as an update.
+        """
+        return RowCountStats(
+            ins_rows=0,
+            del_rows=self.del_rows,
+            upd_rows=self.upd_rows + self.ins_rows,
+            num_excs=self.num_excs,
+            computed_values=self.computed_values,
+        )
+
+    def __add__(self, other: 'RowCountStats') -> 'RowCountStats':
+        """
+        Add the stats from two RowCountStats objects together.
+        """
+        return RowCountStats(
+            ins_rows=self.ins_rows + other.ins_rows,
+            del_rows=self.del_rows + other.del_rows,
+            upd_rows=self.upd_rows + other.upd_rows,
+            num_excs=self.num_excs + other.num_excs,
+            computed_values=self.computed_values + other.computed_values,
+        )
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    """
+    Information about changes to table data or table schema
+    """
+
+    comment: str = ''  # Note about this operation
+
+    updated_cols: list[str] = field(default_factory=list)
+    cols_with_excs: list[str] = field(default_factory=list)
+
+    # stats for the rows affected by the operation
+    row_count_stats: RowCountStats = field(default_factory=RowCountStats)
+
+    # stats for changes cascaded to other tables
+    cascade_row_count_stats: RowCountStats = field(default_factory=RowCountStats)
+
+    @property
+    def num_rows(self) -> int:
+        return self.row_count_stats.num_rows + self.cascade_row_count_stats.num_rows
+
+    @property
+    def num_excs(self) -> int:
+        return self.row_count_stats.num_excs + self.cascade_row_count_stats.num_excs
+
+    @property
+    def num_computed_values(self) -> int:
+        return self.row_count_stats.computed_values + self.cascade_row_count_stats.computed_values
+
+    def insert_to_update(self) -> 'UpdateStatus':
+        """
+        Convert the update status from an insert operation to an update operation.
+        This is used when an insert operation is treated as an update.
+        """
+        return UpdateStatus(
+            comment=self.comment,
+            updated_cols=self.updated_cols,
+            cols_with_excs=self.cols_with_excs,
+            row_count_stats=self.row_count_stats.insert_to_update(),
+            cascade_row_count_stats=self.cascade_row_count_stats.insert_to_update(),
+        )
+
+    def to_cascade(self) -> 'UpdateStatus':
+        """
+        Convert the update status to a cascade update status.
+        This is used when an operation cascades changes to other tables.
+        """
+        return UpdateStatus(
+            comment=self.comment,
+            updated_cols=self.updated_cols,
+            cols_with_excs=self.cols_with_excs,
+            row_count_stats=RowCountStats(),
+            cascade_row_count_stats=self.cascade_row_count_stats + self.row_count_stats,
+        )
+
+    def __add__(self, other: 'UpdateStatus') -> UpdateStatus:
+        """
+        Add the update status from two UpdateStatus objects together.
+        """
+        return UpdateStatus(
+            comment=self.comment,  # comments are not added together
+            updated_cols=list(dict.fromkeys(self.updated_cols + other.updated_cols)),
+            cols_with_excs=list(dict.fromkeys(self.cols_with_excs + other.cols_with_excs)),
+            row_count_stats=self.row_count_stats + other.row_count_stats,
+            cascade_row_count_stats=self.cascade_row_count_stats + other.cascade_row_count_stats,
+        )
+
+    @property
+    def insert_msg(self) -> str:
+        """Return a message describing the results of an insert operation."""
+        if self.num_excs == 0:
+            cols_with_excs_str = ''
+        else:
+            cols_with_excs_str = (
+                f' across {len(self.cols_with_excs)} column{"" if len(self.cols_with_excs) == 1 else "s"}'
+            )
+            cols_with_excs_str += f' ({", ".join(self.cols_with_excs)})'
+        msg = (
+            f'Inserted {self.num_rows} row{"" if self.num_rows == 1 else "s"} '
+            f'with {self.num_excs} error{"" if self.num_excs == 1 else "s"}{cols_with_excs_str}.'
+        )
+        return msg
+
+    @classmethod
+    def __cnt_str(cls, cnt: int, item: str) -> str:
+        assert cnt > 0
+        return f'{cnt} {item}{"" if cnt == 1 else "s"}'
+
+    def _repr_pretty_(self, p: 'RepresentationPrinter', cycle: bool) -> None:
+        messages = []
+        if self.row_count_stats.ins_rows > 0:
+            messages.append(f'{self.__cnt_str(self.row_count_stats.ins_rows, "row")} inserted')
+        if self.row_count_stats.del_rows > 0:
+            messages.append(f'{self.__cnt_str(self.row_count_stats.del_rows, "row")} deleted')
+        if self.row_count_stats.upd_rows > 0:
+            messages.append(f'{self.__cnt_str(self.row_count_stats.upd_rows, "row")} updated')
+        if self.num_computed_values > 0:
+            messages.append(f'{self.__cnt_str(self.num_computed_values, "value")} computed')
+        if self.row_count_stats.num_excs > 0:
+            messages.append(self.__cnt_str(self.row_count_stats.num_excs, 'exception'))
+        p.text(', '.join(messages) + '.' if len(messages) > 0 else 'No rows affected.')

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -17,11 +17,12 @@ if TYPE_CHECKING:
 
 
 from .column import Column
-from .globals import _POS_COLUMN_NAME, MediaValidation, UpdateStatus
+from .globals import _POS_COLUMN_NAME, MediaValidation
 from .table import Table
 from .table_version import TableVersion
 from .table_version_handle import TableVersionHandle
 from .table_version_path import TableVersionPath
+from .update_status import UpdateStatus
 
 if TYPE_CHECKING:
     from pixeltable.globals import TableDataSource

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -229,7 +229,9 @@ class View(Table):
 
             try:
                 plan, _ = Planner.create_view_load_plan(view._tbl_version_path)
-                _, status = tbl_version.store_tbl.insert_rows(plan, v_min=tbl_version.version)
+                _, row_counts = tbl_version.store_tbl.insert_rows(plan, v_min=tbl_version.version)
+                status = UpdateStatus(comment='view creation', row_count_stats=row_counts)
+
             except:
                 # we need to remove the orphaned TableVersion instance
                 del catalog.Catalog.get()._tbl_versions[tbl_version.id, tbl_version.effective_version]

--- a/pixeltable/dataframe.py
+++ b/pixeltable/dataframe.py
@@ -15,7 +15,7 @@ import sqlalchemy as sql
 
 from pixeltable import catalog, exceptions as excs, exec, exprs, plan, type_system as ts
 from pixeltable.catalog import Catalog, is_valid_identifier
-from pixeltable.catalog.globals import UpdateStatus
+from pixeltable.catalog.update_status import UpdateStatus
 from pixeltable.env import Env
 from pixeltable.plan import Planner, SampleClause
 from pixeltable.type_system import ColumnType

--- a/pixeltable/io/external_store.py
+++ b/pixeltable/io/external_store.py
@@ -10,7 +10,7 @@ import pixeltable.exceptions as excs
 import pixeltable.type_system as ts
 from pixeltable import Column, Table
 from pixeltable.catalog import ColumnHandle, TableVersion
-from pixeltable.catalog.globals import RowCountStats, UpdateStatus
+from pixeltable.catalog.update_status import RowCountStats, UpdateStatus
 
 _logger = logging.getLogger('pixeltable')
 

--- a/pixeltable/io/label_studio.py
+++ b/pixeltable/io/label_studio.py
@@ -14,7 +14,7 @@ from requests.exceptions import HTTPError
 import pixeltable.type_system as ts
 from pixeltable import Column, Table, env, exceptions as excs
 from pixeltable.catalog import ColumnHandle
-from pixeltable.catalog.globals import RowCountStats
+from pixeltable.catalog.update_status import RowCountStats
 from pixeltable.config import Config
 from pixeltable.exprs import ColumnRef, DataRow, Expr
 from pixeltable.io.external_store import Project, SyncStatus

--- a/pixeltable/store.py
+++ b/pixeltable/store.py
@@ -14,7 +14,7 @@ import sqlalchemy as sql
 from tqdm import TqdmWarning, tqdm
 
 from pixeltable import catalog, exceptions as excs
-from pixeltable.catalog import RowCountStats
+from pixeltable.catalog.update_status import RowCountStats
 from pixeltable.env import Env
 from pixeltable.exec import ExecNode
 from pixeltable.metadata import schema

--- a/pixeltable/store.py
+++ b/pixeltable/store.py
@@ -377,8 +377,7 @@ class StoreBase:
                 ins_rows=num_rows, num_excs=num_excs, computed_values=computed_values
             )  # insert (StoreBase)
 
-            return cols_with_excs, UpdateStatus(row_count_stats=row_counts)
-
+            return cols_with_excs, UpdateStatus('insert', row_count_stats=row_counts)
         finally:
             exec_plan.close()
 

--- a/pixeltable/store.py
+++ b/pixeltable/store.py
@@ -14,7 +14,7 @@ import sqlalchemy as sql
 from tqdm import TqdmWarning, tqdm
 
 from pixeltable import catalog, exceptions as excs
-from pixeltable.catalog import RowCountStats, UpdateStatus
+from pixeltable.catalog import RowCountStats
 from pixeltable.env import Env
 from pixeltable.exec import ExecNode
 from pixeltable.metadata import schema
@@ -309,7 +309,7 @@ class StoreBase:
         show_progress: bool = True,
         rowids: Optional[Iterator[int]] = None,
         abort_on_exc: bool = False,
-    ) -> tuple[set[int], UpdateStatus]:
+    ) -> tuple[set[int], RowCountStats]:
         """Insert rows into the store table and update the catalog table's md
         Returns:
             number of inserted rows, number of exceptions, set of column ids that have exceptions
@@ -373,11 +373,9 @@ class StoreBase:
             if progress_bar is not None:
                 progress_bar.close()
             computed_values = exec_plan.ctx.num_computed_exprs * num_rows
-            row_counts = RowCountStats(
-                ins_rows=num_rows, num_excs=num_excs, computed_values=computed_values
-            )  # insert (StoreBase)
+            row_counts = RowCountStats(ins_rows=num_rows, num_excs=num_excs, computed_values=computed_values)
 
-            return cols_with_excs, UpdateStatus('insert', row_count_stats=row_counts)
+            return cols_with_excs, row_counts
         finally:
             exec_plan.close()
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -26,36 +26,60 @@ class TestHistory:
             primary_key=['c1'],
         )
         s = t.insert([{'c1': 0, 'c2': 'c'}])
-        self.pr_us(s, 'i')
+        self.pr_us(s, 'i1')
+        r = t.history()
+        print(r)
+        assert s.num_rows == 1  # 1 row inserted
+        assert s.num_computed_values == 1  # 1 computed value: str_filter(c2)
+
         s = t.add_computed_column(c3=t.c1 + 10)
-        self.pr_us(s, 'acc')
+        self.pr_us(s, 'acc1')
         s = t.add_computed_column(c4=t.c2.upper())
-        self.pr_us(s, 'acc')
+        self.pr_us(s, 'acc2')
         v = pxt.create_view('view_of_test', t, comment='view of test table')
         r = v.history()
         print(r)
         assert len(r) == 1
         s = t.add_computed_column(c5=t.c1 + 20)
-        self.pr_us(s, 'acc')
+        self.pr_us(s, 'acc3')
         s = t.add_columns({'c6': pxt.String, 'c7': pxt.Int, 'c8': pxt.Float})
-        self.pr_us(s, 'ac')
+        self.pr_us(s, 'ac1')
         s = t.insert(
             [
                 {'c1': 3, 'c2': 'c', 'c6': 'yyy', 'c7': 100, 'c8': 1.0},
                 {'c1': 4, 'c2': 'd', 'c6': 'xxx', 'c7': 200, 'c8': 2.0},
             ]
         )
-        self.pr_us(s, 'i1')
+        self.pr_us(s, 'i2 - insert 2 rows into table')
+        assert s.num_rows == 4  # inserted: 2 rows table, 2 rows view
+        # 6 -- [str_filter(c6), c2.upper(), c1 + 20, c1 + 10, str_filter(c2), str_filter(c2.upper())]
+        assert s.num_computed_values == 2 * 6
+
         s = t.insert([{'c1': 5, 'c2': 'e'}, {'c1': 6, 'c2': 'e'}])
-        self.pr_us(s, 'i')
+        self.pr_us(s, 'i3')
+
         s = v.add_computed_column(v1=v.c2 + '_view')
+        print(v.history())
         self.pr_us(s, 'vacc')
+        assert s.num_rows == 7
+        assert s.num_computed_values == 0  # 7 * 2 computed values: c2 + '_view', str_filter(v1)
+
+        s = v.recompute_columns('v1')
+        print(v.history())
+        self.pr_us(s, 'vrc1')
+        assert s.num_rows == 7
+        assert s.num_computed_values == 0  # 7 * 2 missing the str_filter() recompute v1, str_filter(v1)
+
         s = t.insert([{'c1': 7, 'c2': 'a'}, {'c1': 8, 'c2': 'b'}])
-        self.pr_us(s, 'i2')
+        self.pr_us(s, 'i4')
         s = t.delete((t.c1 >= 4) & (t.c1 <= 5))
         self.pr_us(s, 'd')
+
         s = t.batch_update([{'c1': 2, 'c2': 'xxx'}])
         self.pr_us(s, 'u')
+        assert s.num_rows == 1 + 1  # One in table, one in view
+        assert s.num_computed_values == 3  # 3 + 1 missing the str_filter() computation for the index column
+
         t.rename_column('c2', 'c2_renamed')
         t.drop_column('c4')
         r = t.history()
@@ -77,7 +101,7 @@ class TestHistory:
 
         r = v.history()
         print(r)
-        assert len(r) == 7
+        assert len(r) == 8
 
         s = pxt.create_snapshot('snapshot_of_test_view', t, comment='snapshot of view of test table')
         r = s.history()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ import pixeltable as pxt
 import pixeltable.type_system as ts
 import pixeltable.utils.s3 as s3_util
 from pixeltable import catalog, exceptions as excs
-from pixeltable.catalog.globals import UpdateStatus
+from pixeltable.catalog.update_status import UpdateStatus
 from pixeltable.dataframe import DataFrameResultSet
 from pixeltable.env import Env
 from pixeltable.io import SyncStatus


### PR DESCRIPTION
    Hoist UpdateStatus into its own file.
    Lower emission of counts from store_table.insert to RowCountStats.
    Add doc to test_history.
    Add comment field to UpdateStatus.
