### PR TITLE
Bugfixes related to missing dependencies

### DIFF
--- a/pixeltable/func/expr_template_function.py
+++ b/pixeltable/func/expr_template_function.py
@@ -90,7 +90,7 @@ class ExprTemplateFunction(Function):
         with_defaults.update(
             {param_name: default for param_name, default in template.defaults.items() if param_name not in bound_args}
         )
-        substituted_expr = self.template.expr.copy().substitute(
+        substituted_expr = template.expr.copy().substitute(
             {template.param_exprs[name]: expr for name, expr in with_defaults.items()}
         )
         return substituted_expr.col_type

--- a/pixeltable/functions/huggingface.py
+++ b/pixeltable/functions/huggingface.py
@@ -63,13 +63,10 @@ def sentence_transformer(
 
 @sentence_transformer.conditional_return_type
 def _(model_id: str) -> ts.ArrayType:
-    try:
-        from sentence_transformers import SentenceTransformer
+    from sentence_transformers import SentenceTransformer
 
-        model = _lookup_model(model_id, SentenceTransformer)
-        return ts.ArrayType((model.get_sentence_embedding_dimension(),), dtype=ts.FloatType(), nullable=False)
-    except ImportError:
-        return ts.ArrayType((None,), dtype=ts.FloatType(), nullable=False)
+    model = _lookup_model(model_id, SentenceTransformer)
+    return ts.ArrayType((model.get_sentence_embedding_dimension(),), dtype=ts.FloatType(), nullable=False)
 
 
 @pxt.udf
@@ -201,13 +198,10 @@ def _(image: Batch[PIL.Image.Image], *, model_id: str) -> Batch[pxt.Array[(None,
 
 @clip.conditional_return_type
 def _(model_id: str) -> ts.ArrayType:
-    try:
-        from transformers import CLIPModel
+    from transformers import CLIPModel
 
-        model = _lookup_model(model_id, CLIPModel.from_pretrained)
-        return ts.ArrayType((model.config.projection_dim,), dtype=ts.FloatType(), nullable=False)
-    except ImportError:
-        return ts.ArrayType((None,), dtype=ts.FloatType(), nullable=False)
+    model = _lookup_model(model_id, CLIPModel.from_pretrained)
+    return ts.ArrayType((model.config.projection_dim,), dtype=ts.FloatType(), nullable=False)
 
 
 @pxt.udf(batch_size=4)

--- a/pixeltable/iterators/document.py
+++ b/pixeltable/iterators/document.py
@@ -213,12 +213,6 @@ class DocumentSplitter(ComponentIterator):
             if kwargs.get('limit') is None:
                 raise Error('limit is required with "token_limit"/"char_limit" separators')
 
-        # check dependencies at the end
-        if Separator.SENTENCE in separators:
-            _ = Env.get().spacy_nlp
-        if Separator.TOKEN_LIMIT in separators:
-            Env.get().require_package('tiktoken')
-
         return schema, []
 
     def __next__(self) -> dict[str, Any]:


### PR DESCRIPTION
Fixes several bugs related to Pixeltable's handling of missing dependencies.
- Allow `DocumentSplitter.output_schema()` to resolve even if necessary dependencies are missing
- Fail gracefully with a UDF warning if `call_return_type()` fails due to missing dependencies (previously we just swallowed the `ImportError`)
- If `call_return_type` gives a more general type than the existing `return_type` of a `FunctionCall`, prefer the more specialized type