### PR TITLE
Load replicas as views

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -575,10 +575,7 @@ class Catalog:
                 raise excs.Error(f'Path {drop_path!r} does not exist.')
             if drop_obj is not None and drop_expected is not None and not isinstance(drop_obj, drop_expected):
                 expected_name = 'table' if drop_expected is Table else 'directory'
-                raise excs.Error(
-                    f'{drop_path!r} needs to be a {expected_name} '
-                    f'but is a {drop_obj._display_name()}'
-                )
+                raise excs.Error(f'{drop_path!r} needs to be a {expected_name} but is a {drop_obj._display_name()}')
 
         add_dir_obj = Dir(add_dir.id, add_dir.parent_id, add_dir.md['name']) if add_dir is not None else None
         return add_obj, add_dir_obj, drop_obj
@@ -640,9 +637,7 @@ class Catalog:
         if path.is_root:
             # the root dir
             if expected is not None and expected is not Dir:
-                raise excs.Error(
-                    f'{path!r} needs to be a table but is a dir'
-                )
+                raise excs.Error(f'{path!r} needs to be a table but is a dir')
             dir = self._get_dir(path, lock_dir=lock_obj)
             if dir is None:
                 raise excs.Error(f'Unknown user: {Env.get().user}')
@@ -660,9 +655,7 @@ class Catalog:
             raise excs.Error(f'Path {path!r} is an existing {obj._display_name()}.')
         elif obj is not None and expected is not None and not isinstance(obj, expected):
             expected_name = 'table' if expected is Table else 'directory'
-            raise excs.Error(
-                f'{path!r} needs to be a {expected_name} but is a {obj._display_name()}.'
-            )
+            raise excs.Error(f'{path!r} needs to be a {expected_name} but is a {obj._display_name()}.')
         return obj
 
     def get_table_by_id(self, tbl_id: UUID) -> Optional[Table]:
@@ -1209,7 +1202,7 @@ class Catalog:
         row = conn.execute(q).one_or_none()
         if row is None:
             return None
-        tbl_record, schema_version_record = _unpack_row(row, [schema.Table, schema.TableSchemaVersion])
+        tbl_record, _ = _unpack_row(row, [schema.Table, schema.TableSchemaVersion])
 
         tbl_md = schema.md_from_dict(schema.TableMd, tbl_record.md)
         view_md = tbl_md.view_md
@@ -1223,12 +1216,13 @@ class Catalog:
 
         # this is a view; determine the sequence of TableVersions to load
         tbl_version_path: list[tuple[UUID, Optional[int]]] = []
-        schema_version_md = schema.md_from_dict(schema.TableSchemaVersionMd, schema_version_record.md)
         if tbl_md.is_pure_snapshot:
             # this is a pure snapshot, without a physical table backing it; we only need the bases
             pass
         else:
-            effective_version = 0 if view_md is not None and view_md.is_snapshot else None  # snapshots only have version 0
+            effective_version = (
+                0 if view_md is not None and view_md.is_snapshot else None
+            )  # snapshots only have version 0
             tbl_version_path.append((tbl_id, effective_version))
         if view_md is not None:
             tbl_version_path.extend((UUID(tbl_id), version) for tbl_id, version in view_md.base_versions)
@@ -1575,8 +1569,7 @@ class Catalog:
                 else:
                     raise AssertionError()
                 raise excs.Error(
-                    f'Path {path!r} already exists but is not a {obj_type_str}. '
-                    f'Cannot {if_exists.name.lower()} it.'
+                    f'Path {path!r} already exists but is not a {obj_type_str}. Cannot {if_exists.name.lower()} it.'
                 )
 
         if obj is None:

--- a/pixeltable/catalog/dir.py
+++ b/pixeltable/catalog/dir.py
@@ -34,8 +34,7 @@ class Dir(SchemaObject):
         dir = cls(dir_record.id, parent_id, name)
         return dir
 
-    @classmethod
-    def _display_name(cls) -> str:
+    def _display_name(self) -> str:
         return 'directory'
 
     def _path(self) -> str:

