### PR TITLE
[WiP] Implementation of storing media files in specific local filesystem directories

### DIFF
--- a/pixeltable/catalog/column.py
+++ b/pixeltable/catalog/column.py
@@ -34,6 +34,7 @@ class Column:
     col_type: ts.ColumnType
     stored: bool
     is_pk: bool
+    destination: Optional[str]
     _media_validation: Optional[MediaValidation]  # if not set, TableVersion.media_validation applies
     schema_version_add: Optional[int]
     schema_version_drop: Optional[int]
@@ -62,6 +63,7 @@ class Column:
         stores_cellmd: Optional[bool] = None,
         value_expr_dict: Optional[dict[str, Any]] = None,
         tbl: Optional[TableVersion] = None,
+        destination: Optional[str] = None,
     ):
         """Column constructor.
 
@@ -126,6 +128,7 @@ class Column:
 
         # computed cols also have storage columns for the exception string and type
         self.sa_cellmd_col = None
+        self.destination = destination
 
     def to_md(self, pos: Optional[int] = None) -> tuple[schema.ColumnMd, Optional[schema.SchemaColumn]]:
         """Returns the Column and optional SchemaColumn metadata for this Column."""
@@ -138,6 +141,7 @@ class Column:
             schema_version_drop=self.schema_version_drop,
             value_expr=self.value_expr.as_dict() if self.value_expr is not None else None,
             stored=self.stored,
+            destination=self.destination,
         )
         if pos is None:
             return col_md, None
@@ -172,6 +176,7 @@ class Column:
             schema_version_drop=col_md.schema_version_drop,
             value_expr_dict=col_md.value_expr,
             tbl=tbl,
+            destination=col_md.destination,
         )
         return col
 

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -6,7 +6,7 @@ import json
 import logging
 from keyword import iskeyword as is_python_keyword
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Iterable, Literal, Optional, TypedDict, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Iterable, Literal, Optional, TypedDict, Union, overload
 
 from typing import _GenericAlias  # type: ignore[attr-defined]  # isort: skip
 import datetime
@@ -19,6 +19,7 @@ import pixeltable as pxt
 from pixeltable import catalog, env, exceptions as excs, exprs, index, type_system as ts
 from pixeltable.metadata import schema
 from pixeltable.metadata.utils import MetadataUtils
+from pixeltable.utils.media_store import MediaStore
 
 from ..exprs import ColumnRef
 from ..utils.description_helper import DescriptionHelper
@@ -597,6 +598,7 @@ class Table(SchemaObject):
         self,
         *,
         stored: Optional[bool] = None,
+        destination: Optional[Union[str, Path]] = None,
         print_stats: bool = False,
         on_error: Literal['abort', 'ignore'] = 'abort',
         if_exists: Literal['error', 'ignore', 'replace'] = 'error',
@@ -658,6 +660,9 @@ class Table(SchemaObject):
             if stored is not None:
                 col_schema['stored'] = stored
 
+            if destination is not None:
+                col_schema['destination'] = destination
+
             # Raise an error if the column expression refers to a column error property
             if isinstance(spec, exprs.Expr):
                 for e in spec.subexprs(expr_class=exprs.ColumnPropertyRef, traverse_matches=False):
@@ -693,7 +698,7 @@ class Table(SchemaObject):
         (on account of containing Python Callables or Exprs).
         """
         assert isinstance(spec, dict)
-        valid_keys = {'type', 'value', 'stored', 'media_validation'}
+        valid_keys = {'type', 'value', 'stored', 'media_validation', 'destination'}
         for k in spec:
             if k not in valid_keys:
                 raise excs.Error(f'Column {name}: invalid key {k!r}')
@@ -717,6 +722,10 @@ class Table(SchemaObject):
         if 'stored' in spec and not isinstance(spec['stored'], bool):
             raise excs.Error(f'Column {name}: "stored" must be a bool, got {spec["stored"]}')
 
