### PR TITLE
Refactor create_replica to conform to concurrency protocol

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -824,8 +824,9 @@ class Catalog:
             # If it's a new version, this will result in a new TableVersion record being created.
             self.__store_replica_md(replica_path, ancestor_md)
 
-            # Now we must clear cached metadata for the ancestor table, so that if descendants have computed columns
-            # that reference the new version of the ancestor, then they will be properly resolved.
+            # Now we must clear cached metadata for the ancestor table, to force the next table operation to pick up
+            # the new TableVersion instance. This is necessary because computed columns of descendant tables might
+            # reference columns of the ancestor table that only exist in the new version.
             replica = Catalog.get().get_table_by_id(ancestor_id)
             assert replica is not None  # If it didn't exist before, it must have been created by now.
             replica._tbl_version_path.clear_cached_md()

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -768,7 +768,7 @@ class Catalog:
 
     @_retry_loop(for_write=True)
     def create_replica(
-        self, path: Path, md: list[schema.FullTableMd], if_exists: IfExistsParam = IfExistsParam.ERROR
+        self, path: Path, md: list[schema.FullTableMd]
     ) -> None:
         """
         Creates table, table_version, and table_schema_version records for a replica with the given metadata.
@@ -780,18 +780,17 @@ class Catalog:
         """
         tbl_id = UUID(md[0].tbl_md.tbl_id)
 
-        # First handle path collisions (if_exists='ignore' or 'replace' or etc).
-        existing = self._handle_path_collision(path, Table, False, if_exists)  # type: ignore[type-abstract]
+        existing = self._handle_path_collision(path, Table, False, if_exists=IfExistsParam.IGNORE)  # type: ignore[type-abstract]
         if existing is not None and existing._id != tbl_id:
             raise excs.Error(
-                f"An attempt was made to create a replica table at {path!r} with if_exists='ignore', "
+                f"An attempt was made to create a replica table at {path!r}, "
                 'but a different table already exists at that location.'
             )
 
         # Ensure that the system directory exists.
         self._create_dir(Path('_system', allow_system_paths=True), if_exists=IfExistsParam.IGNORE, parents=False)
 
-        # Now check to see if this table already exists in the catalog.
+        # Now check to see if this table UUID already exists in the catalog.
         existing = Catalog.get().get_table_by_id(tbl_id)
         if existing is not None:
             existing_path = Path(existing._path(), allow_system_paths=True)
@@ -807,14 +806,11 @@ class Catalog:
                 # location.
                 self._move(existing_path, path)
 
-        # Now store the metadata for this replica; it could be a new version (in which case a new record
-        # will be created) or a known version (in which case the newly received metadata will be validated as
-        # identical).
-        self.__store_replica_md(path, md[0])
-
-        # Now store the metadata for this replica and all of its ancestors. If one or more proper ancestors
+        # Now store the metadata for this replica's proper ancestors. If one or more proper ancestors
         # do not yet exist in the store, they will be created as anonymous system tables.
-        for ancestor_md in md[1:]:
+        # We instantiate the ancestors starting with the base table and ending with the immediate parent of the
+        # table being replicated.
+        for ancestor_md in md[:0:-1]:
             ancestor_id = UUID(ancestor_md.tbl_md.tbl_id)
             replica = Catalog.get().get_table_by_id(ancestor_id)
             replica_path: Path
@@ -827,11 +823,21 @@ class Catalog:
                 # that was directly replicated by the user at some point). In either case, use the existing path.
                 replica_path = Path(replica._path(), allow_system_paths=True)
 
-            # Store the metadata; as before, it could be a new version or a known version.
+            # Store the metadata; it could be a new version (in which case a new record will be created), or a known
+            # version (in which case the newly received metadata will be validated as identical).
+            # If it's a new version, this will result in a new TableVersion record being created.
             self.__store_replica_md(replica_path, ancestor_md)
 
-        # don't create TableVersion instances at this point, they would be superseded by calls to TV.create_replica()
-        # in TableRestorer.restore()
+            # Now we must clear cached metadata for the ancestor table, so that if descendants have computed columns
+            # that reference the new version of the ancestor, then they will be properly resolved.
+            replica = Catalog.get().get_table_by_id(ancestor_id)
+            assert replica is not None  # If it didn't exist before, it must have been created by now.
+            replica._tbl_version_path.clear_cached_md()
+
+        # Finally, store the metadata for the table being replicated; as before, it could be a new version or a known
+        # version. If it's a new version, then a TableVersion record will be created, unless the table being replicated
+        # is a pure snapshot.
+        self.__store_replica_md(path, md[0])
 
     def __store_replica_md(self, path: Path, md: schema.FullTableMd) -> None:
         _logger.info(f'Creating replica table at {path!r} with ID: {md.tbl_md.tbl_id}')
