### PR TITLE
Test cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,7 @@ filterwarnings = [
     "ignore:Pydantic V1 style `@root_validator` validators are deprecated.:DeprecationWarning",
     "ignore:`allow_reuse` is deprecated and will be ignored:DeprecationWarning",
     "ignore::pydantic.PydanticDeprecatedSince20",
+    "ignore::pydantic.PydanticDeprecatedSince211",
     # This warning is from Whisper:
     "ignore:FP16 is not supported on CPU:UserWarning",
     # These four warnings are all from WhisperX:

--- a/tests/functions/test_gemini.py
+++ b/tests/functions/test_gemini.py
@@ -74,6 +74,7 @@ class TestGemini:
         assert results['output2'][0].size == (1280, 896)
 
     @pytest.mark.skip('Very expensive')
+    @pytest.mark.expensive
     @rerun(reruns=3, reruns_delay=30)  # longer delay between reruns
     def test_generate_videos(self, reset_db: None) -> None:
         skip_test_if_not_installed('google.genai')

--- a/tests/functions/test_mistralai.py
+++ b/tests/functions/test_mistralai.py
@@ -37,7 +37,6 @@ class TestMistral:
         assert len(results['output'][0]['choices'][0]['message']['content']) > 0
         assert len(results['output2'][0]['choices'][0]['message']['content']) > 0
 
-    @pytest.mark.skip(reason="Disabled until we figure out why it's failing")
     def test_fim_completions(self, reset_db: None) -> None:
         skip_test_if_not_installed('mistralai')
         skip_test_if_no_client('mistral')
@@ -49,12 +48,14 @@ class TestMistral:
             output2=fim_completions(
                 prompt=t.input,
                 model='codestral-latest',
-                temperature=0.8,
-                top_p=0.95,
-                max_tokens=300,
-                stop=['def'],
-                random_seed=4171780,
-                suffix=t.suffix,
+                model_kwargs={
+                    'temperature': 0.8,
+                    'top_p': 0.95,
+                    'max_tokens': 300,
+                    'stop': ['def'],
+                    'random_seed': 4171780,
+                    'suffix': t.suffix,
+                }
             )
         )
         status = t.insert(

--- a/tests/functions/test_mistralai.py
+++ b/tests/functions/test_mistralai.py
@@ -55,7 +55,7 @@ class TestMistral:
                     'stop': ['def'],
                     'random_seed': 4171780,
                     'suffix': t.suffix,
-                }
+                },
             )
         )
         status = t.insert(

--- a/tests/functions/test_openai.py
+++ b/tests/functions/test_openai.py
@@ -352,22 +352,6 @@ class TestOpenai:
         assert t.collect()['img'][0].size == (1024, 1024)
         assert t.collect()['img_2'][0].size == (512, 512)
 
-    @pytest.mark.skip('Test is expensive and slow')
-    def test_image_generations_dall_e_3(self, reset_db: None) -> None:
-        skip_test_if_not_installed('openai')
-        skip_test_if_no_client('openai')
-        from pixeltable.functions.openai import image_generations
-
-        # Test dall-e-3 options
-        t = pxt.create_table('test_tbl', {'input': pxt.String})
-        t.add_computed_column(
-            img_3=image_generations(
-                t.input, model='dall-e-3', quality='hd', size='1792x1024', style='natural', user='pixeltable'
-            )
-        )
-        validate_update_status(t.insert(input='A friendly dinosaur playing tennis in a cornfield'), 1)
-        assert t.collect()['img_3'][0].size == (1792, 1024)
-
     @pytest.mark.expensive
     def test_table_udf_tools(self, reset_db: None) -> None:
         skip_test_if_not_installed('openai')

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,5 +1,4 @@
 import datetime
-import pickle
 import re
 import urllib.request
 from pathlib import Path

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -1077,37 +1077,7 @@ class TestExprs:
         )
         print(result)
 
-    @pytest.mark.skip(reason='temporarily disabled')
-    def test_similarity(self, small_img_tbl: pxt.Table) -> None:
-        t = small_img_tbl
-        _ = t.show(30)
-        probe = t.select(t.img, t.category).show(1)
-        img = probe[0, 0]
-        result = t.where(t.img.nearest(img)).show(10)
-        assert len(result) == 10
-        # nearest() with one SQL predicate and one Python predicate
-        result = t.select(t.img.nearest(img) & (t.category == probe[0, 1]) & (t.img.width > 1)).show(10)
-        # TODO: figure out how to verify results
-
-        with pytest.raises(excs.Error) as exc_info:
-            _ = t.select(t.img.nearest(img)).order_by(t.category).show()
-        assert 'cannot be used in conjunction with' in str(exc_info.value)
-
-        result = t.select(t.img.nearest('musical instrument')).show(10)
-        assert len(result) == 10
-        # matches() with one SQL predicate and one Python predicate
-        french_horn_category = 'n03394916'
-        result = t[t.img.nearest('musical instrument') & (t.category == french_horn_category) & (t.img.width > 1)].show(
-            10
-        )
-
-        with pytest.raises(excs.Error) as exc_info:
-            _ = t.select(t.img.nearest(5)).show()
-        assert 'requires' in str(exc_info.value)
-
-    # TODO: this doesn't work when combined with test_similarity(), for some reason the data table for img_tbl
-    # doesn't get created; why?
-    def test_similarity2(
+    def test_similarity(
         self, img_tbl: catalog.Table, indexed_img_tbl: catalog.Table, multi_idx_img_tbl: catalog.Table
     ) -> None:
         t = img_tbl


### PR DESCRIPTION
Removes some old/crufty tests from pytest. These have been marked with `pytest.mark.skip` for quite some time.

We should try to avoid having skipped tests sitting around for too long; over time they "drift" away from the codebase and become meaningless/unusable.

Also fixes a mistralai test that was marked as `skip` but was salvageable.