+        d = spec.get('destination')
+        if d is not None and not isinstance(d, (str, Path)):
+            raise excs.Error(f'Column {name}: "destination" must be a string or path, got {d}')
+
     @classmethod
     def _create_columns(cls, schema: dict[str, Any]) -> list[Column]:
         """Construct list of Columns, given schema"""
@@ -727,6 +736,7 @@ class Table(SchemaObject):
             primary_key: bool = False
             media_validation: Optional[catalog.MediaValidation] = None
             stored = True
+            destination: Optional[str] = None
 
             if isinstance(spec, (ts.ColumnType, type, _GenericAlias)):
                 col_type = ts.ColumnType.normalize_type(spec, nullable_default=True, allow_builtin_types=False)
@@ -751,6 +761,8 @@ class Table(SchemaObject):
                 media_validation = (
                     catalog.MediaValidation[media_validation_str.upper()] if media_validation_str is not None else None
                 )
+                if 'destination' in spec:
+                    destination = MediaStore.validate_destination(name, spec['destination'])
             else:
                 raise excs.Error(f'Invalid value for column {name!r}')
 
@@ -761,6 +773,7 @@ class Table(SchemaObject):
                 stored=stored,
                 is_pk=primary_key,
                 media_validation=media_validation,
+                destination=destination,
             )
             columns.append(column)
         return columns
@@ -785,6 +798,10 @@ class Table(SchemaObject):
                     f'Column {col.name!r}: stored={col.stored} is not valid for image columns computed with a '
                     f'streaming function'
                 )
+            )
+        if col.destination is not None and not (col.stored and col.is_computed):
+            raise excs.Error(
+                f'Column {col.name!r}: destination={col.destination} only applies to stored computed columns'
             )
 
     @classmethod

--- a/pixeltable/exec/__init__.py
+++ b/pixeltable/exec/__init__.py
@@ -8,5 +8,6 @@ from .exec_context import ExecContext
 from .exec_node import ExecNode
 from .expr_eval import ExprEvalNode
 from .in_memory_data_node import InMemoryDataNode
+from .object_store_save_node import ObjectStoreSaveNode
 from .row_update_node import RowUpdateNode
 from .sql_node import SqlAggregationNode, SqlJoinNode, SqlLookupNode, SqlNode, SqlSampleNode, SqlScanNode

--- a/pixeltable/exec/object_store_save_node.py
+++ b/pixeltable/exec/object_store_save_node.py
@@ -11,8 +11,8 @@ from uuid import UUID
 
 from pixeltable import exprs
 from pixeltable.utils.media_store import MediaStore, TempStore
-# from pixeltable.utils.s3 import S3ClientContainer
 
+# from pixeltable.utils.s3 import S3ClientContainer
 from .data_row_batch import DataRowBatch
 from .exec_node import ExecNode
 
@@ -47,11 +47,11 @@ class ObjectStoreSaveNode(ExecNode):
         """Specify the source and destination for a WorkItem"""
 
         src_path: str  # source of the file to be processed
-        destination: str  # destination URI for the file to be processed
+        destination: Optional[str]  # destination URI for the file to be processed
 
     class WorkItem(NamedTuple):
         src_path: Path
-        destination: str
+        destination: Optional[str]
         info: exprs.ColumnSlotIdx  # column info for the file being processed
         destination_count: int = 1  # number of unique destinations for this file
 
@@ -60,7 +60,7 @@ class ObjectStoreSaveNode(ExecNode):
 
     retain_input_order: bool  # if True, return rows in the exact order they were received
     file_col_info: list[exprs.ColumnSlotIdx]
-#    boto_client_source: S3ClientContainer
+    #    boto_client_source: S3ClientContainer
 
     # execution state
     num_returned_rows: int
@@ -85,7 +85,7 @@ class ObjectStoreSaveNode(ExecNode):
         row: exprs.DataRow
         idx: Optional[int]  # position in input stream; None if we don't retain input order
         num_missing: int  # number of references to media files in this row
