### PR TITLE
Time travel

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -453,6 +453,7 @@ class Catalog:
 
     def get_dir_path(self, dir_id: UUID) -> Path:
         """Return path for directory with given id"""
+        assert isinstance(dir_id, UUID)
         conn = Env.get().conn
         names: list[str] = []
         while True:
@@ -631,7 +632,7 @@ class Catalog:
         """Return the schema object at the given path, or None if it doesn't exist.
 
         Raises Error if
-        - the parent directory doesn't exist'
+        - the parent directory doesn't exist
         - raise_if_exists is True and the path exists
         - raise_if_not_exists is True and the path does not exist
         - expected is not None and the existing object has a different type
@@ -1275,7 +1276,7 @@ class Catalog:
             if (tbl_id, effective_version) not in self._tbl_versions:
                 _ = self._load_tbl_version(tbl_id, effective_version)
             tvp = TableVersionPath(TableVersionHandle(tbl_id, effective_version))
-            tbl = View(tbl_record.dir_id, TableVersionHandle(tbl_id, effective_version), tbl_md.name, tvp, snapshot_only=True)
+            tbl = View(tbl_id, tbl_record.dir_id, tbl_md.name, tvp, snapshot_only=True)
             return tbl
 
         assert False  # TODO: Views

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -581,7 +581,9 @@ class Catalog:
         add_dir_obj = Dir(add_dir.id, add_dir.parent_id, add_dir.md['name']) if add_dir is not None else None
         return add_obj, add_dir_obj, drop_obj
 
-    def _get_dir_entry(self, dir_id: UUID, name: str, version: Optional[int] = None, lock_entry: bool = False) -> Optional[SchemaObject]:
+    def _get_dir_entry(
+        self, dir_id: UUID, name: str, version: Optional[int] = None, lock_entry: bool = False
+    ) -> Optional[SchemaObject]:
         user = Env.get().user
         conn = Env.get().conn
 
@@ -1289,9 +1291,7 @@ class Catalog:
 
         tvp: Optional[TableVersionPath] = None
         for id, version in ancestors:
-            tvp = TableVersionPath(
-                TableVersionHandle(id, version), base=tvp
-            )
+            tvp = TableVersionPath(TableVersionHandle(id, version), base=tvp)
 
         tbl = View(tbl_id, tbl_record.dir_id, tbl_md.name, tvp, snapshot_only=True)
         return tbl

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1250,7 +1250,7 @@ class Catalog:
         from .view import View
 
         conn = Env.get().conn
-        q = (
+        q: sql.Executable = (
             sql.select(schema.Table, schema.TableVersion)
             .join(schema.TableVersion)
             .where(schema.Table.id == tbl_id)

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1420,7 +1420,7 @@ class Catalog:
         If inserting `version_md` or `schema_version_md` would be a primary key violation, an exception will be raised.
         """
         assert self._in_write_xact
-        assert version_md.created_at > 0.0
+        assert version_md is None or version_md.created_at > 0.0
         session = Env.get().session
 
         # Construct and insert or update table record if requested.

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -864,7 +864,6 @@ class Catalog:
     def _get_schema_object(
         self,
         path: Path,
-        version: Optional[int] = None,
         expected: Optional[type[SchemaObject]] = None,
         raise_if_exists: bool = False,
         raise_if_not_exists: bool = False,
@@ -894,7 +893,7 @@ class Catalog:
         parent_dir = self._get_dir(parent_path, lock_dir=lock_parent)
         if parent_dir is None:
             raise excs.Error(f'Directory {parent_path!r} does not exist.')
-        obj = self._get_dir_entry(parent_dir.id, path.name, version, lock_entry=lock_obj)
+        obj = self._get_dir_entry(parent_dir.id, path.name, path.version, lock_entry=lock_obj)
 
         if obj is None and raise_if_not_exists:
             raise excs.Error(f'Path {path!r} does not exist.')
@@ -1182,8 +1181,8 @@ class Catalog:
             TableVersion.create_replica(md)
 
     @retry_loop(for_write=False)
-    def get_table(self, path: Path, version: Optional[int]) -> Table:
-        obj = Catalog.get()._get_schema_object(path, version=version, expected=Table, raise_if_not_exists=True)
+    def get_table(self, path: Path) -> Table:
+        obj = Catalog.get()._get_schema_object(path, expected=Table, raise_if_not_exists=True)
         assert isinstance(obj, Table)
         # We need to clear cached metadata from tbl_version_path, in case the schema has been changed
         # by another process.

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -709,7 +709,7 @@ class Catalog:
                 break
             names.insert(0, dir.md['name'])
             dir_id = dir.parent_id
-        return Path('.'.join(names), empty_is_valid=True, allow_system_paths=True)
+        return Path.parse('.'.join(names), empty_is_valid=True, allow_system_paths=True)
 
     @dataclasses.dataclass
     class DirEntry:
@@ -1042,12 +1042,12 @@ class Catalog:
             )
 
         # Ensure that the system directory exists.
-        self._create_dir(Path('_system', allow_system_paths=True), if_exists=IfExistsParam.IGNORE, parents=False)
+        self._create_dir(Path.parse('_system', allow_system_paths=True), if_exists=IfExistsParam.IGNORE, parents=False)
 
         # Now check to see if this table already exists in the catalog.
         existing = self.get_table_by_id(tbl_id)
         if existing is not None:
-            existing_path = Path(existing._path(), allow_system_paths=True)
+            existing_path = Path.parse(existing._path(), allow_system_paths=True)
             if existing_path != path:
                 # It does exist, under a different path from the specified one.
                 if not existing_path.is_system_path:
@@ -1070,12 +1070,12 @@ class Catalog:
             replica_path: Path
             if replica is None:
                 # We've never seen this table before. Create a new anonymous system table for it.
-                replica_path = Path(f'_system.replica_{ancestor_id.hex}', allow_system_paths=True)
+                replica_path = Path.parse(f'_system.replica_{ancestor_id.hex}', allow_system_paths=True)
             else:
                 # The table already exists in the catalog. The existing path might be a system path (if the table
                 # was created as an anonymous base table of some other table), or it might not (if it's a snapshot
                 # that was directly replicated by the user at some point). In either case, use the existing path.