--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -54,8 +54,8 @@ class InsertableTable(Table):
         super().__init__(tbl_version.id, dir_id, tbl_version.get().name, tbl_version_path)
         self._tbl_version = tbl_version
 
-    @classmethod
-    def _display_name(cls) -> str:
+    def _display_name(self) -> str:
+        assert not self._tbl_version_path.is_replica()
         return 'table'
 
     @classmethod
@@ -75,10 +75,10 @@ class InsertableTable(Table):
         column_names = [col.name for col in columns]
         for pk_col in primary_key:
             if pk_col not in column_names:
-                raise excs.Error(f'Primary key column {pk_col} not found in table schema')
+                raise excs.Error(f'Primary key column {pk_col!r} not found in table schema.')
             col = columns[column_names.index(pk_col)]
             if col.col_type.nullable:
-                raise excs.Error(f'Primary key column {pk_col} cannot be nullable')
+                raise excs.Error(f'Primary key column {pk_col!r} cannot be nullable.')
             col.is_pk = True
 
         _, tbl_version = TableVersion.create(
@@ -101,8 +101,8 @@ class InsertableTable(Table):
             tbl_version.insert(None, df, fail_on_exception=True)
         session.commit()
 
-        _logger.info(f'Created table `{name}`, id={tbl_version.id}')
-        Env.get().console_logger.info(f'Created table `{name}`.')
+        _logger.info(f'Created table {name!r}, id={tbl_version.id}')
+        Env.get().console_logger.info(f'Created table {name!r}.')
         return tbl
 
     def _get_metadata(self) -> dict[str, Any]:
@@ -204,9 +204,9 @@ class InsertableTable(Table):
 
             for col_name, val in row.items():
                 if col_name not in valid_col_names:
-                    raise excs.Error(f'Unknown column name {col_name} in row {row}')
+                    raise excs.Error(f'Unknown column name {col_name!r} in row {row}')
                 if col_name in computed_col_names:
-                    raise excs.Error(f'Value for computed column {col_name} in row {row}')
+                    raise excs.Error(f'Value for computed column {col_name!r} in row {row}')
 
                 # validate data
                 col = self._tbl_version_path.get_column(col_name)
@@ -246,4 +246,4 @@ class InsertableTable(Table):
         return []
 
     def _table_descriptor(self) -> str:
-        return f'Table {self._path()!r}'
+        return self._display_str()

--- a/pixeltable/catalog/schema_object.py
+++ b/pixeltable/catalog/schema_object.py
@@ -50,13 +50,15 @@ class SchemaObject:
     def _get_metadata(self) -> dict[str, Any]:
         return {'name': self._name, 'path': self._path()}
 
-    @classmethod
     @abstractmethod
     def _display_name(cls) -> str:
         """
         Return name displayed in error messages.
         """
         pass
+
+    def _display_str(self) -> str:
+        return f'{self._display_name()} {self._path()!r}'
 
     def _move(self, new_name: str, new_dir_id: UUID) -> None:
         """Subclasses need to override this to make the change persistent"""

--- a/pixeltable/catalog/schema_object.py
+++ b/pixeltable/catalog/schema_object.py
@@ -51,7 +51,7 @@ class SchemaObject:
         return {'name': self._name, 'path': self._path()}
 
     @abstractmethod
-    def _display_name(cls) -> str:
+    def _display_name(self) -> str:
         """
         Return name displayed in error messages.
         """

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -1544,7 +1544,7 @@ class Table(SchemaObject):
         """
         from pixeltable.catalog import Catalog
 
-        if self._tbl_version_path.is_snapshot() or self._tbl_version_path.is_replica():
+        if not self._tbl_version_path.is_mutable():
             return
         with Catalog.get().begin_xact(tbl=self._tbl_version_path, for_write=True, lock_mutable_tree=False):
             all_stores = self.external_stores()
@@ -1584,7 +1584,7 @@ class Table(SchemaObject):
         """
         from pixeltable.catalog import Catalog
 
-        if self._tbl_version_path.is_snapshot() or self._tbl_version_path.is_replica():
+        if not self._tbl_version_path.is_mutable():
             return UpdateStatus()
         # we lock the entire tree starting at the root base table in order to ensure that all synced columns can
         # have their updates propagated down the tree

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -1443,7 +1443,7 @@ class Table(SchemaObject):
         cat = Catalog.get()
         # lock_mutable_tree=True: we need to be able to see whether any transitive view has column dependents
         with cat.begin_xact(tbl=self._tbl_version_path, for_write=True, lock_mutable_tree=True):
-            self.__check_mutable('recompute columns on')
+            self.__check_mutable('recompute columns of')
             if len(columns) == 0:
                 raise excs.Error('At least one column must be specified to recompute')
             if errors_only and len(columns) > 1:
@@ -1698,6 +1698,6 @@ class Table(SchemaObject):
 
     def __check_mutable(self, op_descr: str) -> None:
         if self._tbl_version_path.is_snapshot():
-            raise excs.Error(f'Cannot {op_descr} a snapshot: {self._path()}')
+            raise excs.Error(f'{self._display_str()}: Cannot {op_descr} a snapshot.')
         if self._tbl_version_path.is_replica():
-            raise excs.Error(f'Cannot {op_descr} a replica table: {self._path()}')
+            raise excs.Error(f'{self._display_str()}: Cannot {op_descr} a {self._display_name()}.')

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -664,6 +664,7 @@ class TableVersion:
     ) -> UpdateStatus:
         """Adds columns to the table."""
         assert not self.is_snapshot