-        multiple_destinations: list[Path]  # paths with multiple destinations, e.g., S3 bucket and local file system
+        delete_destinations: list[Path]  # paths to delete after all copies are complete
 
     def __init__(
         self, tbl_id: UUID, file_col_info: list[exprs.ColumnSlotIdx], input: ExecNode, retain_input_order: bool = True
@@ -131,8 +131,6 @@ class ObjectStoreSaveNode(ExecNode):
                     input_batch = await self.get_input_batch(input_iter)
                     if input_batch is not None:
                         self.__process_input_batch(input_batch, executor)
-
-                print(f'\n===============>>> done={self.input_finished}, queued_work={self.queued_work}\n')
 
                 # Wait for enough completions to enable more queueing or if we're done
                 while self.queued_work > self.QUEUE_DEPTH_LOW_WATER or (self.input_finished and self.queued_work > 0):
@@ -191,8 +189,8 @@ class ObjectStoreSaveNode(ExecNode):
                 state.num_missing -= 1
                 if state.num_missing == 0:
                     # All operations for this row are complete. Delete all files which had multiple destinations
-                    for path in state.multiple_destinations:
-                        TempStore.delete_media_file(path)
+                    for src_path in state.delete_destinations:
+                        TempStore.delete_media_file(src_path)
                     del self.in_flight_rows[id(row)]
                     self.__add_ready_row(row, state.idx)
 
@@ -208,20 +206,33 @@ class ObjectStoreSaveNode(ExecNode):
             unique_destinations: dict[Path, int] = defaultdict(int)  # destination -> count of unique destinations
 
             for info in self.file_col_info:
-                url = row.file_urls[info.slot_idx]
+                col, index = info
+                # we may need to store this imagehave yet to store this image
+                if row.check_needs_saved(index, col):
+                    row.file_urls[index] = row.save_media_object(index, col, True)
+
+                url = row.file_urls[index]
                 if url is None:
                     # nothing to do
                     continue
 
-                assert row.excs[info.slot_idx] is None
-                assert info.col.col_type.is_media_type()
+                assert row.excs[index] is None
+                assert col.col_type.is_media_type()
 
-                src_path = TempStore.resolve_url(url)
-                if src_path is None:
-                    # The media url does not point to a temporary file, leave it as is
+                destination = info.col.destination
+                if MediaStore.get(destination).resolve_url(url) is not None:
+                    # The url already points to the correct destination
                     continue
 
-                destination = ''  # Placeholder for destination URI, e.g., S3 bucket or path
+                src_path = MediaStore.file_url_to_path(url)
+                if src_path is None:
+                    # The url does not point to a local file, leave it where it is
+                    continue
+
+                if destination is None and not TempStore.contains_path(src_path):
+                    # Do not copy local file URLs to the MediaStore
+                    continue
+
                 work_designator = ObjectStoreSaveNode.WorkDesignator(str(src_path), destination)
                 locations = self.in_flight_work.get(work_designator)
                 if locations is not None:
@@ -236,10 +247,10 @@ class ObjectStoreSaveNode(ExecNode):
                 num_missing += 1
                 unique_destinations[src_path] += 1
 
+            # Update work items to reflect the number of unique destinations
             new_to_do = []
-            multiple_destinations = []
             for work_item in row_to_do:
-                if unique_destinations[work_item.src_path] == 1:
+                if unique_destinations[work_item.src_path] == 1 and TempStore.contains_path(work_item.src_path):
                     new_to_do.append(work_item)
                 else:
                     new_to_do.append(
@@ -247,15 +258,16 @@ class ObjectStoreSaveNode(ExecNode):
                             work_item.src_path,
                             work_item.destination,
                             work_item.info,
-                            destination_count=unique_destinations[work_item.src_path],
+                            # +1 for the TempStore destination
+                            destination_count=unique_destinations[work_item.src_path] + 1,
                         )
                     )