-                replica_path = Path(replica._path(), allow_system_paths=True)
+                replica_path = Path.parse(replica._path(), allow_system_paths=True)
 
             # Store the metadata; it could be a new version (in which case a new record will be created), or a known
             # version (in which case the newly received metadata will be validated as identical).

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -709,7 +709,7 @@ class Catalog:
                 break
             names.insert(0, dir.md['name'])
             dir_id = dir.parent_id
-        return Path.parse('.'.join(names), empty_is_valid=True, allow_system_paths=True)
+        return Path.parse('.'.join(names), allow_empty_path=True, allow_system_path=True)
 
     @dataclasses.dataclass
     class DirEntry:
@@ -1042,12 +1042,12 @@ class Catalog:
             )
 
         # Ensure that the system directory exists.
-        self._create_dir(Path.parse('_system', allow_system_paths=True), if_exists=IfExistsParam.IGNORE, parents=False)
+        self._create_dir(Path.parse('_system', allow_system_path=True), if_exists=IfExistsParam.IGNORE, parents=False)
 
         # Now check to see if this table already exists in the catalog.
         existing = self.get_table_by_id(tbl_id)
         if existing is not None:
-            existing_path = Path.parse(existing._path(), allow_system_paths=True)
+            existing_path = Path.parse(existing._path(), allow_system_path=True)
             if existing_path != path:
                 # It does exist, under a different path from the specified one.
                 if not existing_path.is_system_path:
@@ -1070,12 +1070,12 @@ class Catalog:
             replica_path: Path
             if replica is None:
                 # We've never seen this table before. Create a new anonymous system table for it.
-                replica_path = Path.parse(f'_system.replica_{ancestor_id.hex}', allow_system_paths=True)
+                replica_path = Path.parse(f'_system.replica_{ancestor_id.hex}', allow_system_path=True)
             else:
                 # The table already exists in the catalog. The existing path might be a system path (if the table
                 # was created as an anonymous base table of some other table), or it might not (if it's a snapshot
                 # that was directly replicated by the user at some point). In either case, use the existing path.
-                replica_path = Path.parse(replica._path(), allow_system_paths=True)
+                replica_path = Path.parse(replica._path(), allow_system_path=True)
 
             # Store the metadata; it could be a new version (in which case a new record will be created), or a known
             # version (in which case the newly received metadata will be validated as identical).

--- a/pixeltable/catalog/path.py
+++ b/pixeltable/catalog/path.py
@@ -1,20 +1,46 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterator
+from typing import Iterator, Optional
 
 from pixeltable import exceptions as excs
 
-from .globals import is_valid_path
+from .globals import is_valid_identifier
 
 _logger = logging.getLogger('pixeltable')
 
 
 class Path:
-    def __init__(self, path: str, empty_is_valid: bool = False, allow_system_paths: bool = False):
-        if not is_valid_path(path, empty_is_valid, allow_system_paths):
-            raise excs.Error(f"Invalid path format: '{path}'")
-        self.components = path.split('.')
+    components: list[str]
+    version: Optional[int]
+
+    def __init__(
+        self,
+        path: str,
+        empty_is_valid: bool = False,
+        allow_system_paths: bool = False,
+        allow_versioned_path: bool = False,
+    ):
+        if ':' in path:
+            parts = path.split(':')
+            if len(parts) != 2:
+                raise excs.Error(f'Invalid path: {path}')
+            try:
+                self.components = parts[0].split('.')
+                self.version = int(parts[1])
+            except ValueError:
+                raise excs.Error(f'Invalid path: {path}') from None
+        else:
+            self.components = path.split('.')
+            self.version = None
+
+        if (self.is_root and not empty_is_valid) or not (
+            self.is_root or all(is_valid_identifier(c, allow_system_paths) for c in self.components)
+        ):
+            raise excs.Error(f'Invalid path: {path}')
+
+        if not allow_versioned_path and self.version is not None:
+            raise excs.Error(f'Versioned path not allowed here: {path}')
 
     @property
     def len(self) -> int:
@@ -32,6 +58,10 @@ class Path:
     @property
     def is_system_path(self) -> bool:
         return self.components[0].startswith('_')
+
+    @property
+    def is_versioned(self) -> bool:
+        return self.version is not None
 
     @property
     def parent(self) -> Path:
@@ -68,14 +98,18 @@ class Path:
         if self.is_root:
             return
         else:
-            for i in range(0, len(self.components)):
+            for i in range(len(self.components)):
                 yield Path('.'.join(self.components[0:i]), empty_is_valid=True)
 
     def __repr__(self) -> str:
         return repr(str(self))
 
     def __str__(self) -> str:
-        return '.'.join(self.components)
+        base_path = '.'.join(self.components)
+        if self.version is not None:
+            return f'{base_path}:{self.version}'
+        else:
+            return base_path
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Path) and str(self) == str(other)

--- a/pixeltable/catalog/schema_object.py
+++ b/pixeltable/catalog/schema_object.py
@@ -18,6 +18,7 @@ class SchemaObject:
 
     def __init__(self, obj_id: UUID, name: str, dir_id: Optional[UUID]):
         # make these private so they don't collide with column names (id and name are fairly common)
