### PR TITLE
Correct the table.history status report for newly created views.

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1757,9 +1757,7 @@ class Catalog:
         stmt = (
             sql.update(schema.TableVersion)
             .where(schema.TableVersion.tbl_id == tbl_id, schema.TableVersion.version == version)
-            .values(
-                md=schema.TableVersion.md.op('||')({'additional_md': {'update_status': dataclasses.asdict(status)}})
-            )
+            .values(md=schema.TableVersion.md.op('||')({'update_status': dataclasses.asdict(status)}))
         )
 
         res = conn.execute(stmt)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 import pytest
 
 import pixeltable as pxt
@@ -39,7 +41,13 @@ class TestHistory:
         v = pxt.create_view('view_of_test', t, comment='view of test table')
         r = v.history()
         print(r)
+        view_created_at = r['created_at'][0]
+        # created_at should be recent
+        assert view_created_at > datetime.now() - timedelta(seconds=30)
+        assert view_created_at < datetime.now()
+        assert r['inserts'][0] > 0
         assert len(r) == 1
+
         s = t.add_computed_column(c5=t.c1 + 20)
         self.pr_us(s, 'acc3')
         s = t.add_columns({'c6': pxt.String, 'c7': pxt.Int, 'c8': pxt.Float})


### PR DESCRIPTION
The UpdateStatus used in the table.history report for newly created views is not located in the expected place in the TableVersion metadata. Its data is therefore not reported in the history() report for the newly created view.
Please the UpdateStatus in the correct place. 