+        assert not self.is_replica
         assert all(is_valid_identifier(col.name) for col in cols if col.name is not None)
         assert all(col.stored is not None for col in cols)
         assert all(col.name not in self.cols_by_name for col in cols if col.name is not None)

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -638,7 +638,7 @@ class TableVersion:
         return status
 
     def drop_index(self, idx_id: int) -> None:
-        assert not self.is_snapshot
+        assert self.is_mutable
         assert idx_id in self._tbl_md.index_md
 
         # we're creating a new schema version
@@ -663,8 +663,7 @@ class TableVersion:
         self, cols: Iterable[Column], print_stats: bool, on_error: Literal['abort', 'ignore']
     ) -> UpdateStatus:
         """Adds columns to the table."""
-        assert not self.is_snapshot
-        assert not self.is_replica
+        assert self.is_mutable
         assert all(is_valid_identifier(col.name) for col in cols if col.name is not None)
         assert all(col.stored is not None for col in cols)
         assert all(col.name not in self.cols_by_name for col in cols if col.name is not None)
@@ -802,7 +801,7 @@ class TableVersion:
     def drop_column(self, col: Column) -> None:
         """Drop a column from the table."""
 
-        assert not self.is_snapshot
+        assert self.is_mutable
 
         # we're creating a new schema version
         self.version += 1
@@ -831,7 +830,7 @@ class TableVersion:
 
     def _drop_columns(self, cols: Iterable[Column]) -> None:
         """Mark columns as dropped"""
-        assert not self.is_snapshot
+        assert self.is_mutable
 
         for col in cols:
             col.schema_version_drop = self.schema_version
@@ -854,7 +853,7 @@ class TableVersion:
 
     def rename_column(self, old_name: str, new_name: str) -> None:
         """Rename a column."""
-        assert not self.is_snapshot
+        assert self.is_mutable
         if old_name not in self.cols_by_name:
             raise excs.Error(f'Unknown column: {old_name}')
         if not is_valid_identifier(new_name):
