### PR TITLE
Fix for "zero timestamp" issue in table versions

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1363,7 +1363,7 @@ class Catalog:
         If inserting `version_md` or `schema_version_md` would be a primary key violation, an exception will be raised.
         """
         assert self._in_write_xact
-        assert version_md.created_at > 0.0
+        assert version_md is None or version_md.created_at > 0.0
         session = Env.get().session
 
         # Construct and insert or update table record if requested.
@@ -1406,7 +1406,7 @@ class Catalog:
             session.add(schema_version_record)
         session.flush()  # Inform SQLAlchemy that we want to write these changes to the DB.
 
-    def update_tbl_version_md(self, version_md: Optional[schema.TableVersionMd]) -> None:
+    def update_tbl_version_md(self, version_md: schema.TableVersionMd) -> None:
         """
         Update the TableVersion.md field in the DB. Typically used to update the cascade row count status.
 

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -178,7 +178,9 @@ class TableVersion:
         """Create a snapshot copy of this TableVersion"""
         assert not self.is_snapshot
         base = self.path.base.tbl_version if self.is_view else None
-        return TableVersion(self.id, self.tbl_md, self.version, self.schema_version_md, mutable_views=[], base=base)
+        return TableVersion(
+            self.id, self.tbl_md, self.version, self.created_at, self.schema_version_md, mutable_views=[], base=base
+        )
 
     @property
     def versioned_name(self) -> str:
@@ -297,7 +299,9 @@ class TableVersion:
         effective_version = 0 if is_snapshot else None
         base_path = pxt.catalog.TableVersionPath.from_md(view_md.base_versions) if view_md is not None else None
         base = base_path.tbl_version if base_path is not None else None
-        tbl_version = cls(tbl_id, table_md, effective_version, timestamp, schema_version_md, [], base_path=base_path, base=base)
+        tbl_version = cls(
+            tbl_id, table_md, effective_version, timestamp, schema_version_md, [], base_path=base_path, base=base
+        )
         # TODO: break this up, so that Catalog.create_table() registers tbl_version
         cat._tbl_versions[tbl_id, effective_version] = tbl_version
         tbl_version.init()
@@ -334,7 +338,14 @@ class TableVersion:
         base_path = pxt.catalog.TableVersionPath.from_md(view_md.base_versions) if view_md is not None else None
         base = base_path.tbl_version if base_path is not None else None
         tbl_version = cls(
-            tbl_id, md.tbl_md, md.version_md.version, md.version_md.created_at, md.schema_version_md, [], base_path=base_path, base=base
+            tbl_id,
+            md.tbl_md,
+            md.version_md.version,
+            md.version_md.created_at,
+            md.schema_version_md,
+            [],
+            base_path=base_path,
+            base=base,
         )
         cat = pxt.catalog.Catalog.get()
         # We're creating a new TableVersion replica, so we should never have seen this particular

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -241,7 +241,7 @@ class View(Table):
                 plan, _ = Planner.create_view_load_plan(view._tbl_version_path)
                 _, row_counts = tbl_version.store_tbl.insert_rows(plan, v_min=tbl_version.version)
                 status = UpdateStatus(row_count_stats=row_counts)
-                tbl_version._write_md_update_status(0, update_status=status)
+                tbl_version._write_md_update_status(status)
 
             except:
                 # we need to remove the orphaned TableVersion instance


### PR DESCRIPTION
Fixes an issue where the created_at field in TableVersion metadata was inadvertently set to 0 after metadata was updated in response to UpdateStatus changes.

With this change, TableVersion keeps track of the original created_at timestamp and uses it to repopulate any md updates.