### PR TITLE
Move stored_img_cols from ExecNode To RowBuilder, add stored_media_cols

### DIFF
--- a/pixeltable/exec/aggregation_node.py
+++ b/pixeltable/exec/aggregation_node.py
@@ -103,6 +103,6 @@ class AggregationNode(ExecNode):
             self.row_builder.eval(prev_row, self.agg_fn_eval_ctx, profile=self.ctx.profile)
             self.output_batch.add_row(prev_row)
 
-        self.output_batch.flush_imgs(None, self.stored_img_cols, self.flushed_img_slots)
+        self.output_batch.flush_imgs(None, self.row_builder.stored_img_cols, self.flushed_img_slots)
         _logger.debug(f'AggregateNode: consumed {num_input_rows} rows, returning {len(self.output_batch.rows)} rows')
         yield self.output_batch

--- a/pixeltable/exec/exec_node.py
+++ b/pixeltable/exec/exec_node.py
@@ -20,7 +20,6 @@ class ExecNode(abc.ABC):
     row_builder: exprs.RowBuilder
     input: Optional[ExecNode]
     flushed_img_slots: list[int]  # idxs of image slots of our output_exprs dependencies
-    stored_img_cols: list[exprs.ColumnSlotIdx]
     ctx: Optional[ExecContext]
 
     def __init__(
@@ -40,19 +39,12 @@ class ExecNode(abc.ABC):
         self.flushed_img_slots = [
             e.slot_idx for e in output_dependencies if e.col_type.is_image_type() and e.slot_idx not in output_slot_idxs
         ]
-        self.stored_img_cols = []
         self.ctx = None  # all nodes of a tree share the same context
 
     def set_ctx(self, ctx: ExecContext) -> None:
         self.ctx = ctx
         if self.input is not None:
             self.input.set_ctx(ctx)
-
-    def set_stored_img_cols(self, stored_img_cols: list[exprs.ColumnSlotIdx]) -> None:
-        self.stored_img_cols = stored_img_cols
-        # propagate batch size to the source
-        if self.input is not None:
-            self.input.set_stored_img_cols(stored_img_cols)
 
     @abc.abstractmethod
     def __aiter__(self) -> AsyncIterator[DataRowBatch]:

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -86,6 +86,8 @@ class RowBuilder:
     img_slot_idxs: list[int]  # Indices of image slots
     media_slot_idxs: list[int]  # Indices of non-image media slots
     array_slot_idxs: list[int]  # Indices of array slots
+    stored_img_cols: list[exprs.ColumnSlotIdx]
+    stored_media_cols: list[exprs.ColumnSlotIdx]
 
     @dataclass
     class EvalCtx:
@@ -242,6 +244,10 @@ class RowBuilder:
             e.slot_idx for e in self.unique_exprs if e.col_type.is_media_type() and not e.col_type.is_image_type()
         ]
         self.array_slot_idxs = [e.slot_idx for e in self.unique_exprs if e.col_type.is_array_type()]
+
+        stored_col_info = self.output_slot_idxs()
+        self.stored_img_cols = [info for info in stored_col_info if info.col.col_type.is_image_type()]
+        self.stored_media_cols = [info for info in stored_col_info if info.col.col_type.is_media_type()]
 
     def add_table_column(self, col: catalog.Column, slot_idx: int) -> None:
         """Record a column that is part of the table row"""
@@ -499,17 +505,3 @@ class RowBuilder:
     def make_row(self) -> exprs.DataRow:
         """Creates a new DataRow with the current row_builder's configuration."""
         return exprs.DataRow(self.num_materialized, self.img_slot_idxs, self.media_slot_idxs, self.array_slot_idxs)
-
-    @property
-    def stored_img_cols(self) -> list[exprs.ColumnSlotIdx]:
-        """Returns the list of stored image columns"""
-        stored_col_info = self.output_slot_idxs()
-        stored_img_col_info = [info for info in stored_col_info if info.col.col_type.is_image_type()]
-        return stored_img_col_info
-
-    @property
-    def stored_media_cols(self) -> list[exprs.ColumnSlotIdx]:
-        """Returns the list of stored media columns"""
-        stored_col_info = self.output_slot_idxs()
-        stored_media_col_info = [info for info in stored_col_info if info.col.col_type.is_media_type()]
-        return stored_media_col_info

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -403,7 +403,6 @@ class Planner:
                 ignore_errors=ignore_errors,
             )
         )
-        plan.set_stored_img_cols(row_builder.stored_img_cols)
         return plan
 
     @classmethod
@@ -426,7 +425,6 @@ class Planner:
             col = tbl.cols_by_name[col_name]
             plan.row_builder.add_table_column(col, expr.slot_idx)
 
-        plan.set_stored_img_cols(plan.row_builder.stored_img_cols)
         plan.set_ctx(
             exec.ExecContext(
                 plan.row_builder, batch_size=0, show_pbar=True, num_computed_exprs=0, ignore_errors=ignore_errors
@@ -652,7 +650,6 @@ class Planner:
         for i, col in enumerate(copied_cols + list(recomputed_cols)):  # same order as select_list
             plan.row_builder.add_table_column(col, select_list[i].slot_idx)
         # TODO: avoid duplication with view_load_plan() logic (where does this belong?)
-        plan.set_stored_img_cols(plan.row_builder.stored_img_cols)
         return plan
 
     @classmethod
@@ -719,7 +716,6 @@ class Planner:
                 row_builder, output_exprs=view_output_exprs, input_exprs=base_output_exprs, input=plan
             )
 
-        plan.set_stored_img_cols(row_builder.stored_img_cols)
         exec_ctx.ignore_errors = True
         plan.set_ctx(exec_ctx)
         return plan, len(row_builder.default_eval_ctx.target_exprs)
@@ -1044,6 +1040,4 @@ class Planner:
         computed_exprs = row_builder.output_exprs - row_builder.input_exprs
         plan.ctx.num_computed_exprs = len(computed_exprs)  # we are adding a computed column, so we need to evaluate it
 
-        # we want to flush images
-        plan.set_stored_img_cols(row_builder.stored_img_cols)
         return plan


### PR DESCRIPTION
The member stored_img_cols is moved from ExecNode to RowBuilder, and filled during RowBuilder construction.
The member stored_media_cols is added, with a similar policy.