@@ -973,8 +972,7 @@ class TableVersion:
             cascade: if True, also update all computed columns that transitively depend on the updated columns,
                 including within views.
         """
-        if self.is_snapshot:
-            raise excs.Error('Cannot update a snapshot')
+        assert self.is_mutable
 
         from pixeltable.plan import Planner
 
@@ -1088,7 +1086,7 @@ class TableVersion:
         return update_targets
 
     def recompute_columns(self, col_names: list[str], errors_only: bool = False, cascade: bool = True) -> UpdateStatus:
-        assert not self.is_snapshot
+        assert self.is_mutable
         assert all(name in self.cols_by_name for name in col_names)
         assert len(col_names) > 0
         assert len(col_names) == 1 or not errors_only
@@ -1224,7 +1222,7 @@ class TableVersion:
 
     def revert(self) -> None:
         """Reverts the table to the previous version."""
-        assert not self.is_snapshot
+        assert self.is_mutable
         if self.version == 0:
             raise excs.Error('Cannot revert version 0')
         self._revert()
@@ -1483,7 +1481,7 @@ class TableVersion:
     @property
     def is_insertable(self) -> bool:
         """Returns True if this corresponds to an InsertableTable"""
-        return not self.is_snapshot and not self.is_view
+        return self.is_mutable and not self.is_view
 
     def is_iterator_column(self, col: Column) -> bool:
         """Returns True if col is produced by an iterator"""

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -301,6 +301,8 @@ class View(Table):
         raise excs.Error(f'{self._display_name()} {self._name!r}: cannot delete from view')
 
     def _get_base_table(self) -> Optional['Table']:
+        if self._tbl_version_path.base is None:
+            return None  # this can happen for a replica of a base table
         # if this is a pure snapshot, our tbl_version_path only reflects the base (there is no TableVersion instance
         # for the snapshot itself)
         base_id = self._tbl_version_path.tbl_id if self._snapshot_only else self._tbl_version_path.base.tbl_id

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -55,7 +55,7 @@ class View(Table):
             assert self._tbl_version_path.is_replica()
             name = 'table'
         if self._tbl_version_path.is_replica():
-            name = f'replica-{name}'
+            name = f'{name}-replica'
         return name
 
     @classmethod

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -537,9 +537,12 @@ def list_tables(dir_path: str = '', recursive: bool = True) -> list[str]:
 
         >>> pxt.list_tables('dir1')
     """