@@ -914,6 +920,10 @@ class Catalog:
                 )
 
         self.store_tbl_md(UUID(tbl_id), None, new_tbl_md, new_version_md, new_schema_version_md)
+
+        if new_version_md is not None and not md.is_pure_snapshot:
+            # It's a new version of a table that has a physical store, so we need to create a TableVersion instance.
+            TableVersion.create_replica(md)
 
     @_retry_loop(for_write=False)
     def get_table(self, path: Path) -> Table:

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -766,9 +766,7 @@ class Catalog:
         self._tbls[view._id] = view
         return view
 
-    def create_replica(
-        self, path: Path, md: list[schema.FullTableMd]
-    ) -> None:
+    def create_replica(self, path: Path, md: list[schema.FullTableMd]) -> None:
         """
         Creates table, table_version, and table_schema_version records for a replica with the given metadata.
         The metadata should be presented in standard "ancestor order", with the table being replicated at
@@ -781,7 +779,7 @@ class Catalog:
         existing = self._handle_path_collision(path, Table, False, if_exists=IfExistsParam.IGNORE)  # type: ignore[type-abstract]
         if existing is not None and existing._id != tbl_id:
             raise excs.Error(
-                f"An attempt was made to create a replica table at {path!r}, "
+                f'An attempt was made to create a replica table at {path!r}, '
                 'but a different table already exists at that location.'
             )
 

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -766,7 +766,6 @@ class Catalog:
         self._tbls[view._id] = view
         return view
 
-    @_retry_loop(for_write=True)
     def create_replica(
         self, path: Path, md: list[schema.FullTableMd]
     ) -> None:
@@ -774,10 +773,9 @@ class Catalog:
         Creates table, table_version, and table_schema_version records for a replica with the given metadata.
         The metadata should be presented in standard "ancestor order", with the table being replicated at
         list position 0 and the (root) base table at list position -1.
-
-        TODO: create_replica() also needs to create the store tables and populate them in order to make
-        replica creation atomic.
         """
+        assert Env.get().in_xact
+
         tbl_id = UUID(md[0].tbl_md.tbl_id)
 
         existing = self._handle_path_collision(path, Table, False, if_exists=IfExistsParam.IGNORE)  # type: ignore[type-abstract]

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -318,6 +318,7 @@ class TableVersion:
 
     @classmethod
     def create_replica(cls, md: schema.FullTableMd) -> TableVersion:
+        assert Env.get().in_xact
         tbl_id = UUID(md.tbl_md.tbl_id)
         _logger.info(f'Creating replica table version {tbl_id}:{md.version_md.version}.')
         view_md = md.tbl_md.view_md

--- a/pixeltable/metadata/schema.py
+++ b/pixeltable/metadata/schema.py
@@ -308,6 +308,14 @@ class FullTableMd(NamedTuple):
     version_md: TableVersionMd
     schema_version_md: TableSchemaVersionMd
 