-                    multiple_destinations.append(work_item.src_path)
+            delete_destinations = [k for k, v in unique_destinations.items() if v > 1 and TempStore.contains_path(k)]
             row_to_do = new_to_do
 
             if len(row_to_do) > 0:
                 self.in_flight_rows[id(row)] = self.RowState(
-                    row, row_idx, num_missing, multiple_destinations=multiple_destinations
+                    row, row_idx, num_missing, delete_destinations=delete_destinations
                 )
                 work_to_do.extend(row_to_do)
             else:
@@ -273,13 +285,12 @@ class ObjectStoreSaveNode(ExecNode):
 
         src_path = work_item.src_path
         destination = work_item.destination
-        assert destination == ''
         col = work_item.info.col
         try:
             if work_item.destination_count > 1:
-                new_file_url = MediaStore.get().copy_local_media_file(src_path, col)
+                new_file_url = MediaStore.get(destination).copy_local_media_file(src_path, col)
             else:
-                new_file_url = MediaStore.get().relocate_local_media_file(src_path, col)
+                new_file_url = MediaStore.get(destination).relocate_local_media_file(src_path, col)
             return new_file_url, None
         except Exception as e:
             _logger.debug(f'Failed to move/copy {src_path}: {e}', exc_info=e)

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -114,6 +114,8 @@ class RowBuilder:
         """
         self.unique_exprs: ExprSet[Expr] = ExprSet()  # dependencies precede their dependents
         self.next_slot_idx = 0
+        self.stored_img_cols = []
+        self.stored_media_cols = []
 
         # record input and output exprs; make copies to avoid reusing execution state
         unique_input_exprs = [self._record_unique_expr(e.copy(), recursive=False) for e in input_exprs]
@@ -245,18 +247,15 @@ class RowBuilder:
         ]
         self.array_slot_idxs = [e.slot_idx for e in self.unique_exprs if e.col_type.is_array_type()]
 
-        stored_col_info = self.output_slot_idxs()
-        self.stored_img_cols = [info for info in stored_col_info if info.col.col_type.is_image_type()]
-        self.stored_media_cols = [info for info in stored_col_info if info.col.col_type.is_media_type()]
-
     def add_table_column(self, col: catalog.Column, slot_idx: int) -> None:
         """Record a column that is part of the table row"""
         assert self.tbl is not None
-        self.table_columns.append(ColumnSlotIdx(col, slot_idx))
-
-    def output_slot_idxs(self) -> list[ColumnSlotIdx]:
-        """Return ColumnSlotIdx for output columns"""
-        return self.table_columns
+        info = ColumnSlotIdx(col, slot_idx)
+        self.table_columns.append(info)
+        if col.col_type.is_media_type():
+            self.stored_media_cols.append(info)
+            if col.col_type.is_image_type():
+                self.stored_img_cols.append(info)
 
     @property
     def num_materialized(self) -> int:

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -477,7 +477,7 @@ class RowBuilder:
                     if col.col_type.is_image_type() and data_row.file_urls[slot_idx] is None:
                         # we have yet to store this image
                         data_row.flush_img(slot_idx, col)
-                    data_row.move_tmp_media_file(slot_idx, col)
+                #                    data_row.move_tmp_media_file(slot_idx, col)
                 val = data_row.get_stored_val(slot_idx, col.get_sa_col_type())
                 table_row.append(val)
                 if col.stores_cellmd:

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -473,11 +473,6 @@ class RowBuilder:
                     # exceptions get stored in the errortype/-msg properties of the cellmd column
                     table_row.append(ColumnPropertyRef.create_cellmd_exc(exc))
             else:
-                if col.col_type.is_media_type():
-                    if col.col_type.is_image_type() and data_row.file_urls[slot_idx] is None:
-                        # we have yet to store this image
-                        data_row.flush_img(slot_idx, col)
-                #                    data_row.move_tmp_media_file(slot_idx, col)
                 val = data_row.get_stored_val(slot_idx, col.get_sa_col_type())
                 table_row.append(val)
                 if col.stores_cellmd:

--- a/pixeltable/metadata/schema.py
+++ b/pixeltable/metadata/schema.py
@@ -115,6 +115,9 @@ class ColumnMd:
     # if True, the column is present in the stored table
     stored: Optional[bool]
 
+    # If present, the URI for the destination for column values
+    destination: Optional[str] = None
+
 
 @dataclasses.dataclass
 class IndexMd:

--- a/pixeltable/utils/media_store.py
+++ b/pixeltable/utils/media_store.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 import PIL.Image
 
-from pixeltable import env
+from pixeltable import env, exceptions as excs
 
 if TYPE_CHECKING:
     from pixeltable.catalog import Column
@@ -86,12 +86,31 @@ class MediaStore:
         except (OSError, ValueError) as e:
             raise excs.Error(f'Column {col_name}: Invalid destination path: {dest}. Error: {str(e)!r}') from None
 
+    @staticmethod
+    def file_url_to_path(url: str) -> Optional[Path]:
+        """Convert a file:// URI to a Path object with support for Windows UNC paths."""
+        assert isinstance(url, str), type(url)
+        parsed = urllib.parse.urlparse(url)
+
+        # Verify it's a file scheme
+        # We should never be passed a local file path here. The "len > 1" ensures that Windows
+        # file paths aren't mistaken for URLs with a single-character scheme.
+        assert len(parsed.scheme) > 1, url
+        if parsed.scheme.lower() != 'file':
+            return None
+
+        path_str = urllib.parse.unquote(urllib.request.url2pathname(parsed.path))
+        return Path(path_str)
+
     @classmethod