-    path_obj = catalog.Path(dir_path, empty_is_valid=True)  # validate format
-    cat = Catalog.get()
-    contents = cat.get_dir_contents(path_obj, recursive=recursive)
+    return _list_tables(dir_path, recursive=recursive, allow_system_paths=False)
+
+
+def _list_tables(dir_path: str = '', recursive: bool = True, allow_system_paths: bool = False) -> list[catalog.Table]:
+    path_obj = catalog.Path(dir_path, empty_is_valid=True, allow_system_paths=allow_system_paths)
+    contents = Catalog.get().get_dir_contents(path_obj, recursive=recursive)
     return [str(p) for p in _extract_paths(contents, parent=path_obj, entry_type=catalog.Table)]
 
 

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -255,9 +255,7 @@ def create_view(
         tbl_version_path = base._tbl_version_path
         sample_clause = None
     elif isinstance(base, DataFrame):
-        base._validate_mutable('create_view', allow_select=True)
-        if len(base._from_clause.tbls) > 1:
-            raise excs.Error('Cannot create a view of a join')
+        base._validate_mutable_op_sequence('create_view', allow_select=True)
         tbl_version_path = base._from_clause.tbls[0]
         where = base.where_clause
         sample_clause = base.sample_clause
@@ -540,7 +538,7 @@ def list_tables(dir_path: str = '', recursive: bool = True) -> list[str]:
     return _list_tables(dir_path, recursive=recursive, allow_system_paths=False)
 
 
-def _list_tables(dir_path: str = '', recursive: bool = True, allow_system_paths: bool = False) -> list[catalog.Table]:
+def _list_tables(dir_path: str = '', recursive: bool = True, allow_system_paths: bool = False) -> list[str]:
     path_obj = catalog.Path(dir_path, empty_is_valid=True, allow_system_paths=allow_system_paths)
     contents = Catalog.get().get_dir_contents(path_obj, recursive=recursive)
     return [str(p) for p in _extract_paths(contents, parent=path_obj, entry_type=catalog.Table)]

--- a/pixeltable/metadata/schema.py
+++ b/pixeltable/metadata/schema.py
@@ -195,7 +195,12 @@ class TableMd:
 
     @property
     def is_pure_snapshot(self) -> bool:
-        return self.view_md is not None and self.view_md.is_snapshot and self.view_md.predicate is None and len(self.column_md) == 0
+        return (
+            self.view_md is not None
+            and self.view_md.is_snapshot
+            and self.view_md.predicate is None
+            and len(self.column_md) == 0
+        )
 
 
 class Table(Base):

--- a/pixeltable/metadata/schema.py
+++ b/pixeltable/metadata/schema.py
@@ -193,6 +193,10 @@ class TableMd:
     view_md: Optional[ViewMd]
     additional_md: dict[str, Any]
 
+    @property
+    def is_pure_snapshot(self) -> bool:
+        return self.view_md is not None and self.view_md.is_snapshot and self.view_md.predicate is None and len(self.column_md) == 0
+
 
 class Table(Base):
     """

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -516,3 +516,9 @@ class TestPackager:
                 s.recompute_columns('icol')
             with pytest.raises(pxt.Error, match=f'{display_str}: Cannot revert a {kind}.'):
                 s.revert()
+
+            # TODO: Align these DataFrame error messages with Table error messages
+            with pytest.raises(pxt.Error, match=r'Cannot use `update` on a replica.'):
+                s.where(s.icol < 5).update({'icol': 100})
+            with pytest.raises(pxt.Error, match=r'Cannot use `delete` on a replica.'):
+                s.where(s.icol < 5).delete()

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -481,8 +481,8 @@ class TestPackager:
         # Check that test_tbl was instantiated as a system table
         assert pxt.list_tables() == ['view_replica']
         system_path = pxt.catalog.Path('_system', allow_system_paths=True)
-        system_contents = pxt.catalog.Catalog.get().get_dir_contents(system_path)
-        assert len(system_contents) == 1 and next(iter(system_contents.keys())).startswith('replica_')
+        system_contents = pxt.globals._list_tables('_system', allow_system_paths=True)
+        assert len(system_contents) == 1 and system_contents[0].startswith('_system.replica_')
 
         self.__restore_and_check_table(t_bundle, 'tbl_replica')
         # Check that test_tbl has been renamed to a user table
@@ -492,7 +492,7 @@ class TestPackager:
         t = pxt.get_table('tbl_replica')
         v = pxt.get_table('view_replica')
 
-        for s, name, kind in ((t, 'tbl_replica', 'replica-table'), (v, 'view_replica', 'replica-view')):
+        for s, name, kind in ((t, 'tbl_replica', 'table-replica'), (v, 'view_replica', 'view-replica')):
             display_str = f'{kind} {name!r}'
             with pytest.raises(pxt.Error, match=f'{display_str}: Cannot insert into a {kind}.'):
                 s.insert({'icol': 10, 'scol': 'string 10'})

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -492,24 +492,27 @@ class TestPackager:
         t = pxt.get_table('tbl_replica')
         v = pxt.get_table('view_replica')
 
-        for s, name in ((t, 'tbl_replica'), (v, 'view_replica')):
-            with pytest.raises(pxt.Error, match='cannot insert into view'):
+        for s, name, kind in ((t, 'tbl_replica', 'replica-table'), (v, 'view_replica', 'replica-view')):
+            display_str = f'{kind} {name!r}'
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot insert into a {kind}.'):
                 s.insert({'icol': 10, 'scol': 'string 10'})
-            with pytest.raises(pxt.Error, match=f'Cannot add columns to a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot delete from a {kind}.'):
+                s.delete()
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot add columns to a {kind}.'):
                 s.add_column(new_col=pxt.Bool)
-            with pytest.raises(pxt.Error, match=f'Cannot add columns to a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot add columns to a {kind}.'):
                 s.add_columns({'new_col': pxt.Bool})
-            with pytest.raises(pxt.Error, match=f'Cannot add columns to a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot add columns to a {kind}.'):
                 s.add_computed_column(new_col=(t.icol + 1))
-            with pytest.raises(pxt.Error, match=f'Cannot drop columns from a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot drop columns from a {kind}.'):
                 s.drop_column('scol')
-            with pytest.raises(pxt.Error, match=f'Cannot add an index to a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot add an index to a {kind}.'):
                 s.add_embedding_index('icol', embedding=clip_embed)
-            with pytest.raises(pxt.Error, match=f'Cannot drop an index from a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot drop an index from a {kind}.'):
                 s.drop_embedding_index(column='icol')
-            with pytest.raises(pxt.Error, match=f'Cannot update a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot update a {kind}.'):
                 s.update({'icol': 11})
-            with pytest.raises(pxt.Error, match=f'Cannot recompute columns on a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot recompute columns of a {kind}.'):
                 s.recompute_columns('icol')
-            with pytest.raises(pxt.Error, match=f'Cannot revert a replica table: {name}'):
+            with pytest.raises(pxt.Error, match=f'{display_str}: Cannot revert a {kind}.'):
                 s.revert()

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -535,18 +535,18 @@ class TestDataFrame:
         # delete from view
         with pytest.raises(excs.Error) as exc_info:
             v2.where(t.c2 < 10).delete()
-        assert 'Cannot delete from view' in str(exc_info.value)
+        assert 'Cannot use `delete` on a view.' in str(exc_info.value)
 
         # update snapshot
         snap = pxt.create_snapshot('test_snapshot', t)
         with pytest.raises(excs.Error) as exc_info:
             snap.where(t.c2 < 10).update({'c3': 0.0})
-        assert 'Cannot update a snapshot' in str(exc_info.value)
+        assert 'Cannot use `update` on a snapshot.' in str(exc_info.value)
 
         # delete from snapshot
         with pytest.raises(excs.Error) as exc_info:
             snap.where(t.c2 < 10).delete()
-        assert 'Cannot delete from view' in str(exc_info.value)
+        assert 'Cannot use `delete` on a snapshot.' in str(exc_info.value)
 
     def __check_constant_query(self, df: pxt.DataFrame, v: Any) -> None:
         r = df.limit(5).collect()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -195,44 +195,34 @@ class TestSnapshot:
     def test_errors(self, reset_db: None, clip_embed: func.Function) -> None:
         tbl = create_test_tbl()
         snap = pxt.create_snapshot('snap', tbl)
+        display_str = "snapshot 'snap'"
 
-        with pytest.raises(pxt.Error) as excinfo:
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot insert into a snapshot.'):
             _ = snap.insert([{'c3': 1.0}])
-        assert 'cannot insert into view' in str(excinfo.value).lower()
 
-        with pytest.raises(pxt.Error) as excinfo:
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot insert into a snapshot.'):
             _ = snap.insert(c3=1.0)
-        assert 'cannot insert into view' in str(excinfo.value).lower()
 
         # adding column is not supported for snapshots
-        with pytest.raises(pxt.Error, match='Cannot add column to a snapshot'):
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot add columns to a snapshot.'):
             snap.add_column(non_existing_col1=pxt.String)
-        with pytest.raises(pxt.Error, match='Cannot add column to a snapshot'):
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot add columns to a snapshot.'):
             snap.add_computed_column(on_existing_col1=tbl.c2 + tbl.c3)
-        with pytest.raises(pxt.Error, match='Cannot add column to a snapshot'):
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot add columns to a snapshot.'):
             snap.add_columns({'non_existing_col1': pxt.String, 'non_existing_col2': pxt.String})
-
-        with pytest.raises(pxt.Error) as excinfo:
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot delete from a snapshot.'):
             _ = snap.delete()
-        assert 'cannot delete from view' in str(excinfo.value).lower()
-
-        with pytest.raises(pxt.Error) as excinfo:
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot update a snapshot.'):
             _ = snap.update({'c3': snap.c3 + 1.0})
-        assert 'cannot update a snapshot' in str(excinfo.value).lower()
-
-        with pytest.raises(pxt.Error) as excinfo:
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot update a snapshot.'):
             _ = snap.batch_update([{'c3': 1.0, 'c2': 1}])
-        assert 'cannot update a snapshot' in str(excinfo.value).lower()
-
-        with pytest.raises(pxt.Error) as excinfo:
+        with pytest.raises(pxt.Error, match=f'{display_str}: Cannot revert a snapshot.'):
             snap.revert()
-        assert 'cannot revert a snapshot' in str(excinfo.value).lower()
 
-        with pytest.raises(pxt.Error) as excinfo:
+        with pytest.raises(pxt.Error, match=f"snapshot 'img_snap': Cannot add an index to a snapshot."):
             img_tbl = create_img_tbl()
             snap = pxt.create_snapshot('img_snap', img_tbl)
             snap.add_embedding_index('img', image_embed=clip_embed)
-        assert 'cannot add an index to a snapshot' in str(excinfo.value).lower()
 
     def test_views_of_snapshots(self, reset_db: None) -> None:
         t = pxt.create_table('tbl', {'a': pxt.Int})

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -219,7 +219,7 @@ class TestSnapshot:
         with pytest.raises(pxt.Error, match=f'{display_str}: Cannot revert a snapshot.'):
             snap.revert()
 
-        with pytest.raises(pxt.Error, match=f"snapshot 'img_snap': Cannot add an index to a snapshot."):
+        with pytest.raises(pxt.Error, match=r"snapshot 'img_snap': Cannot add an index to a snapshot."):
             img_tbl = create_img_tbl()
             snap = pxt.create_snapshot('img_snap', img_tbl)
             snap.add_embedding_index('img', image_embed=clip_embed)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -751,15 +751,15 @@ class TestTable:
 
         with pytest.raises(excs.Error) as exc_info:
             pxt.create_table('test', {'c1': pxt.Required[pxt.String]}, primary_key='c2')
-        assert 'primary key column c2 not found' in str(exc_info.value).lower()
+        assert "primary key column 'c2' not found" in str(exc_info.value).lower()
 
         with pytest.raises(excs.Error) as exc_info:
             pxt.create_table('test', {'c1': pxt.Required[pxt.String]}, primary_key=['c1', 'c2'])
-        assert 'primary key column c2 not found' in str(exc_info.value).lower()
+        assert "primary key column 'c2' not found" in str(exc_info.value).lower()
 
         with pytest.raises(excs.Error) as exc_info:
             pxt.create_table('test', {'c1': pxt.Required[pxt.String]}, primary_key=['c2'])
-        assert 'primary key column c2 not found' in str(exc_info.value).lower()
+        assert "primary key column 'c2' not found" in str(exc_info.value).lower()
 
         with pytest.raises(excs.Error) as exc_info:
             pxt.create_table('test', {'c1': pxt.Required[pxt.String]}, primary_key=0)  # type: ignore[arg-type]
@@ -2156,10 +2156,10 @@ class TestTable:
         # drop_column is not allowed on a snapshot
         s1 = pxt.create_snapshot('s1', t, additional_columns={'s1': t.c3 + 1})
         assert 'c1' not in s1.columns()
-        with pytest.raises(excs.Error, match='Cannot drop column from a snapshot'):
+        with pytest.raises(excs.Error, match="snapshot 's1': Cannot drop columns from a snapshot."):
             s1.drop_column('c1')
         assert 's1' in s1.columns()
-        with pytest.raises(excs.Error, match='Cannot drop column from a snapshot'):
+        with pytest.raises(excs.Error, match="snapshot 's1': Cannot drop columns from a snapshot."):
             s1.drop_column('s1')
         assert 's1' in s1.columns()
 
@@ -2297,7 +2297,7 @@ class TestTable:
         # test case: view with additional columns
         r = repr(v2)
         assert strip_lines(r) == strip_lines(
-            """View 'test_subview' (of 'test_view', 'test_tbl')
+            """view 'test_subview' (of 'test_view', 'test_tbl')
             Where: ~(c1 == None)
 
             Column Name                          Type           Computed With
@@ -2326,7 +2326,7 @@ class TestTable:
         s1 = pxt.create_snapshot('test_snap1', v2)
         r = repr(s1)
         assert strip_lines(r) == strip_lines(
-            """Snapshot 'test_snap1' (of 'test_subview:3', 'test_view:0', 'test_tbl:2')
+            """snapshot 'test_snap1' (of 'test_subview:3', 'test_view:0', 'test_tbl:2')
             Where: ~(c1 == None)
 
             Column Name                          Type           Computed With
@@ -2351,7 +2351,7 @@ class TestTable:
         s2 = pxt.create_snapshot('test_snap2', test_tbl)
         r = repr(s2)
         assert strip_lines(r) == strip_lines(
-            """Snapshot 'test_snap2' (of 'test_tbl:2')
+            """snapshot 'test_snap2' (of 'test_tbl:2')
 
             Column Name                          Type           Computed With
                      c1              Required[String]
@@ -2369,7 +2369,7 @@ class TestTable:
         s3 = pxt.create_snapshot('test_snap3', test_tbl, additional_columns={'computed1': test_tbl.c2 + test_tbl.c3})
         r = repr(s3)
         assert strip_lines(r) == strip_lines(
-            """View 'test_snap3' (of 'test_tbl:2')
+            """snapshot 'test_snap3' (of 'test_tbl:2')
 
             Column Name                          Type           Computed With
               computed1               Required[Float]                 c2 + c3

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2156,10 +2156,10 @@ class TestTable:
         # drop_column is not allowed on a snapshot
         s1 = pxt.create_snapshot('s1', t, additional_columns={'s1': t.c3 + 1})
         assert 'c1' not in s1.columns()
-        with pytest.raises(excs.Error, match="snapshot 's1': Cannot drop columns from a snapshot."):
+        with pytest.raises(excs.Error, match=r"snapshot 's1': Cannot drop columns from a snapshot."):
             s1.drop_column('c1')
         assert 's1' in s1.columns()
-        with pytest.raises(excs.Error, match="snapshot 's1': Cannot drop columns from a snapshot."):
+        with pytest.raises(excs.Error, match=r"snapshot 's1': Cannot drop columns from a snapshot."):
             s1.drop_column('s1')
         assert 's1' in s1.columns()
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -53,11 +53,10 @@ class TestView:
         with pytest.raises(excs.Error, match=r"view 'test_view': Cannot delete from a view."):
             _ = v.delete()
 
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match=r'Cannot use `create_view` after `join`.'):
             u = pxt.create_table('joined_tbl', {'c1': pxt.String})
             join_df = t.join(u, on=t.c1 == u.c1)
             _ = pxt.create_view('join_view', join_df)
-        assert 'cannot create a view of a join' in str(exc_info.value).lower()
 
     def test_basic(self, reset_db: None) -> None:
         t = self.create_tbl()

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -46,15 +46,12 @@ class TestView:
     def test_errors(self, reset_db: None) -> None:
         t = self.create_tbl()
         v = pxt.create_view('test_view', t)
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match="view 'test_view': Cannot insert into a view."):
             _ = v.insert([{'bad_col': 1}])
-        assert 'cannot insert into view' in str(exc_info.value)
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match="view 'test_view': Cannot insert into a view."):
             _ = v.insert(bad_col=1)
-        assert 'cannot insert into view' in str(exc_info.value)
-        with pytest.raises(excs.Error) as exc_info:
+        with pytest.raises(excs.Error, match="view 'test_view': Cannot delete from a view."):
             _ = v.delete()
-        assert 'cannot delete from view' in str(exc_info.value)
 
         with pytest.raises(excs.Error) as exc_info:
             u = pxt.create_table('joined_tbl', {'c1': pxt.String})

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -46,11 +46,11 @@ class TestView:
     def test_errors(self, reset_db: None) -> None:
         t = self.create_tbl()
         v = pxt.create_view('test_view', t)
-        with pytest.raises(excs.Error, match="view 'test_view': Cannot insert into a view."):
+        with pytest.raises(excs.Error, match=r"view 'test_view': Cannot insert into a view."):
             _ = v.insert([{'bad_col': 1}])
-        with pytest.raises(excs.Error, match="view 'test_view': Cannot insert into a view."):
+        with pytest.raises(excs.Error, match=r"view 'test_view': Cannot insert into a view."):
             _ = v.insert(bad_col=1)
-        with pytest.raises(excs.Error, match="view 'test_view': Cannot delete from a view."):
+        with pytest.raises(excs.Error, match=r"view 'test_view': Cannot delete from a view."):
             _ = v.delete()
 
         with pytest.raises(excs.Error) as exc_info:


### PR DESCRIPTION
Ensures that all replicas are loaded as instances of `View` (regardless of the kind of the original table). Safeguards replicas against all mutable operations, regardless of their kind.

Also rewrites a bunch of error messages to make them clearer / more consistent.