### PR TITLE
CI changes for random-tbl-ops

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -88,6 +88,11 @@ jobs:
             python-version: "3.10"
             test-category: "lint"
             poetry-options: "--with dev"
+          # Random table ops
+          - os: ubuntu-22.04
+            python-version: "3.10"
+            test-category: "random-tbl-ops"
+            poetry-options: ""
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -178,6 +183,9 @@ jobs:
         run: |
           ./scripts/prepare-nb-tests.sh --no-pip docs/notebooks tests
           pytest -v -m '' --nbmake --nbmake-timeout=1800 target/nb-tests/*.ipynb
+      - name: Run random table ops
+        if: ${{ matrix.test-category == 'random-tbl-ops' }}
+        run: python tool/worker_harness.py 12 1800 tool/random_tbl_ops.py 2>&1 | tee random-tbl-ops-${{ matrix.os }}.log
       - name: Type check
         if: ${{ matrix.test-category == 'lint' }}
         run: mypy pixeltable tests tool

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -50,7 +50,7 @@ jobs:
         # Retry 3 times to be resilient against transient connectivity issues.
         run: ./scripts/retry.sh 3 60 poetry install
       - name: Run the stress tests
-        run: python tool/worker_harness.py 12 3600 tool/random_tbl_ops.py 2>&1 | tee random-tbl-ops.log
+        run: python tool/worker_harness.py 12 18000 tool/random_tbl_ops.py 2>&1 | tee random-tbl-ops.log
       - name: Check for errors
         run: |
           echo "Checking for errors."

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ help:
 	@echo ''
 	@echo 'Targets:'
 	@echo '  install       Install the development environment'
-	@echo '  test          Run pytest and check'
-	@echo '  fulltest      Run fullpytest, nbtest, and check'
+	@echo '  test          Run pytest, stresstest, and check'
+	@echo '  fulltest      Run fullpytest, nbtest, stresstest, and check'
 	@echo '  check		   Run typecheck, docscheck, lint, and formatcheck'
 	@echo '  format        Run `ruff format` (updates .py files in place)'
 	@echo '  release       Create a pypi release and post to github'
@@ -52,6 +52,7 @@ help:
 	@echo '  pytest        Run `pytest`'
 	@echo '  fullpytest    Run `pytest`, including expensive tests'
 	@echo '  nbtest        Run `pytest` on notebooks'
+	@echo '  stresstest    Run stress tests such as random-tbl-ops'
 	@echo '  typecheck     Run `mypy`'
 	@echo '  docscheck     Run `mkdocs build --strict`'
 	@echo '  lint          Run `ruff check`'
@@ -124,6 +125,10 @@ nbtest: install
 	@echo 'Running `pytest` on notebooks ...'
 	@$(SHELL_PREFIX) scripts/prepare-nb-tests.sh --no-pip docs/notebooks tests
 	@$(ULIMIT_CMD) pytest -v --nbmake --nbmake-timeout=$(NB_CELL_TIMEOUT) --nbmake-kernel=$(KERNEL_NAME) target/nb-tests/*.ipynb
+
+.PHONY: stresstest
+stresstest: install
+	@$(SHELL_PREFIX) scripts/stress-tests.sh
 
 .PHONY: typecheck
 typecheck: install

--- a/scripts/stress-tests.sh
+++ b/scripts/stress-tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$0")
+PXT_DIR=$(realpath "$SCRIPT_DIR/..")
+mkdir -p "$PXT_DIR"/target
+
+echo "Running random-tbl-ops (12 workers for 120 seconds) ..."
+LOG_FILE="$PXT_DIR"/target/random-tbl-ops.log
+python "$PXT_DIR"/tool/worker_harness.py 12 120 "$PXT_DIR"/tool/random_tbl_ops.py 2>&1 > "$LOG_FILE"
+
+IGNORE_ERRORS='That Pixeltable operation could not be completed|Table was dropped|Path.*does not exist'
+if [ -n "$(grep ERROR "$LOG_FILE" | grep -vE "$IGNORE_ERRORS")" ]; then
+    echo "Errors occurred during the stress test, such as:"
+    echo "$(grep ERROR "$LOG_FILE" | grep -vE "$IGNORE_ERRORS" | head -5)"
+    echo "See the logfile for more details: $LOG_FILE"
+    exit 1
+fi


### PR DESCRIPTION
- Add a CI job for random table ops for PRs & merge queue (30 minutes)
- Increase stress-test duration from 1 to 5 hours
- Also adds a `make stresstest` target