-    def get(cls, base_uri: Optional[Path] = None) -> MediaStore:
-        """Get a MediaStore instance for the given base URI, or the environment's media_dir if None."""
+    def get(cls, base_uri: Optional[str] = None) -> MediaStore:
+        """Get a MediaStoreFile instance for the specified base URI, or the environment's media_dir if None."""
         if base_uri is None:
             return MediaStore(env.Env.get().media_dir)
-        raise NotImplementedError
+        base_path = cls.file_url_to_path(base_uri)
+        if base_path is None:
+            raise excs.Error(f"URI must have 'file' scheme: '{base_uri}'")
+        return MediaStore(base_path)
 
     @classmethod
     def _save_binary_media_file(cls, file_data: bytes, dest_path: Path, format: Optional[str]) -> Path:
@@ -135,6 +154,10 @@ class MediaStore:
         assert col.tbl is not None, 'Column must be associated with a table'
         return self._prepare_media_path_raw(col.tbl.id, col.id, col.tbl.version, ext)
 
+    def contains_path(self, file_path: Path) -> bool:
+        """Return True if the given path refers to a file managed by this MediaStore, else False."""
+        return str(file_path).startswith(str(self.__base_dir))
+
     def resolve_url(self, file_url: Optional[str]) -> Optional[Path]:
         """Return path if the given url refers to a file managed by this MediaStore, else None.
 
@@ -146,19 +169,13 @@ class MediaStore:
         """
         if file_url is None:
             return None
-        assert isinstance(file_url, str), type(file_url)
-        parsed = urllib.parse.urlparse(file_url)
-        # We should never be passed a local file path here. The "len > 1" ensures that Windows
-        # file paths aren't mistaken for URLs with a single-character scheme.
-        assert len(parsed.scheme) > 1, file_url
-        if parsed.scheme != 'file':
-            # remote url
+        file_path = self.file_url_to_path(file_url)
+        if file_path is None:
             return None