+    @property
+    def is_pure_snapshot(self) -> bool:
+        return (
+            self.tbl_md.view_md is not None
+            and self.tbl_md.view_md.predicate is None
+            and len(self.schema_version_md.columns) == 0
+        )
+
     def as_dict(self) -> dict[str, Any]:
         return {
             'table_id': self.tbl_md.tbl_id,

--- a/pixeltable/share/packager.py
+++ b/pixeltable/share/packager.py
@@ -364,41 +364,22 @@ class TableRestorer:
         for md in tbl_md:
             md.tbl_md.is_replica = True
 
-        # Create the replica table
-        # The logic here needs to be completely restructured in order to make it concurrency-safe.
-        # - Catalog.create_replica() needs to write the metadata and also create the physical store tables
-        #   and populate them, otherwise concurrent readers will see an inconsistent state (table metadata w/o
-        #   an actual table)
-        # - this could be done one replica at a time (instead of the entire hierarchy)
         cat = catalog.Catalog.get()
-        cat.create_replica(catalog.Path(self.tbl_path), tbl_md)
-        # don't call get_table() until after the calls to create_replica() and __import_table() below;
-        # the TV instances created by get_table() would be replaced by create_replica(), which creates duplicate
-        # TV instances for the same replica version, which then leads to failures when constructing queries
 
-        # Now we need to instantiate and load data for replica_tbl and its ancestors, except that we skip
-        # replica_tbl itself if it's a pure snapshot.
-        target_md = tbl_md[0]
-        is_pure_snapshot = (
-            target_md.tbl_md.view_md is not None
-            and target_md.tbl_md.view_md.predicate is None
-            and len(target_md.schema_version_md.columns) == 0
-        )
-        if is_pure_snapshot:
-            ancestor_md = tbl_md[1:]  # Pure snapshot; skip replica_tbl
-        else:
-            ancestor_md = tbl_md  # Not a pure snapshot; include replica_tbl
-
-        # Instantiate data from the Parquet tables.
         with cat.begin_xact(for_write=True):
-            for md in ancestor_md[::-1]:  # Base table first
-                # Create a TableVersion instance (and a store table) for this ancestor.
-                tv = cat.get_tbl_version(UUID(md.tbl_md.tbl_id), md.version_md.version)
-                # Now import data from Parquet.
-                _logger.info(f'Importing table {tv.name!r}.')
-                self.__import_table(self.tmp_dir, tv, md)
+            # Create (or update) the replica table and its ancestors, along with TableVersion instances for any
+            # versions that have not been seen before.
+            cat.create_replica(catalog.Path(self.tbl_path), tbl_md)
 
-        with cat.begin_xact(for_write=False):
+            # Now we need to load data for replica_tbl and its ancestors, except that we skip
+            # replica_tbl itself if it's a pure snapshot.
+            for md in tbl_md[::-1]:  # Base table first
+                if not md.is_pure_snapshot:
+                    tv = cat.get_tbl_version(UUID(md.tbl_md.tbl_id), md.version_md.version)
+                    # Import data from Parquet.
+                    _logger.info(f'Importing table {tv.name!r}.')
+                    self.__import_table(self.tmp_dir, tv, md)
+
             return cat.get_table_by_id(UUID(tbl_md[0].tbl_md.tbl_id))
 
     def __import_table(self, bundle_path: Path, tv: catalog.TableVersion, tbl_md: schema.FullTableMd) -> None:

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -345,7 +345,8 @@ class TestPackager:
         self.__restore_and_check_table(bundle1, 'replica1')
         self.__restore_and_check_table(bundle2, 'replica2')
 
-    def test_multi_view_round_trip_4(self, all_datatypes_tbl: pxt.Table) -> None:
+    @pytest.mark.parametrize('different_tv', [False, True])
+    def test_multi_view_round_trip_4(self, different_tv: bool, all_datatypes_tbl: pxt.Table) -> None:
         """
         Snapshots that involve all the different column types.
         """
@@ -353,8 +354,9 @@ class TestPackager:
         snap1 = pxt.create_snapshot('snap1', t.where(t.row_id % 2 != 0))
         bundle1 = self.__package_table(snap1)
 
-        more_data = create_table_data(t, num_rows=22)
-        t.insert(more_data[11:])
+        if different_tv:
+            more_data = create_table_data(t, num_rows=22)
+            t.insert(more_data[11:])
 
         snap2 = pxt.create_snapshot('snap2', t.where(t.row_id % 3 != 0))
         bundle2 = self.__package_table(snap2)

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -345,16 +345,17 @@ class TestPackager:
         self.__restore_and_check_table(bundle1, 'replica1')
         self.__restore_and_check_table(bundle2, 'replica2')
 
-    @pytest.mark.parametrize('different_tv', [False, True])
-    def test_multi_view_round_trip_4(self, different_tv: bool, all_datatypes_tbl: pxt.Table) -> None:
+    @pytest.mark.parametrize('different_versions', [False, True])
+    def test_multi_view_round_trip_4(self, different_versions: bool, all_datatypes_tbl: pxt.Table) -> None:
         """
-        Snapshots that involve all the different column types.
+        Snapshots that involve all the different column types. Two snapshots of the same base table will be created;
+        they will snapshot either the same or different versions of the table, depending on `different_versions`.
         """
         t = all_datatypes_tbl
         snap1 = pxt.create_snapshot('snap1', t.where(t.row_id % 2 != 0))
         bundle1 = self.__package_table(snap1)
 
-        if different_tv:
+        if different_versions:
             more_data = create_table_data(t, num_rows=22)
             t.insert(more_data[11:])
 


### PR DESCRIPTION
Refactors Catalog.create_replica() to conform to the concurrency protocol:
- Instantiation of TableVersion instances is moved inside __store_tbl_md
- Transaction boundary is no longer localized to create_replica(), so that the data import can take place within the same transaction