+        assert dir_id is None or isinstance(dir_id, UUID), type(dir_id)
         self._id = obj_id
         self._name = name
         self._dir_id = dir_id

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -89,6 +89,8 @@ class Table(SchemaObject):
 
                 ```python
                 {
+                    'name': 'my_table',
+                    'path': 'my_dir.my_subdir.my_table',
                     'base': None,  # If this is a view or snapshot, will contain the name of its base table
                     'schema': {
                         'col1': StringType(),
@@ -96,6 +98,7 @@ class Table(SchemaObject):
                     },
                     'is_replica': False,
                     'version': 22,
+                    'version_created': datetime.datetime(...),
                     'schema_version': 1,
                     'comment': '',
                     'num_retained_versions': 10,

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -112,6 +112,9 @@ class Table(SchemaObject):
         md['schema'] = self._get_schema()
         md['is_replica'] = self._tbl_version_path.is_replica()
         md['version'] = self._get_version()
+        md['version_created'] = datetime.datetime.fromtimestamp(
+            self._tbl_version_path.tbl_version.get().created_at, tz=datetime.timezone.utc
+        )
         md['schema_version'] = self._tbl_version_path.schema_version()
         md['comment'] = self._get_comment()
         md['num_retained_versions'] = self._get_num_retained_versions()

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -178,7 +178,9 @@ class TableVersion:
         """Create a snapshot copy of this TableVersion"""
         assert not self.is_snapshot
         base = self.path.base.tbl_version if self.is_view else None
-        return TableVersion(self.id, self.tbl_md, self.version, self.schema_version_md, mutable_views=[], base=base)
+        return TableVersion(
+            self.id, self.tbl_md, self.version, self.created_at, self.schema_version_md, mutable_views=[], base=base
+        )
 
     @property
     def versioned_name(self) -> str:

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -297,7 +297,9 @@ class TableVersion:
         effective_version = 0 if is_snapshot else None
         base_path = pxt.catalog.TableVersionPath.from_md(view_md.base_versions) if view_md is not None else None
         base = base_path.tbl_version if base_path is not None else None
-        tbl_version = cls(tbl_id, table_md, effective_version, timestamp, schema_version_md, [], base_path=base_path, base=base)
+        tbl_version = cls(
+            tbl_id, table_md, effective_version, timestamp, schema_version_md, [], base_path=base_path, base=base
+        )
         # TODO: break this up, so that Catalog.create_table() registers tbl_version
         cat._tbl_versions[tbl_id, effective_version] = tbl_version
         tbl_version.init()
@@ -334,7 +336,14 @@ class TableVersion:
         base_path = pxt.catalog.TableVersionPath.from_md(view_md.base_versions) if view_md is not None else None
         base = base_path.tbl_version if base_path is not None else None
         tbl_version = cls(
-            tbl_id, md.tbl_md, md.version_md.version, md.version_md.created_at, md.schema_version_md, [], base_path=base_path, base=base
+            tbl_id,
+            md.tbl_md,
+            md.version_md.version,
+            md.version_md.created_at,
+            md.schema_version_md,
+            [],
+            base_path=base_path,
+            base=base,
         )
         cat = pxt.catalog.Catalog.get()
         # We're creating a new TableVersion replica, so we should never have seen this particular

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -241,7 +241,7 @@ class View(Table):
                 plan, _ = Planner.create_view_load_plan(view._tbl_version_path)
                 _, row_counts = tbl_version.store_tbl.insert_rows(plan, v_min=tbl_version.version)
                 status = UpdateStatus(row_count_stats=row_counts)
-                tbl_version._write_md_update_status(0, update_status=status)
+                tbl_version._write_md_update_status(status)
 
             except:
                 # we need to remove the orphaned TableVersion instance

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -336,8 +336,8 @@ class View(Table):
     @property
     def _effective_base_versions(self) -> list[Optional[int]]:
         effective_versions = [tv.effective_version for tv in self._tbl_version_path.get_tbl_versions()]
-        if self._snapshot_only:
-            return effective_versions
+        if self._snapshot_only and not self._is_anonymous_snapshot():
+            return effective_versions  # Named pure snapshot
         else:
             return effective_versions[1:]
 

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -445,9 +445,24 @@ def get_table(path: str) -> catalog.Table:
         Handles to views and snapshots are retrieved in the same way:
 
         >>> tbl = pxt.get_table('my_snapshot')
+
+        Get a handle to a specific version of a table:
+
+        >>> tbl = pxt.get_table('my_table:722')
     """
-    path_obj = catalog.Path(path)
-    tbl = Catalog.get().get_table(path_obj)
+    version: Optional[int] = None
+    if ':' in path:
+        components = path.split(':')
+        if len(components) != 2:
+            raise excs.Error(f'Invalid path: {path}')
+        path_obj = catalog.Path(components[0])
+        try:
+            version = int(components[1])
+        except ValueError:
+            raise excs.Error(f'Invalid path: {path}')
+    else:
+        path_obj = catalog.Path(path)
+    tbl = Catalog.get().get_table(path_obj, version)
     return tbl
 
 

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -459,7 +459,7 @@ def get_table(path: str) -> catalog.Table:
         try:
             version = int(components[1])
         except ValueError:
-            raise excs.Error(f'Invalid path: {path}')
+            raise excs.Error(f'Invalid path: {path}') from None
     else:
         path_obj = catalog.Path(path)
     tbl = Catalog.get().get_table(path_obj, version)

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -561,7 +561,7 @@ def list_tables(dir_path: str = '', recursive: bool = True) -> list[str]:
 
 
 def _list_tables(dir_path: str = '', recursive: bool = True, allow_system_paths: bool = False) -> list[str]:
-    path_obj = catalog.Path.parse(dir_path, empty_is_valid=True, allow_system_paths=allow_system_paths)
+    path_obj = catalog.Path.parse(dir_path, allow_empty_path=True, allow_system_path=allow_system_paths)
     contents = Catalog.get().get_dir_contents(path_obj, recursive=recursive)
     return [str(p) for p in _extract_paths(contents, parent=path_obj, entry_type=catalog.Table)]
 
@@ -674,7 +674,7 @@ def ls(path: str = '') -> pd.DataFrame:
     from pixeltable.metadata import schema
 
     cat = Catalog.get()
-    path_obj = catalog.Path.parse(path, empty_is_valid=True)
+    path_obj = catalog.Path.parse(path, allow_empty_path=True)
     dir_entries = cat.get_dir_contents(path_obj)
 
     @retry_loop(for_write=False)
@@ -763,7 +763,7 @@ def list_dirs(path: str = '', recursive: bool = True) -> list[str]:
         >>> cl.list_dirs('my_dir', recursive=True)
         ['my_dir', 'my_dir.sub_dir1']
     """
-    path_obj = catalog.Path.parse(path, empty_is_valid=True)  # validate format
+    path_obj = catalog.Path.parse(path, allow_empty_path=True)  # validate format
     cat = Catalog.get()
     contents = cat.get_dir_contents(path_obj, recursive=recursive)
     return [str(p) for p in _extract_paths(contents, parent=path_obj, entry_type=catalog.Dir)]

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -450,19 +450,8 @@ def get_table(path: str) -> catalog.Table:
 
         >>> tbl = pxt.get_table('my_table:722')
     """
-    version: Optional[int] = None
-    if ':' in path:
-        components = path.split(':')
-        if len(components) != 2:
-            raise excs.Error(f'Invalid path: {path}')
-        path_obj = catalog.Path(components[0])
-        try:
-            version = int(components[1])
-        except ValueError:
-            raise excs.Error(f'Invalid path: {path}') from None
-    else:
-        path_obj = catalog.Path(path)
-    tbl = Catalog.get().get_table(path_obj, version)
+    path_obj = catalog.Path(path, allow_versioned_path=True)
+    tbl = Catalog.get().get_table(path_obj)
     return tbl
 
 

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -146,7 +146,7 @@ def create_table(
     if schema is not None and (len(schema) == 0 or not isinstance(schema, dict)):
         raise excs.Error('`schema` must be a non-empty dictionary')
 
-    path_obj = catalog.Path(path)
+    path_obj = catalog.Path.parse(path)
     if_exists_ = catalog.IfExistsParam.validated(if_exists, 'if_exists')
     media_validation_ = catalog.MediaValidation.validated(media_validation, 'media_validation')
     primary_key: Optional[list[str]] = normalize_primary_key_parameter(primary_key)
@@ -284,7 +284,7 @@ def create_view(
         raise excs.Error('`base` must be an instance of `Table` or `DataFrame`')
     assert isinstance(base, (catalog.Table, DataFrame))
 
-    path_obj = catalog.Path(path)
+    path_obj = catalog.Path.parse(path)
     if_exists_ = catalog.IfExistsParam.validated(if_exists, 'if_exists')
     media_validation_ = catalog.MediaValidation.validated(media_validation, 'media_validation')
 
@@ -450,7 +450,7 @@ def get_table(path: str) -> catalog.Table:
 
         >>> tbl = pxt.get_table('my_table:722')
     """
-    path_obj = catalog.Path(path, allow_versioned_path=True)
+    path_obj = catalog.Path.parse(path, allow_versioned_path=True)
     tbl = Catalog.get().get_table(path_obj)
     return tbl
 
@@ -476,7 +476,7 @@ def move(path: str, new_path: str) -> None:
     """
     if path == new_path:
         raise excs.Error('move(): source and destination cannot be identical')
-    path_obj, new_path_obj = catalog.Path(path), catalog.Path(new_path)
+    path_obj, new_path_obj = catalog.Path.parse(path), catalog.Path.parse(new_path)
     if path_obj.is_ancestor(new_path_obj):
         raise excs.Error(f'move(): cannot move {path!r} into its own subdirectory')
     cat = Catalog.get()
@@ -529,7 +529,7 @@ def drop_table(
         assert isinstance(table, str)
         tbl_path = table
 
-    path_obj = catalog.Path(tbl_path)
+    path_obj = catalog.Path.parse(tbl_path)
     if_not_exists_ = catalog.IfNotExistsParam.validated(if_not_exists, 'if_not_exists')
     Catalog.get().drop_table(path_obj, force=force, if_not_exists=if_not_exists_)
 
@@ -561,7 +561,7 @@ def list_tables(dir_path: str = '', recursive: bool = True) -> list[str]:
 
 
 def _list_tables(dir_path: str = '', recursive: bool = True, allow_system_paths: bool = False) -> list[str]:
-    path_obj = catalog.Path(dir_path, empty_is_valid=True, allow_system_paths=allow_system_paths)
+    path_obj = catalog.Path.parse(dir_path, empty_is_valid=True, allow_system_paths=allow_system_paths)
     contents = Catalog.get().get_dir_contents(path_obj, recursive=recursive)
     return [str(p) for p in _extract_paths(contents, parent=path_obj, entry_type=catalog.Table)]
 
@@ -613,7 +613,7 @@ def create_dir(
 
         >>> pxt.create_dir('parent1.parent2.sub_dir', parents=True)
     """
-    path_obj = catalog.Path(path)
+    path_obj = catalog.Path.parse(path)
     if_exists_ = catalog.IfExistsParam.validated(if_exists, 'if_exists')
     return Catalog.get().create_dir(path_obj, if_exists=if_exists_, parents=parents)
 
@@ -655,7 +655,7 @@ def drop_dir(path: str, force: bool = False, if_not_exists: Literal['error', 'ig
 
         >>> pxt.drop_dir('my_dir', force=True)
     """
-    path_obj = catalog.Path(path)  # validate format
+    path_obj = catalog.Path.parse(path)  # validate format
     if_not_exists_ = catalog.IfNotExistsParam.validated(if_not_exists, 'if_not_exists')
     Catalog.get().drop_dir(path_obj, if_not_exists=if_not_exists_, force=force)
 
@@ -674,7 +674,7 @@ def ls(path: str = '') -> pd.DataFrame:
     from pixeltable.metadata import schema
 
     cat = Catalog.get()
-    path_obj = catalog.Path(path, empty_is_valid=True)
+    path_obj = catalog.Path.parse(path, empty_is_valid=True)
     dir_entries = cat.get_dir_contents(path_obj)
 
     @retry_loop(for_write=False)
@@ -763,7 +763,7 @@ def list_dirs(path: str = '', recursive: bool = True) -> list[str]:
         >>> cl.list_dirs('my_dir', recursive=True)
         ['my_dir', 'my_dir.sub_dir1']
     """
-    path_obj = catalog.Path(path, empty_is_valid=True)  # validate format
+    path_obj = catalog.Path.parse(path, empty_is_valid=True)  # validate format
     cat = Catalog.get()
     contents = cat.get_dir_contents(path_obj, recursive=recursive)
     return [str(p) for p in _extract_paths(contents, parent=path_obj, entry_type=catalog.Dir)]

--- a/pixeltable/share/packager.py
+++ b/pixeltable/share/packager.py
@@ -369,7 +369,7 @@ class TableRestorer:
         with cat.begin_xact(for_write=True):
             # Create (or update) the replica table and its ancestors, along with TableVersion instances for any
             # versions that have not been seen before.
-            cat.create_replica(catalog.Path(self.tbl_path), tbl_md)
+            cat.create_replica(catalog.Path.parse(self.tbl_path), tbl_md)
 
             # Now we need to load data for replica_tbl and its ancestors, except that we skip
             # replica_tbl itself if it's a pure snapshot.

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -480,14 +480,13 @@ class TestPackager:
         self.__restore_and_check_table(v_bundle, 'view_replica')
         # Check that test_tbl was instantiated as a system table
         assert pxt.list_tables() == ['view_replica']
-        system_path = pxt.catalog.Path('_system', allow_system_paths=True)
         system_contents = pxt.globals._list_tables('_system', allow_system_paths=True)
         assert len(system_contents) == 1 and system_contents[0].startswith('_system.replica_')
 
         self.__restore_and_check_table(t_bundle, 'tbl_replica')
         # Check that test_tbl has been renamed to a user table
         assert pxt.list_tables() == ['view_replica', 'tbl_replica']
-        assert len(pxt.catalog.Catalog.get().get_dir_contents(system_path)) == 0
+        assert len(pxt.globals._list_tables('_system', allow_system_paths=True)) == 0
 
         t = pxt.get_table('tbl_replica')
         v = pxt.get_table('view_replica')

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,9 +1,8 @@
 from textwrap import dedent
 
-import pytest
-
 import pixeltable as pxt
 from pixeltable.catalog import Path, is_valid_identifier, is_valid_path
+from pixeltable.catalog.path import ROOT_PATH
 from pixeltable.share.packager import TablePackager, TableRestorer
 from tests.conftest import clean_db
 from tests.utils import reload_catalog
@@ -39,25 +38,15 @@ class TestCatalog:
     def test_path_ancestors(self) -> None:
         # multiple ancestors in path
         path = Path.parse('a.b.c')
-        ancestors = path.ancestors()
-        assert str(next(ancestors)) == ''
-        assert str(next(ancestors)) == 'a'
-        assert str(next(ancestors)) == 'a.b'
-        with pytest.raises(StopIteration):
-            next(ancestors)
+        assert path.ancestors() == [ROOT_PATH, Path(['a']), Path(['a', 'b'])]
 
         # single element in path
         path = Path.parse('a')
-        ancestors = path.ancestors()
-        assert str(next(ancestors)) == ''
-        with pytest.raises(StopIteration):
-            next(ancestors)
+        assert path.ancestors() == [ROOT_PATH]
 
         # root
-        path = Path.parse('', empty_is_valid=True)
-        ancestors = path.ancestors()
-        with pytest.raises(StopIteration):
-            next(ancestors)
+        path = Path.parse('', allow_empty_path=True)
+        assert path.ancestors() == []
 
     def test_ls(self, reset_db: None) -> None:
         t = pxt.create_table('tbl_for_replica', {'a': pxt.Int})

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -38,7 +38,7 @@ class TestCatalog:
 
     def test_path_ancestors(self) -> None:
         # multiple ancestors in path
-        path = Path('a.b.c')
+        path = Path.parse('a.b.c')
         ancestors = path.ancestors()
         assert str(next(ancestors)) == ''
         assert str(next(ancestors)) == 'a'
@@ -47,14 +47,14 @@ class TestCatalog:
             next(ancestors)
 
         # single element in path
-        path = Path('a')
+        path = Path.parse('a')
         ancestors = path.ancestors()
         assert str(next(ancestors)) == ''
         with pytest.raises(StopIteration):
             next(ancestors)
 
         # root
-        path = Path('', empty_is_valid=True)
+        path = Path.parse('', empty_is_valid=True)
         ancestors = path.ancestors()
         with pytest.raises(StopIteration):
             next(ancestors)

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -16,18 +16,20 @@ class TestDirs:
             assert md['name'] == name.split('.')[-1]
 
         # invalid names
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: 1dir'):
             pxt.create_dir('1dir')
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: _dir1'):
             pxt.create_dir('_dir1')
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: dir 1'):
             pxt.create_dir('dir 1')
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: dir1..sub2'):
             pxt.create_dir('dir1..sub2')
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: dir1.sub2.'):
             pxt.create_dir('dir1.sub2.')
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: dir1:sub2.'):
             pxt.create_dir('dir1:sub2.')
+        with pytest.raises(excs.Error, match='Versioned path not allowed here: dir1:120'):
+            pxt.create_dir('dir1:120')
 
         # existing dirs raise error by default
         with pytest.raises(excs.Error, match='is an existing'):
@@ -166,11 +168,13 @@ class TestDirs:
         make_tbl('dir1.t1')
 
         # bad name
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: 1dir'):
             pxt.drop_dir('1dir')
         # bad path
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: dir1..sub1'):
             pxt.drop_dir('dir1..sub1')
+        with pytest.raises(excs.Error, match='Versioned path not allowed here: dir1:120'):
+            pxt.drop_dir('dir1:120')
         # doesn't exist
         self._test_drop_if_not_exists('dir2')
         # not empty

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -22,11 +22,11 @@ class TestDirs:
             pxt.create_dir('_dir1')
         with pytest.raises(excs.Error, match='Invalid path: dir 1'):
             pxt.create_dir('dir 1')
-        with pytest.raises(excs.Error, match='Invalid path: dir1..sub2'):
+        with pytest.raises(excs.Error, match=r'Invalid path: dir1..sub2'):
             pxt.create_dir('dir1..sub2')
-        with pytest.raises(excs.Error, match='Invalid path: dir1.sub2.'):
+        with pytest.raises(excs.Error, match=r'Invalid path: dir1.sub2.'):
             pxt.create_dir('dir1.sub2.')
-        with pytest.raises(excs.Error, match='Invalid path: dir1:sub2.'):
+        with pytest.raises(excs.Error, match=r'Invalid path: dir1:sub2.'):
             pxt.create_dir('dir1:sub2.')
         with pytest.raises(excs.Error, match='Versioned path not allowed here: dir1:120'):
             pxt.create_dir('dir1:120')
@@ -171,7 +171,7 @@ class TestDirs:
         with pytest.raises(excs.Error, match='Invalid path: 1dir'):
             pxt.drop_dir('1dir')
         # bad path
-        with pytest.raises(excs.Error, match='Invalid path: dir1..sub1'):
+        with pytest.raises(excs.Error, match=r'Invalid path: dir1..sub1'):
             pxt.drop_dir('dir1..sub1')
         with pytest.raises(excs.Error, match='Versioned path not allowed here: dir1:120'):
             pxt.drop_dir('dir1:120')

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -27,8 +27,8 @@ class TestReplica:
         reload_catalog()
 
         with cat.begin_xact(for_write=True):
-            cat.create_replica(Path('replica_1'), md1)
-            cat.create_replica(Path('replica_2'), md2)
+            cat.create_replica(Path.parse('replica_1'), md1)
+            cat.create_replica(Path.parse('replica_2'), md2)
         reload_catalog()
 
         t1 = pxt.get_table('replica_1')
@@ -97,17 +97,17 @@ class TestReplica:
         for i, md in enumerate(s11_md):
             print(f'\n{i}: {md}')
         with cat.begin_xact(for_write=True):
-            cat.create_replica(Path('replica_s11'), s11_md)
-            cat.create_replica(Path('replica_s12'), s12_md)
-            cat.create_replica(Path('replica_s31'), s31_md)
+            cat.create_replica(Path.parse('replica_s11'), s11_md)
+            cat.create_replica(Path.parse('replica_s12'), s12_md)
+            cat.create_replica(Path.parse('replica_s31'), s31_md)
 
         # Intentionally create r61 first, before r51; this way we address both cases for snapshot-over-snapshot:
         # Base snapshot inserted first (r61 after r31); base snapshot inserted last (r51 after r61).
         with cat.begin_xact(for_write=True):
-            cat.create_replica(Path('replica_s61'), s61_md)
+            cat.create_replica(Path.parse('replica_s61'), s61_md)
         r61 = pxt.get_table('replica_s61')
         with cat.begin_xact(for_write=True):
-            cat.create_replica(Path('replica_s51'), s51_md)
+            cat.create_replica(Path.parse('replica_s51'), s51_md)
         r51 = pxt.get_table('replica_s51')
 
         with cat.begin_xact(for_write=False):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -6,7 +6,14 @@ import pytest
 import pixeltable as pxt
 from pixeltable import exceptions as excs, func
 
-from .utils import ReloadTester, assert_resultset_eq, create_img_tbl, create_test_tbl, reload_catalog, validate_update_status
+from .utils import (
+    ReloadTester,
+    assert_resultset_eq,
+    create_img_tbl,
+    create_test_tbl,
+    reload_catalog,
+    validate_update_status,
+)
 
 
 class TestSnapshot:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -28,6 +28,7 @@ from .utils import (
     TESTS_DIR,
     ReloadTester,
     assert_resultset_eq,
+    assert_table_metadata_eq,
     create_table_data,
     get_audio_files,
     get_documents,
@@ -264,65 +265,77 @@ class TestTable:
             assert tbl._name == tbl_path.split('.')[-1]
             assert tbl._parent()._path() == '.'.join(tbl_path.split('.')[:-1])
 
-            assert tbl.get_metadata() == {
-                'base': None,
-                'comment': '',
-                'is_view': False,
-                'is_snapshot': False,
-                'is_replica': False,
-                'name': 'test',
-                'num_retained_versions': 10,
-                'media_validation': media_val,
-                'path': tbl_path,
-                'schema': tbl._get_schema(),
-                'schema_version': 0,
-                'version': 0,
-            }
+            assert_table_metadata_eq(
+                {
+                    'base': None,
+                    'comment': '',
+                    'is_view': False,
+                    'is_snapshot': False,
+                    'is_replica': False,
+                    'name': 'test',
+                    'num_retained_versions': 10,
+                    'media_validation': media_val,
+                    'path': tbl_path,
+                    'schema': tbl._get_schema(),
+                    'schema_version': 0,
+                    'version': 0,
+                },
+                tbl.get_metadata(),
+            )
 
-            assert view.get_metadata() == {
-                'base': tbl_path,
-                'comment': '',
-                'is_view': True,
-                'is_snapshot': False,
-                'is_replica': False,
-                'name': 'test_view',
-                'num_retained_versions': 10,
-                'media_validation': media_val,
-                'path': view_path,
-                'schema': view._get_schema(),
-                'schema_version': 0,
-                'version': 0,
-            }
+            assert_table_metadata_eq(
+                {
+                    'base': tbl_path,
+                    'comment': '',
+                    'is_view': True,
+                    'is_snapshot': False,
+                    'is_replica': False,
+                    'name': 'test_view',
+                    'num_retained_versions': 10,
+                    'media_validation': media_val,
+                    'path': view_path,
+                    'schema': view._get_schema(),
+                    'schema_version': 0,
+                    'version': 0,
+                },
+                view.get_metadata(),
+            )
 
-            assert puresnap.get_metadata() == {
-                'base': f'{tbl_path}:0',
-                'comment': '',
-                'is_view': True,
-                'is_snapshot': True,
-                'is_replica': False,
-                'name': 'test_puresnap',
-                'num_retained_versions': 10,
-                'media_validation': media_val,
-                'path': puresnap_path,
-                'schema': puresnap._get_schema(),
-                'schema_version': 0,
-                'version': 0,
-            }
+            assert_table_metadata_eq(
+                {
+                    'base': f'{tbl_path}:0',
+                    'comment': '',
+                    'is_view': True,
+                    'is_snapshot': True,
+                    'is_replica': False,
+                    'name': 'test_puresnap',
+                    'num_retained_versions': 10,
+                    'media_validation': media_val,
+                    'path': puresnap_path,
+                    'schema': puresnap._get_schema(),
+                    'schema_version': 0,
+                    'version': 0,
+                },
+                puresnap.get_metadata(),
+            )
 
-            assert snap.get_metadata() == {
-                'base': f'{tbl_path}:0',
-                'comment': '',
-                'is_view': True,
-                'is_snapshot': True,
-                'is_replica': False,
-                'name': 'test_snap',
-                'num_retained_versions': 10,
-                'media_validation': media_val,
-                'path': snap_path,
-                'schema': snap._get_schema(),
-                'schema_version': 0,
-                'version': 0,
-            }
+            assert_table_metadata_eq(
+                {
+                    'base': f'{tbl_path}:0',
+                    'comment': '',
+                    'is_view': True,
+                    'is_snapshot': True,
+                    'is_replica': False,
+                    'name': 'test_snap',
+                    'num_retained_versions': 10,
+                    'media_validation': media_val,
+                    'path': snap_path,
+                    'schema': snap._get_schema(),
+                    'schema_version': 0,
+                    'version': 0,
+                },
+                snap.get_metadata(),
+            )
 
     def test_media_validation(self, reset_db: None) -> None:
         tbl_schema = {'img': {'type': pxt.Image, 'media_validation': 'on_write'}, 'video': pxt.Video}

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -135,7 +135,7 @@ class TestTable:
             pxt.drop_table('test')
         with pytest.raises(excs.Error, match=r"Path 'dir1.test2' does not exist"):
             pxt.drop_table('dir1.test2')
-        with pytest.raises(excs.Error, match='Invalid path: .test2'):
+        with pytest.raises(excs.Error, match=r'Invalid path: .test2'):
             pxt.drop_table('.test2')
         with pytest.raises(excs.Error, match='Versioned path not allowed here: test2:120'):
             pxt.drop_table('test2:120')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -96,10 +96,12 @@ class TestTable:
         tbl = pxt.create_table('test', schema)
         _ = pxt.create_table('dir1.test', schema)
 
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: 1test'):
             pxt.create_table('1test', schema)
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: bad name'):
             pxt.create_table('bad name', {'c1': pxt.String})
+        with pytest.raises(excs.Error, match='Versioned path not allowed here: test:120'):
+            pxt.create_table('test:120', schema)
         with pytest.raises(excs.Error, match='is an existing table'):
             pxt.create_table('test', schema)
         with pytest.raises(excs.Error, match='does not exist'):
@@ -108,7 +110,7 @@ class TestTable:
         _ = pxt.list_tables()
         _ = pxt.list_tables('dir1')
 
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: 1dir'):
             pxt.list_tables('1dir')
         with pytest.raises(excs.Error, match='does not exist'):
             pxt.list_tables('dir2')
@@ -133,8 +135,10 @@ class TestTable:
             pxt.drop_table('test')
         with pytest.raises(excs.Error, match=r"Path 'dir1.test2' does not exist"):
             pxt.drop_table('dir1.test2')
-        with pytest.raises(excs.Error, match='Invalid path format'):
+        with pytest.raises(excs.Error, match='Invalid path: .test2'):
             pxt.drop_table('.test2')
+        with pytest.raises(excs.Error, match='Versioned path not allowed here: test2:120'):
+            pxt.drop_table('test2:120')
 
         with pytest.raises(excs.Error, match="'pos' is a reserved name in Pixeltable"):
             pxt.create_table('bad_col_name', {'pos': pxt.Int})

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -9,7 +9,14 @@ import pixeltable as pxt
 from pixeltable import catalog, exceptions as excs, type_system as ts
 from pixeltable.func import Batch
 
-from .utils import ReloadTester, assert_resultset_eq, create_test_tbl, reload_catalog, validate_update_status
+from .utils import (
+    ReloadTester,
+    assert_resultset_eq,
+    assert_table_metadata_eq,
+    create_test_tbl,
+    reload_catalog,
+    validate_update_status,
+)
 
 logger = logging.getLogger('pixeltable')
 
@@ -878,20 +885,23 @@ class TestView:
             else:
                 expected_schema = {'balloon': ts.StringType(nullable=True)}
                 expected_schema_version = 6
-            assert vmd == {
-                'base': None,
-                'comment': '',
-                'is_replica': False,
-                'is_snapshot': True,
-                'is_view': True,
-                'media_validation': 'on_write',
-                'name': f'test_tbl:{i}',
-                'num_retained_versions': 10,
-                'path': f'dir.test_tbl:{i}',
-                'schema': expected_schema,
-                'schema_version': expected_schema_version,
-                'version': i,
-            }
+            assert_table_metadata_eq(
+                {
+                    'base': None,
+                    'comment': '',
+                    'is_replica': False,
+                    'is_snapshot': True,
+                    'is_view': True,
+                    'media_validation': 'on_write',
+                    'name': f'test_tbl:{i}',
+                    'num_retained_versions': 10,
+                    'path': f'dir.test_tbl:{i}',
+                    'schema': expected_schema,
+                    'schema_version': expected_schema_version,
+                    'version': i,
+                },
+                vmd,
+            )
 
         res = [list(ver[i].head(100)) for i in range(len(ver))]
         assert res[0] == []
@@ -968,20 +978,24 @@ class TestView:
                 }
                 expected_schema_version = 4
                 expected_base_version = 7
-            assert vmd == {
-                'base': f'dir.test_tbl:{expected_base_version}',
-                'comment': '',
-                'is_replica': False,
-                'is_snapshot': True,
-                'is_view': True,
-                'media_validation': 'on_write',
-                'name': f'test_view:{i}',
-                'num_retained_versions': 10,
-                'path': f'dir.test_view:{i}',
-                'schema': expected_schema,
-                'schema_version': expected_schema_version,
-                'version': i,
-            }
+
+            assert_table_metadata_eq(
+                {
+                    'base': f'dir.test_tbl:{expected_base_version}',
+                    'comment': '',
+                    'is_replica': False,
+                    'is_snapshot': True,
+                    'is_view': True,
+                    'media_validation': 'on_write',
+                    'name': f'test_view:{i}',
+                    'num_retained_versions': 10,
+                    'path': f'dir.test_view:{i}',
+                    'schema': expected_schema,
+                    'schema_version': expected_schema_version,
+                    'version': i,
+                },
+                vmd,
+            )
 
     def test_column_defaults(self, reset_db: None) -> None:
         """

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -854,7 +854,7 @@ class TestView:
         assert t.count() == 110
         check(s, v, view_s)
 
-    def test_prior_versions_of_table(self, reset_db: None) -> None:
+    def test_table_time_travel(self, reset_db: None) -> None:
         pxt.create_dir('dir')
         t = pxt.create_table('dir.test_tbl', {'c1': pxt.Int})
         assert t.get_metadata()['version'] == 0
@@ -913,7 +913,7 @@ class TestView:
         assert res[6] == [{'balloon': r['c2']} for r in res[5]]
         assert res[7] == res[6] + [{'balloon': f'str{i}'} for i in range(10, 20)]
 
-    def test_prior_versions_of_view(self, reset_db: None) -> None:
+    def test_view_time_travel(self, reset_db: None) -> None:
         pxt.create_dir('dir')
         t = pxt.create_table('dir.test_tbl', {'c1': pxt.Int})
         assert t.get_metadata()['version'] == 0
@@ -970,7 +970,7 @@ class TestView:
                 }
                 expected_schema_version = 2
                 expected_base_version = 7
-            elif i == 4:
+            else:
                 expected_schema = {
                     'balloon': ts.IntType(nullable=True),
                     'c4': ts.IntType(nullable=True),
@@ -996,6 +996,15 @@ class TestView:
                 },
                 vmd,
             )
+
+        res = [list(ver[i].head(100)) for i in range(len(ver))]
+        assert res[0] == [{'c1': 2, 'c2': None}] + [{'c1': i, 'c2': f'str{i}'} for i in range(4, 10, 2)]
+        assert res[1] == [d | {'c3': d['c1'] // 2} for d in res[0]]
+        assert res[2] == [d | {'c4': None} for d in res[1]]
+        assert res[3] == [{'balloon': i, 'c3': i // 2, 'c4': None} for i in range(2, 20, 2)]
+        assert res[4] == [{'balloon': i, 'hamburger': i // 2, 'c4': None} for i in range(2, 20, 2)]
+        assert res[5] == [{'balloon': i, 'hamburger': i // 2, 'c4': i // 2 + 91} for i in range(2, 20, 2)]
+
 
     def test_column_defaults(self, reset_db: None) -> None:
         """

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -873,6 +873,7 @@ class TestView:
         for i in range(len(ver)):
             assert isinstance(ver[i], pxt.View)
             vmd = ver[i].get_metadata()
+            expected_schema: dict[str, ts.ColumnType]
             if i < 3:
                 expected_schema = {'c1': ts.IntType(nullable=True)}
                 expected_schema_version = 0
@@ -1004,7 +1005,6 @@ class TestView:
         assert res[3] == [{'balloon': i, 'c3': i // 2, 'c4': None} for i in range(2, 20, 2)]
         assert res[4] == [{'balloon': i, 'hamburger': i // 2, 'c4': None} for i in range(2, 20, 2)]
         assert res[5] == [{'balloon': i, 'hamburger': i // 2, 'c4': i // 2 + 91} for i in range(2, 20, 2)]
-
 
     def test_column_defaults(self, reset_db: None) -> None:
         """

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -936,19 +936,36 @@ class TestView:
                 expected_schema_version = 0
                 expected_base_version = 4
             elif i == 1:
-                expected_schema = {'c1': ts.IntType(nullable=True), 'c2': ts.StringType(nullable=True), 'c3': ts.IntType(nullable=True)}
+                expected_schema = {
+                    'c1': ts.IntType(nullable=True),
+                    'c2': ts.StringType(nullable=True),
+                    'c3': ts.IntType(nullable=True),
+                }
                 expected_schema_version = 1
                 expected_base_version = 4
             elif i == 2:
-                expected_schema = {'c1': ts.IntType(nullable=True), 'c2': ts.StringType(nullable=True), 'c3': ts.IntType(nullable=True), 'c4': ts.IntType(nullable=True)}
+                expected_schema = {
+                    'c1': ts.IntType(nullable=True),
+                    'c2': ts.StringType(nullable=True),
+                    'c3': ts.IntType(nullable=True),
+                    'c4': ts.IntType(nullable=True),
+                }
                 expected_schema_version = 2
                 expected_base_version = 4
             elif i == 3:
-                expected_schema = {'balloon': ts.IntType(nullable=True), 'c3': ts.IntType(nullable=True), 'c4': ts.IntType(nullable=True)}
+                expected_schema = {
+                    'balloon': ts.IntType(nullable=True),
+                    'c3': ts.IntType(nullable=True),
+                    'c4': ts.IntType(nullable=True),
+                }
                 expected_schema_version = 2
                 expected_base_version = 7
             elif i == 4:
-                expected_schema = {'balloon': ts.IntType(nullable=True), 'c4': ts.IntType(nullable=True), 'hamburger': ts.IntType(nullable=True)}
+                expected_schema = {
+                    'balloon': ts.IntType(nullable=True),
+                    'c4': ts.IntType(nullable=True),
+                    'hamburger': ts.IntType(nullable=True),
+                }
                 expected_schema_version = 4
                 expected_base_version = 7
             assert vmd == {

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -920,6 +920,7 @@ class TestView:
         t.drop_column('c2')
         t.rename_column('c1', 'balloon')
         t.insert({'balloon': i} for i in range(10, 20))
+        assert v.get_metadata()['version'] == 3
         v.rename_column('c3', 'hamburger')
         v.update({'c4': v.hamburger + 91})
         assert t.get_metadata()['version'] == 7
@@ -930,11 +931,28 @@ class TestView:
         for i in range(len(ver)):
             assert isinstance(ver[i], pxt.View)
             vmd = ver[i].get_metadata()
-            if i < 3:
-                expected_schema = {'c1': ts.IntType(nullable=True)}
+            if i == 0:
+                expected_schema = {'c1': ts.IntType(nullable=True), 'c2': ts.StringType(nullable=True)}
                 expected_schema_version = 0
+                expected_base_version = 4
+            elif i == 1:
+                expected_schema = {'c1': ts.IntType(nullable=True), 'c2': ts.StringType(nullable=True), 'c3': ts.IntType(nullable=True)}
+                expected_schema_version = 1
+                expected_base_version = 4
+            elif i == 2:
+                expected_schema = {'c1': ts.IntType(nullable=True), 'c2': ts.StringType(nullable=True), 'c3': ts.IntType(nullable=True), 'c4': ts.IntType(nullable=True)}
+                expected_schema_version = 2
+                expected_base_version = 4
+            elif i == 3:
+                expected_schema = {'balloon': ts.IntType(nullable=True), 'c3': ts.IntType(nullable=True), 'c4': ts.IntType(nullable=True)}
+                expected_schema_version = 2
+                expected_base_version = 7
+            elif i == 4:
+                expected_schema = {'balloon': ts.IntType(nullable=True), 'c4': ts.IntType(nullable=True), 'hamburger': ts.IntType(nullable=True)}
+                expected_schema_version = 4
+                expected_base_version = 7
             assert vmd == {
-                'base': 'dir.test_tbl',
+                'base': f'dir.test_tbl:{expected_base_version}',
                 'comment': '',
                 'is_replica': False,
                 'is_snapshot': True,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ import random
 import urllib.parse
 from pathlib import Path
 from typing import Any, Callable, Optional
+from unittest import TestCase
 
 import more_itertools
 import numpy as np
@@ -446,6 +447,20 @@ def __mismatch_err_string(col_name: str, s1: list[Any], s2: list[Any], mismatche
     if len(mismatches) > 5:
         lines.append(f'(... {len(mismatches) - 5} more mismatches)')
     return '\n'.join(lines)
+
+
+def assert_table_metadata_eq(expected: dict[str, Any], actual: dict[str, Any]) -> None:
+    """
+    Assert that table metadata (user-facing metadata as returned by `tbl.get_metadata()`) matches the expected dict.
+    `version_created` will be checked to be less than 1 minute ago; the other fields will be checked for exact
+    equality.
+    """
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    actual_created_at: datetime.datetime = actual['version_created']
+    assert (now - actual_created_at).total_seconds() <= 60
+
+    trimmed_actual = {k: v for k, v in actual.items() if k != 'version_created'}
+    TestCase().assertDictEqual(expected, trimmed_actual)
 
 
 def strip_lines(s: str) -> str:


### PR DESCRIPTION
Allows retrieving a handle to an older version of a table via the notation

```python
t = pxt.get_table('my_table:722')
```

Specific-version handles will always be instances of `View` and treated as snapshots.