-        src_path = urllib.parse.unquote(urllib.request.url2pathname(parsed.path))
-        if not src_path.startswith(str(self.__base_dir)):
+        if not str(file_path).startswith(str(self.__base_dir)):
             # not a tmp file
             return None
-        return Path(src_path)
+        return file_path
 
     def relocate_local_media_file(self, src_path: Path, col: Column) -> str:
         """Relocate a local file to a MediaStore, and return its new URL"""
@@ -258,6 +275,10 @@ class TempStore:
         return MediaStore(cls._tmp_dir()).count(tbl_id)
 
     @classmethod
+    def contains_path(cls, file_path: Path) -> bool:
+        return MediaStore(cls._tmp_dir()).contains_path(file_path)
+
+    @classmethod
     def resolve_url(cls, file_url: Optional[str]) -> Optional[Path]:
         return MediaStore(cls._tmp_dir()).resolve_url(file_url)
 
@@ -266,12 +287,13 @@ class TempStore:
         return MediaStore(cls._tmp_dir()).save_media_object(data, col, format)
 
     @classmethod
-    def delete_media_file(cls, obj_path: Path) -> None:
+    def delete_media_file(cls, file_path: Path) -> None:
         """Delete a media object from the temporary store."""
-        assert obj_path is not None, 'Object path must be provided'
-        assert obj_path.exists(), f'Object path does not exist: {obj_path}'
-        assert cls.resolve_url(str(obj_path)) is not None, f'Object path is not a valid media store path: {obj_path}'
-        obj_path.unlink()
+        assert file_path is not None, 'Object path must be provided'
+        assert file_path.exists(), f'Object path does not exist: {file_path}'
+        assert cls.contains_path(file_path), f'Object path must be in the TempStore: {file_path}'
+        file_path.unlink()
+        _logger.debug(f'Media Storage: deleted {file_path}')
 
     @classmethod
     def create_path(cls, tbl_id: Optional[UUID] = None, extension: str = '') -> Path:

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -80,8 +80,8 @@ class TestDestination:
         r_dest = t.select(t.img.fileurl, t.img_rot1.fileurl, t.img_rot2.fileurl, t.img_rot3.fileurl).collect()
         print(r_dest)
 
-        dest1_uri = f'file://{valid_dest_1}'
-        dest2_uri = f'file://{valid_dest_2}'
+        dest1_uri = valid_dest_1.resolve().as_uri()
+        dest2_uri = valid_dest_2.resolve().as_uri()
         assert len(r) == 2
         assert len(r) == MediaStore.get().count(t._id)
         assert len(r) == MediaStore.get(dest1_uri).count(t._id)
@@ -112,8 +112,8 @@ class TestDestination:
         r_dest = t.select(t.img_rot1.fileurl, t.img_rot2.fileurl, t.img_rot3.fileurl, t.img_rot4.fileurl).collect()
         print(r_dest)
 
-        dest1_uri = f'file://{valid_dest_1}'
-        dest2_uri = f'file://{valid_dest_2}'
+        dest1_uri = valid_dest_1.resolve().as_uri()
+        dest2_uri = valid_dest_2.resolve().as_uri()
         assert len(r) == 2
         assert len(r) == MediaStore.get().count(t._id)
         assert len(r) == MediaStore.get(dest1_uri).count(t._id)
@@ -132,7 +132,7 @@ class TestDestination:
         valid_dest_1 = self.base_dest() / 'img_rot1'
         if not valid_dest_1.exists():
             valid_dest_1.mkdir()
-        dest1_uri = f'file://{valid_dest_1}'
+        dest1_uri = valid_dest_1.resolve().as_uri()
 
         t = pxt.create_table('test_dest', schema={'img': pxt.Image})
         t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
@@ -170,7 +170,7 @@ class TestDestination:
 
         assert len(r) == 2
 
