### PR TITLE
schema_overrides bugfixes

### DIFF
--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -158,9 +158,7 @@ def create_table(
         tds.check_source_format()
         data_source = tds.specialize()
         src_schema_overrides: dict[str, ts.ColumnType] = {}
-        if schema_overrides is None:
-            src_schema_overrides = {}
-        else:
+        if schema_overrides is not None:
             for col_name, py_type in schema_overrides.items():
                 col_type = ts.ColumnType.normalize_type(py_type, nullable_default=True, allow_builtin_types=False)
                 if col_type is None:

--- a/pixeltable/io/datarows.py
+++ b/pixeltable/io/datarows.py
@@ -20,7 +20,7 @@ def _infer_schema_from_rows(
                 # in which the column names are encountered in the input data, even if `schema_overrides`
                 # is specified.
                 if col_name not in schema:
-                    schema[col_name] = schema_overrides[col_name]
+                    schema[col_name] = ts.ColumnType.from_python_type(schema_overrides[col_name], nullable_default=True)
             elif value is not None:
                 # If `key` is not in `schema_overrides`, then we infer its type from the data.
                 # The column type will always be nullable by default.

--- a/pixeltable/io/datarows.py
+++ b/pixeltable/io/datarows.py
@@ -8,7 +8,7 @@ from pixeltable import exceptions as excs
 
 
 def _infer_schema_from_rows(
-    rows: Iterable[dict[str, Any]], schema_overrides: dict[str, Any], primary_key: list[str]
+    rows: Iterable[dict[str, Any]], schema_overrides: dict[str, ts.ColumnType], primary_key: list[str]
 ) -> dict[str, ts.ColumnType]:
     schema: dict[str, ts.ColumnType] = {}
     cols_with_nones: set[str] = set()
@@ -20,7 +20,8 @@ def _infer_schema_from_rows(
                 # in which the column names are encountered in the input data, even if `schema_overrides`
                 # is specified.
                 if col_name not in schema:
-                    schema[col_name] = ts.ColumnType.from_python_type(schema_overrides[col_name], nullable_default=True)
+                    assert isinstance(schema_overrides[col_name], ts.ColumnType)
+                    schema[col_name] = schema_overrides[col_name]
             elif value is not None:
                 # If `key` is not in `schema_overrides`, then we infer its type from the data.
                 # The column type will always be nullable by default.

--- a/pixeltable/io/pandas.py
+++ b/pixeltable/io/pandas.py
@@ -132,7 +132,8 @@ def df_infer_schema(
     pd_schema: dict[str, ts.ColumnType] = {}
     for pd_name, pd_dtype in zip(df.columns, df.dtypes):
         if pd_name in schema_overrides:
-            pxt_type = ts.ColumnType.from_python_type(schema_overrides[pd_name], nullable_default=True)
+            assert isinstance(schema_overrides[pd_name], ts.ColumnType)
+            pxt_type = schema_overrides[pd_name]
         else:
             pxt_type = __pd_coltype_to_pxt_type(pd_dtype, df[pd_name], pd_name not in primary_key)
         pd_schema[pd_name] = pxt_type

--- a/pixeltable/io/pandas.py
+++ b/pixeltable/io/pandas.py
@@ -132,7 +132,7 @@ def df_infer_schema(
     pd_schema: dict[str, ts.ColumnType] = {}
     for pd_name, pd_dtype in zip(df.columns, df.dtypes):
         if pd_name in schema_overrides:
-            pxt_type = schema_overrides[pd_name]
+            pxt_type = ts.ColumnType.from_python_type(schema_overrides[pd_name], nullable_default=True)
         else:
             pxt_type = __pd_coltype_to_pxt_type(pd_dtype, df[pd_name], pd_name not in primary_key)
         pd_schema[pd_name] = pxt_type

--- a/pixeltable/io/table_data_conduit.py
+++ b/pixeltable/io/table_data_conduit.py
@@ -47,7 +47,7 @@ class TableDataConduitFormat(str, enum.Enum):
 
 @dataclass
 class TableDataConduit:
-    source: TableDataSource
+    source: 'TableDataSource'
     source_format: Optional[str] = None
     source_column_map: Optional[dict[str, str]] = None
     if_row_exists: Literal['update', 'ignore', 'error'] = 'error'

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Optional
 
 import pytest
 

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -25,7 +25,7 @@ class TestImport:
             'children': ts.IntType(nullable=True),
         }
 
-        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': Optional[pxt.Float]})
+        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': pxt.Float})
         assert t2.count() == 4
         assert t2._get_schema() == {
             'name': ts.StringType(nullable=True),
@@ -73,7 +73,7 @@ class TestImport:
         t1.insert(data)
         assert t1.count() == 8
 
-        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': Optional[pxt.Float]})
+        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': pxt.Float})
         assert t2.count() == 4
         t2.insert(data)
         assert t2.count() == 8

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -24,7 +25,7 @@ class TestImport:
             'children': ts.IntType(nullable=True),
         }
 
-        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': ts.FloatType(nullable=True)})
+        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': Optional[pxt.Float]})
         assert t2.count() == 4
         assert t2._get_schema() == {
             'name': ts.StringType(nullable=True),
@@ -40,7 +41,7 @@ class TestImport:
         assert 'The following columns have no non-null values: only_none' in str(exc_info.value)
 
         with pytest.raises(excs.Error) as exc_info:
-            pxt.io.import_rows('example4', [{'col': 1}], schema_overrides={'not_col': ts.StringType()})
+            pxt.io.import_rows('example4', [{'col': 1}], schema_overrides={'not_col': pxt.String})
         assert 'Some column(s) specified in `schema_overrides` are not present in the source: not_col' in str(
             exc_info.value
         )
@@ -72,7 +73,7 @@ class TestImport:
         t1.insert(data)
         assert t1.count() == 8
 
-        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': ts.FloatType(nullable=True)})
+        t2 = pxt.io.import_rows('example2', data, schema_overrides={'children': Optional[pxt.Float]})
         assert t2.count() == 4
         t2.insert(data)
         assert t2.count() == 8

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -192,9 +192,7 @@ class TestPandas:
         from pixeltable.io.pandas import import_csv
 
         # Test overriding string type to images
-        t4 = import_csv(
-            'images', 'tests/data/datasets/images.csv', schema_overrides={'image': Optional[pxt.Image]}
-        )
+        t4 = import_csv('images', 'tests/data/datasets/images.csv', schema_overrides={'image': pxt.Image})
         assert t4.count() == 4
         assert t4._get_schema() == {'name': ts.StringType(nullable=True), 'image': ts.ImageType(nullable=True)}
         result_set = t4.order_by(t4.name).select(t4.image.width).collect()
@@ -245,9 +243,7 @@ class TestPandas:
 
         with pytest.raises(excs.Error) as exc_info:
             _ = import_csv(
-                'online_foods',
-                'tests/data/datasets/onlinefoods.csv',
-                schema_overrides={'Non-Column': ts.StringType(nullable=True)},
+                'online_foods', 'tests/data/datasets/onlinefoods.csv', schema_overrides={'Non-Column': pxt.String}
             )
         assert 'Some column(s) specified in `schema_overrides` are not present' in str(exc_info.value)
 

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 from zoneinfo import ZoneInfo
 
 import numpy as np
@@ -192,7 +193,7 @@ class TestPandas:
 
         # Test overriding string type to images
         t4 = import_csv(
-            'images', 'tests/data/datasets/images.csv', schema_overrides={'image': ts.ImageType(nullable=True)}
+            'images', 'tests/data/datasets/images.csv', schema_overrides={'image': Optional[pxt.Image]}
         )
         assert t4.count() == 4
         assert t4._get_schema() == {'name': ts.StringType(nullable=True), 'image': ts.ImageType(nullable=True)}

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Optional
 from zoneinfo import ZoneInfo
 
 import numpy as np

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -6,7 +6,6 @@ import pytest
 
 import pixeltable as pxt
 import pixeltable.functions as pxtf
-import pixeltable.type_system as ts
 from pixeltable import catalog, exceptions as excs
 
 from .utils import SAMPLE_IMAGE_URL, ReloadTester
@@ -16,9 +15,9 @@ class TestSample:
     @classmethod
     def create_sample_data(cls, row_mult: int, cat_count: int, with_null: bool) -> pxt.Table:
         schema = {
-            'id': ts.IntType(nullable=False),
-            'cat1': ts.IntType(nullable=with_null),
-            'cat2': ts.IntType(nullable=with_null),
+            'id': pxt.Required[pxt.Int],
+            'cat1': pxt.Int if with_null else pxt.Required[pxt.Int],
+            'cat2': pxt.Int if with_null else pxt.Required[pxt.Int],
         }
         rows = []
         rowid = 0


### PR DESCRIPTION
Fixes a bug in the schema_overrides parameter for data imports: schema_overrides was still expecting old-style ColumnType parameters (`pxt.FloatType(nullable=True)`) rather than new-style type parameters (`pxt.Float`); this fixes it so that `schema_overrides` semantics align with `schema`.

Also improves the documentation for `create_table()`.