### PR TITLE
WIP: Add COCO Dataset Import Support

### DIFF
--- a/docs/api/pixeltable/io.md
+++ b/docs/api/pixeltable/io.md
@@ -4,6 +4,7 @@
       members:
         - create_label_studio_project
         - export_parquet
+        - import_coco
         - import_csv
         - import_excel
         - import_huggingface_dataset

--- a/docs/mintlify/docs/datastore/bringing-data.mdx
+++ b/docs/mintlify/docs/datastore/bringing-data.mdx
@@ -14,9 +14,10 @@ Pixeltable supports importing data directly during table creation and insertion 
 
 Pixeltable supports importing from a variety of data sources:
 - CSV files (`.csv`)
-- Excel files (`.xls`, `.xlsx`)
+- Excel files (`.xls`, `.xlsx`) 
 - Parquet files (`.parquet`, `.pq`, `.parq`)
 - JSON files (`.json`)
+- COCO datasets (annotation JSON + images directory)
 - Pandas DataFrames
 - Pixeltable DataFrames
 - Hugging Face datasets
@@ -434,6 +435,32 @@ table.insert(df)
         'myproject.json_url',
         'https://api.example.com/data.json'
     )
+    ```
+  </Accordion>
+
+  <Accordion title="COCO Dataset Import" icon="image">
+    ```python
+    # Basic COCO import
+    table1 = pxt.io.import_coco(
+        'myproject.coco_dataset',
+        'annotations/instances_train2017.json',
+        'images/train2017/'
+    )
+
+    # COCO import with schema overrides
+    table2 = pxt.io.import_coco(
+        'myproject.coco_typed',
+        'annotations/instances_val2017.json',
+        'images/val2017/',
+        schema_overrides={
+            'image_id': pxt.String,
+            'annotations': pxt.Json
+        }
+    )
+
+    # The imported table can be used with existing COCO utilities
+    query = table1.select({'image': table1.image, 'annotations': table1.annotations})
+    export_path = query.to_coco_dataset()
     ```
   </Accordion>
 

--- a/pixeltable/io/__init__.py
+++ b/pixeltable/io/__init__.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F401
 
+from .coco import import_coco
 from .datarows import import_json, import_rows
 from .external_store import ExternalStore
 from .globals import create_label_studio_project, export_images_as_fo_dataset
@@ -8,7 +9,7 @@ from .pandas import import_csv, import_excel, import_pandas
 from .parquet import export_parquet, import_parquet
 
 __default_dir = {symbol for symbol in dir() if not symbol.startswith('_')}
-__removed_symbols = {'globals', 'hf_datasets', 'pandas', 'parquet', 'datarows'}
+__removed_symbols = {'globals', 'hf_datasets', 'pandas', 'parquet', 'datarows', 'coco'}
 __all__ = sorted(__default_dir - __removed_symbols)
 
 

--- a/pixeltable/io/coco.py
+++ b/pixeltable/io/coco.py
@@ -1,0 +1,225 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import PIL.Image
+
+import pixeltable as pxt
+import pixeltable.exceptions as excs
+
+
+def import_coco(
+    tbl_name: str,
+    coco_json_path: Union[str, os.PathLike[str]],
+    images_dir: Union[str, os.PathLike[str]],
+    *,
+    schema_overrides: Optional[dict[str, Any]] = None,
+    primary_key: Optional[Union[str, list[str]]] = None,
+    num_retained_versions: int = 10,
+    comment: str = '',
+) -> Any:
+    """
+    Creates a new base table from a COCO dataset annotation file and images directory.
+
+    This function imports data from the standard COCO (Common Objects in Context) annotation format,
+    which is a widely adopted JSON-based standard for storing and sharing image and video annotations,
+    particularly for object detection, instance segmentation, and human pose estimation tasks.
+
+    The COCO format consists of:
+    - A JSON annotation file containing image metadata and annotations
+    - A directory containing the actual image files
+
+    The resulting table will have the following columns:
+    - `image`: PIL.Image containing the loaded image
+    - `annotations`: JSON containing the annotations in Pixeltable's expected format
+    - `image_id`: Integer ID of the image from the COCO dataset
+    - `file_name`: String filename of the image
+    - `width`: Integer width of the image
+    - `height`: Integer height of the image
+
+    Args:
+        tbl_name: The name of the table to create.
+        coco_json_path: Path to the COCO annotation JSON file.
+        images_dir: Path to the directory containing the image files.
+        schema_overrides: If specified, then for each (name, type) pair in `schema_overrides`,
+            the column with name `name` will be given type `type`, instead of being inferred.
+        primary_key: The primary key of the table (see [`create_table()`][pixeltable.create_table]).
+        num_retained_versions: The number of retained versions of the table.
+        comment: A comment to attach to the table.
+
+    Returns:
+        A handle to the newly created Table.
+
+    Raises:
+        Error: If the COCO JSON file is malformed or images cannot be loaded.
+
+    Example:
+        Create a table from a COCO dataset:
+
+        >>> tbl = pxt.io.import_coco(
+        ...     'my_dataset',
+        ...     'annotations/instances_train2017.json',
+        ...     'images/train2017/'
+        ... )
+
+        The resulting table can be used with other Pixeltable COCO utilities:
+
+        >>> # Export as COCO dataset
+        >>> query = tbl.select({'image': tbl.image, 'annotations': tbl.annotations})
+        >>> path = query.to_coco_dataset()
+    """
+    coco_json_path = Path(coco_json_path)
+    images_dir = Path(images_dir)
+
+    # Validate inputs
+    if not coco_json_path.exists():
+        raise excs.Error(f'COCO JSON file not found: {coco_json_path}')
+    if not images_dir.exists():
+        raise excs.Error(f'Images directory not found: {images_dir}')
+    if not images_dir.is_dir():
+        raise excs.Error(f'Images path is not a directory: {images_dir}')
+
+    # Load and parse COCO JSON
+    try:
+        with open(coco_json_path, 'r', encoding='utf-8') as f:
+            coco_data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise excs.Error(f'Invalid JSON in COCO file: {e}') from e
+    except Exception as e:
+        raise excs.Error(f'Error reading COCO file: {e}') from e
+
+    # Validate COCO format
+    _validate_coco_format(coco_data)
+
+    # Convert COCO data to Pixeltable format
+    table_data = _convert_coco_to_pixeltable_format(coco_data, images_dir)
+
+    # Create the table
+    return pxt.create_table(
+        tbl_name,
+        source=table_data,
+        schema_overrides=schema_overrides,
+        primary_key=primary_key,
+        num_retained_versions=num_retained_versions,
+        comment=comment,
+    )
+
+
+def _validate_coco_format(coco_data: dict[str, Any]) -> None:
+    """Validate that the loaded JSON follows COCO format."""
+    required_fields = ['images', 'annotations', 'categories']
+    for field in required_fields:
+        if field not in coco_data:
+            raise excs.Error(f'Missing required field "{field}" in COCO JSON')
+        if not isinstance(coco_data[field], list):
+            raise excs.Error(f'Field "{field}" must be a list in COCO JSON')
+
+    # Validate images structure
+    for i, image in enumerate(coco_data['images']):
+        if not isinstance(image, dict):
+            raise excs.Error(f'Image at index {i} is not a dictionary')
+        required_image_fields = ['id', 'file_name', 'width', 'height']
+        for field in required_image_fields:
+            if field not in image:
+                raise excs.Error(f'Missing required field "{field}" in image at index {i}')
+
+    # Validate categories structure
+    for i, category in enumerate(coco_data['categories']):
+        if not isinstance(category, dict):
+            raise excs.Error(f'Category at index {i} is not a dictionary')
+        required_category_fields = ['id', 'name']
+        for field in required_category_fields:
+            if field not in category:
+                raise excs.Error(f'Missing required field "{field}" in category at index {i}')
+
+    # Validate annotations structure
+    for i, annotation in enumerate(coco_data['annotations']):
+        if not isinstance(annotation, dict):
+            raise excs.Error(f'Annotation at index {i} is not a dictionary')
+        required_annotation_fields = ['id', 'image_id', 'category_id', 'bbox']
+        for field in required_annotation_fields:
+            if field not in annotation:
+                raise excs.Error(f'Missing required field "{field}" in annotation at index {i}')
+
+        # Validate bbox format
+        bbox = annotation['bbox']
+        if not isinstance(bbox, list) or len(bbox) != 4:
+            raise excs.Error(f'Invalid bbox format in annotation at index {i}. Expected [x, y, width, height]')
+
+
+def _convert_coco_to_pixeltable_format(coco_data: dict[str, Any], images_dir: Path) -> list[dict[str, Any]]:
+    """Convert COCO data to Pixeltable table format."""
+
+    # Create mappings
+    image_id_to_info = {img['id']: img for img in coco_data['images']}
+    category_id_to_name = {cat['id']: cat['name'] for cat in coco_data['categories']}
+
+    # Group annotations by image_id
+    image_annotations: dict[int, list[dict[str, Any]]] = {}
+    for annotation in coco_data['annotations']:
+        image_id = annotation['image_id']
+        if image_id not in image_annotations:
+            image_annotations[image_id] = []
+        image_annotations[image_id].append(annotation)
+
+    table_rows = []
+
+    for image_id, image_info in image_id_to_info.items():
+        file_name = image_info['file_name']
+        image_path = images_dir / file_name
+
+        # Try to load the image
+        try:
+            if not image_path.exists():
+                raise excs.Error(f'Image file not found: {image_path}')
+            with PIL.Image.open(image_path) as pil_image:
+                # Convert to RGB if necessary (handles RGBA, grayscale, etc.)
+                if pil_image.mode != 'RGB':
+                    image = pil_image.convert('RGB')
+                else:
+                    image = pil_image.copy()
+        except Exception as e:
+            raise excs.Error(f'Error loading image {file_name}: {e}') from e
+
+        # Convert annotations to Pixeltable format
+        pxt_annotations = []
+        if image_id in image_annotations:
+            for annotation in image_annotations[image_id]:
+                bbox = annotation['bbox']
+                category_id = annotation['category_id']
+
+                # Convert COCO bbox format [x, y, width, height] to Pixeltable format [x, y, width, height]
+                # Note: COCO bbox is already in the format Pixeltable expects
+                pxt_annotation = {
+                    'bbox': [int(bbox[0]), int(bbox[1]), int(bbox[2]), int(bbox[3])],
+                    'category': category_id_to_name.get(category_id, f'unknown_{category_id}'),
+                }
+
+                # Add optional fields if present
+                if 'area' in annotation:
+                    pxt_annotation['area'] = annotation['area']
+                if 'iscrowd' in annotation:
+                    pxt_annotation['iscrowd'] = annotation['iscrowd']
+
+                pxt_annotations.append(pxt_annotation)
+
+        # Create the row in the format expected by Pixeltable
+        row = {
+            'image': image,
+            'annotations': pxt_annotations,
+            'image_id': image_id,
+            'file_name': file_name,
+            'width': image_info['width'],
+            'height': image_info['height'],
+        }
+
+        # Add optional image fields if present
+        if 'date_captured' in image_info:
+            row['date_captured'] = image_info['date_captured']
+        if 'license' in image_info:
+            row['license'] = image_info['license']
+
+        table_rows.append(row)
+
+    return table_rows

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -1,0 +1,358 @@
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import PIL.Image
+import pytest
+
+import pixeltable as pxt
+import pixeltable.exceptions as excs
+
+
+class TestImportCoco:
+    def create_sample_coco_data(self) -> dict[str, Any]:
+        """Create a sample COCO annotation dataset for testing."""
+        return {
+            'info': {
+                'description': 'Test COCO Dataset',
+                'version': '1.0',
+                'year': 2024,
+                'contributor': 'Test',
+                'date_created': '2024-01-01 00:00:00',
+            },
+            'licenses': [{'id': 1, 'name': 'Test License', 'url': 'https://example.com/license'}],
+            'images': [
+                {
+                    'id': 1,
+                    'width': 100,
+                    'height': 100,
+                    'file_name': 'image1.jpg',
+                    'license': 1,
+                    'date_captured': '2024-01-01 10:00:00',
+                },
+                {
+                    'id': 2,
+                    'width': 150,
+                    'height': 150,
+                    'file_name': 'image2.jpg',
+                    'license': 1,
+                    'date_captured': '2024-01-01 11:00:00',
+                },
+            ],
+            'annotations': [
+                {'id': 1, 'image_id': 1, 'category_id': 1, 'bbox': [10, 20, 30, 40], 'area': 1200, 'iscrowd': 0},
+                {'id': 2, 'image_id': 1, 'category_id': 2, 'bbox': [50, 60, 20, 30], 'area': 600, 'iscrowd': 0},
+                {'id': 3, 'image_id': 2, 'category_id': 1, 'bbox': [5, 5, 40, 40], 'area': 1600, 'iscrowd': 0},
+            ],
+            'categories': [
+                {'id': 1, 'name': 'person', 'supercategory': 'human'},
+                {'id': 2, 'name': 'car', 'supercategory': 'vehicle'},
+            ],
+        }
+
+    def create_test_images(self, images_dir: Path) -> None:
+        """Create test images in the specified directory."""
+        images_dir.mkdir(exist_ok=True)
+
+        # Create image1.jpg (100x100)
+        img1 = PIL.Image.new('RGB', (100, 100), color='red')
+        img1.save(images_dir / 'image1.jpg')
+
+        # Create image2.jpg (150x150)
+        img2 = PIL.Image.new('RGB', (150, 150), color='blue')
+        img2.save(images_dir / 'image2.jpg')
+
+    def test_import_coco_basic(self, reset_db: None) -> None:
+        """Test basic COCO import functionality."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            images_dir = tmp_path / 'images'
+            annotations_file = tmp_path / 'annotations.json'
+
+            # Create test data
+            coco_data = self.create_sample_coco_data()
+            self.create_test_images(images_dir)
+
+            # Write COCO JSON
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(coco_data, f)
+
+            # Import COCO data
+            tbl = pxt.io.import_coco('test.coco_import', annotations_file, images_dir)
+
+            # Verify table structure
+            assert tbl.count() == 2  # Two images
+
+            # Check schema
+            schema = tbl.schema
+            assert 'image' in schema
+            assert 'annotations' in schema
+            assert 'image_id' in schema
+            assert 'file_name' in schema
+            assert 'width' in schema
+            assert 'height' in schema
+
+            # Verify data
+            rows = list(tbl.select())
+            assert len(rows) == 2
+
+            # Check first image
+            row1 = next(r for r in rows if r['image_id'] == 1)
+            assert row1['file_name'] == 'image1.jpg'
+            assert row1['width'] == 100
+            assert row1['height'] == 100
+            assert isinstance(row1['image'], PIL.Image.Image)
+            assert len(row1['annotations']) == 2  # Two annotations for image1
+
+            # Check annotations format
+            ann1 = row1['annotations'][0]
+            assert 'bbox' in ann1
+            assert 'category' in ann1
+            assert ann1['category'] in ['person', 'car']
+            assert len(ann1['bbox']) == 4
+
+            # Check second image
+            row2 = next(r for r in rows if r['image_id'] == 2)
+            assert row2['file_name'] == 'image2.jpg'
+            assert row2['width'] == 150
+            assert row2['height'] == 150
+            assert len(row2['annotations']) == 1  # One annotation for image2
+
+    def test_import_coco_with_schema_overrides(self, reset_db: None) -> None:
+        """Test COCO import with schema overrides."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            images_dir = tmp_path / 'images'
+            annotations_file = tmp_path / 'annotations.json'
+
+            # Create test data
+            coco_data = self.create_sample_coco_data()
+            self.create_test_images(images_dir)
+
+            # Write COCO JSON
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(coco_data, f)
+
+            # Import with schema overrides
+            tbl = pxt.io.import_coco(
+                'test.coco_schema_override', annotations_file, images_dir, schema_overrides={'image_id': pxt.String}
+            )
+
+            # Verify schema override was applied
+            schema = tbl.schema
+            assert schema['image_id'].is_string_type()
+
+    def test_import_coco_error_missing_json(self, reset_db: None) -> None:
+        """Test error handling when COCO JSON file is missing."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            missing_file = tmp_path / 'missing.json'
+            images_dir = tmp_path / 'images'
+            images_dir.mkdir()
+
+            with pytest.raises(excs.Error, match='COCO JSON file not found'):
+                pxt.io.import_coco('test.missing_json', missing_file, images_dir)
+
+    def test_import_coco_error_missing_images_dir(self, reset_db: None) -> None:
+        """Test error handling when images directory is missing."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            annotations_file = tmp_path / 'annotations.json'
+            missing_dir = tmp_path / 'missing_images'
+
+            # Create minimal COCO JSON
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(self.create_sample_coco_data(), f)
+
+            with pytest.raises(excs.Error, match='Images directory not found'):
+                pxt.io.import_coco('test.missing_dir', annotations_file, missing_dir)
+
+    def test_import_coco_error_invalid_json(self, reset_db: None) -> None:
+        """Test error handling with invalid JSON."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            annotations_file = tmp_path / 'invalid.json'
+            images_dir = tmp_path / 'images'
+            images_dir.mkdir()
+
+            # Write invalid JSON
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                f.write('{ invalid json }')
+
+            with pytest.raises(excs.Error, match='Invalid JSON in COCO file'):
+                pxt.io.import_coco('test.invalid_json', annotations_file, images_dir)
+
+    def test_import_coco_error_missing_required_fields(self, reset_db: None) -> None:
+        """Test error handling when required COCO fields are missing."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            annotations_file = tmp_path / 'incomplete.json'
+            images_dir = tmp_path / 'images'
+            images_dir.mkdir()
+
+            # Create incomplete COCO data (missing 'categories')
+            incomplete_data: dict[str, Any] = {
+                'images': [],
+                'annotations': [],
+                # Missing 'categories'
+            }
+
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(incomplete_data, f)
+
+            with pytest.raises(excs.Error, match='Missing required field "categories"'):
+                pxt.io.import_coco('test.incomplete', annotations_file, images_dir)
+
+    def test_import_coco_error_missing_image_file(self, reset_db: None) -> None:
+        """Test error handling when an image file is missing."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            annotations_file = tmp_path / 'annotations.json'
+            images_dir = tmp_path / 'images'
+            images_dir.mkdir()
+
+            # Create COCO data but don't create the image files
+            coco_data = self.create_sample_coco_data()
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(coco_data, f)
+
+            with pytest.raises(excs.Error, match='Image file not found'):
+                pxt.io.import_coco('test.missing_image', annotations_file, images_dir)
+
+    def test_import_coco_empty_annotations(self, reset_db: None) -> None:
+        """Test COCO import with images that have no annotations."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            images_dir = tmp_path / 'images'
+            annotations_file = tmp_path / 'annotations.json'
+
+            # Create COCO data with no annotations
+            coco_data = {
+                'images': [{'id': 1, 'width': 100, 'height': 100, 'file_name': 'image1.jpg'}],
+                'annotations': [],  # No annotations
+                'categories': [{'id': 1, 'name': 'person'}],
+            }
+
+            self.create_test_images(images_dir)
+
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(coco_data, f)
+
+            # Import should succeed
+            tbl = pxt.io.import_coco('test.empty_annotations', annotations_file, images_dir)
+
+            # Verify data
+            rows = list(tbl.select())
+            assert len(rows) == 1
+            assert len(rows[0]['annotations']) == 0  # Empty annotations list
+
+    def test_import_coco_integration_with_export(self, reset_db: None) -> None:
+        """Test that imported COCO data can be exported back to COCO format."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            images_dir = tmp_path / 'images'
+            annotations_file = tmp_path / 'annotations.json'
+
+            # Create test data
+            coco_data = self.create_sample_coco_data()
+            self.create_test_images(images_dir)
+
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(coco_data, f)
+
+            # Import COCO data
+            tbl = pxt.io.import_coco('test.coco_roundtrip', annotations_file, images_dir)
+
+            # Create a query in the format expected by to_coco_dataset
+            query = tbl.select({'image': tbl.image, 'annotations': tbl.annotations})
+
+            # Export to COCO format
+            export_path = query.to_coco_dataset()
+
+            # Verify the export succeeded
+            assert export_path.exists()
+            assert export_path.is_file()
+
+            # Load and verify the exported data
+            with open(export_path, 'r', encoding='utf-8') as f:
+                exported_data = json.load(f)
+
+            assert 'images' in exported_data
+            assert 'annotations' in exported_data
+            assert 'categories' in exported_data
+            assert len(exported_data['images']) == 2  # Two images
+
+    def test_import_coco_with_unknown_categories(self, reset_db: None) -> None:
+        """Test COCO import with annotations referencing unknown category IDs."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            images_dir = tmp_path / 'images'
+            annotations_file = tmp_path / 'annotations.json'
+
+            # Create COCO data with annotation referencing unknown category
+            coco_data = {
+                'images': [{'id': 1, 'width': 100, 'height': 100, 'file_name': 'image1.jpg'}],
+                'annotations': [
+                    {
+                        'id': 1,
+                        'image_id': 1,
+                        'category_id': 999,  # Unknown category ID
+                        'bbox': [10, 20, 30, 40],
+                    }
+                ],
+                'categories': [{'id': 1, 'name': 'person'}],
+            }
+
+            self.create_test_images(images_dir)
+
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(coco_data, f)
+
+            # Import should succeed but use fallback category name
+            tbl = pxt.io.import_coco('test.unknown_category', annotations_file, images_dir)
+
+            # Verify unknown category is handled
+            rows = list(tbl.select())
+            assert len(rows) == 1
+            assert len(rows[0]['annotations']) == 1
+            assert rows[0]['annotations'][0]['category'] == 'unknown_999'
+
+    def test_import_coco_different_image_modes(self, reset_db: None) -> None:
+        """Test COCO import with different image color modes (RGBA, grayscale, etc.)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            images_dir = tmp_path / 'images'
+            annotations_file = tmp_path / 'annotations.json'
+            images_dir.mkdir()
+
+            # Create images with different modes
+            # RGBA image
+            rgba_img = PIL.Image.new('RGBA', (100, 100), color=(255, 0, 0, 128))
+            rgba_img.save(images_dir / 'rgba_image.png')
+
+            # Grayscale image
+            gray_img = PIL.Image.new('L', (100, 100), color=128)
+            gray_img.save(images_dir / 'gray_image.jpg')
+
+            # Create COCO data
+            coco_data = {
+                'images': [
+                    {'id': 1, 'width': 100, 'height': 100, 'file_name': 'rgba_image.png'},
+                    {'id': 2, 'width': 100, 'height': 100, 'file_name': 'gray_image.jpg'},
+                ],
+                'annotations': [],
+                'categories': [],
+            }
+
+            with open(annotations_file, 'w', encoding='utf-8') as f:
+                json.dump(coco_data, f)
+
+            # Import should succeed and convert all images to RGB
+            tbl = pxt.io.import_coco('test.image_modes', annotations_file, images_dir)
+
+            # Verify all images are converted to RGB
+            rows = list(tbl.select())
+            assert len(rows) == 2
+            for row in rows:
+                assert row['image'].mode == 'RGB'


### PR DESCRIPTION
### ✅ **Current Implementation**
- **`pxt.io.import_coco(table_name, json_path, images_dir)`** - Standalone function
- Full COCO format support (images, annotations, categories)
- Seamless integration with existing `to_coco_dataset()` export
- Comprehensive error handling and validation

### 🔄 **Next Steps: `create_table(source=...)` Integration Options**

**Option 1: Dict Source (Recommended)**
```python
tbl = pxt.create_table('dataset', source={
    'annotations': 'path/to/annotations.json',
    'images_dir': 'path/to/images/'
}, source_format='coco')
```
- **Pros**: Clean API, explicit parameters
- **Cons**: API change needed

**Option 2: Convention-Based**
```python
tbl = pxt.create_table('dataset', source='annotations.json', source_format='coco')
# Auto-infer images from common patterns: ./images/, ../images/, etc.
```
- **Pros**: Minimal API change, follows COCO conventions
- **Cons**: Less explicit, potential ambiguity

**Option 3: Extended Parameters**
```python
tbl = pxt.create_table('dataset', source='annotations.json', 
                      source_format='coco', images_dir='path/to/images/')
```
- **Pros**: Explicit, backward compatible
- **Cons**: COCO-specific parameter in generic API

**Option 4: Keep Separate (Current)**
```python
tbl = pxt.io.import_coco('dataset', 'annotations.json', 'images/')
```
- **Pros**: No API changes, specialized for COCO's dual-input nature
- **Cons**: Inconsistent with other imports

### 🎯 **Recommendation**
Start with **Option 4** (current approach) for initial release, then add **Option 1** based on user feedback. COCO's dual-input requirement (JSON + images directory) makes it naturally different from single-file imports.

This keeps the implementation focused and production-ready while leaving room for future API unification.