-        dest1_uri = f'file://{valid_dest_1}'
+        dest1_uri = valid_dest_1.resolve().as_uri()
 
         # Copying a local file to the MediaStore is not allowed
         assert MediaStore.get().count(t._id) == 0

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -1,0 +1,75 @@
+import pytest
+
+from pixeltable.utils.media_store import MediaStore
+import pixeltable as pxt
+import pixeltable.exceptions as excs
+from pixeltable import env
+
+
+class TestDestination:
+    def pr_us(self, us: pxt.UpdateStatus, op: str = '') -> None:
+        """Print contents of UpdateStatus"""
+        print(f'=========================== pr_us =========================== op: {op}')
+        print(f'num_rows: {us.num_rows}')
+        print(f'num_computed_values: {us.num_computed_values}')
+        print(f'num_excs: {us.num_excs}')
+        print(f'updated_cols: {us.updated_cols}')
+        print(f'cols_with_excs: {us.cols_with_excs}')
+        print(us.row_count_stats)
+        print(us.cascade_row_count_stats)
+        print('============================================================')
+
+    def test_dest_errors(self, reset_db: None) -> None:
+        t = pxt.create_table('test_dest_errors', schema={'img': pxt.Image})
+        valid_dest = 'tests/data/'
+
+        # Basic tests of the destination parameter: types and store / computed
+        with pytest.raises(excs.Error, match='must be a string or path'):
+            t.add_computed_column(img_rot=t.img.rotate(90), destination=27)
+
+        with pytest.raises(excs.Error, match='only applies to stored computed columns'):
+            t.add_computed_column(img_rot=t.img.rotate(90), stored=False, destination=valid_dest)
+
+        with pytest.raises(excs.Error, match='only applies to stored computed columns'):
+            _ = pxt.create_table('test_dest_bad', schema={'img': {'type': pxt.Image, 'destination': f'{valid_dest}'}})
+
+        # Test destination with a non-existent directory
+        with pytest.raises(excs.Error, match='does not exist'):
+            t.add_computed_column(img_rot=t.img.rotate(90), destination='non_existent_dir/img_rot')
+
+        # Test destination with a file path instead of a directory
+        with pytest.raises(excs.Error, match='must be a directory, not a file'):
+            t.add_computed_column(
+                img_rot=t.img.rotate(90), destination='tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'
+            )
+
+        # Test with invalid scheme
+        with pytest.raises(excs.Error, match='must be a valid URI to a supported'):
+            t.add_computed_column(img_rot=t.img.rotate(90), destination='https://anything/')
+
+    def test_dest_local_2(self, reset_db: None) -> None:
+        """Test destination with two local directories"""
+
+        # Create two valid local directories for image rotation
+        base_dest = env.Env.get().tmp_dir
+        valid_dest_1 = base_dest / 'img_rot1'
+        if not valid_dest_1.exists():
+            valid_dest_1.mkdir()
+        valid_dest_2 = base_dest / 'img_rot2'
+        if not valid_dest_2.exists():
+            valid_dest_2.mkdir()
+
+        t = pxt.create_table('test_dest', schema={'img': pxt.Image})
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        t.add_computed_column(img_rot1=t.img.rotate(90), destination=None)
+        t.add_computed_column(img_rot2=t.img.rotate(180), destination=valid_dest_1)
+        t.add_computed_column(img_rot3=t.img.rotate(270), destination=valid_dest_2)
+        print(t.collect())
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        r = t.collect()
+        print(r)
+
+        assert len(r) == 2
+        assert 3 * len(r) == MediaStore.get().count(t._id)
+#        assert len(r) == MediaStore.get(valid_dest_1).count(t._id)
+#        assert len(r) == MediaStore.get(valid_dest_2).count(t._id)


### PR DESCRIPTION
Creates an ObjectStoreSaveNode which is added to plans as needed. 
Plumbs Column destination parameter through from user schema specification to implementation.
Moves all saving / moving of media files from RowBuilder.create_table_store_row into the ObjectStoreSaveNode.
Still some editing / renaming required, but all tests pass.