### PR TITLE
Enable a destination parameter on stored computed columns.

### DIFF
--- a/pixeltable/catalog/column.py
+++ b/pixeltable/catalog/column.py
@@ -34,6 +34,7 @@ class Column:
     col_type: ts.ColumnType
     stored: bool
     is_pk: bool
+    destination: Optional[str]
     _media_validation: Optional[MediaValidation]  # if not set, TableVersion.media_validation applies
     schema_version_add: Optional[int]
     schema_version_drop: Optional[int]
@@ -62,6 +63,7 @@ class Column:
         stores_cellmd: Optional[bool] = None,
         value_expr_dict: Optional[dict[str, Any]] = None,
         tbl: Optional[TableVersion] = None,
+        destination: Optional[str] = None,
     ):
         """Column constructor.
 
@@ -126,6 +128,7 @@ class Column:
 
         # computed cols also have storage columns for the exception string and type
         self.sa_cellmd_col = None
+        self.destination = destination
 
     def to_md(self, pos: Optional[int] = None) -> tuple[schema.ColumnMd, Optional[schema.SchemaColumn]]:
         """Returns the Column and optional SchemaColumn metadata for this Column."""
@@ -138,6 +141,7 @@ class Column:
             schema_version_drop=self.schema_version_drop,
             value_expr=self.value_expr.as_dict() if self.value_expr is not None else None,
             stored=self.stored,
+            destination=self.destination,
         )
         if pos is None:
             return col_md, None
@@ -172,6 +176,7 @@ class Column:
             schema_version_drop=col_md.schema_version_drop,
             value_expr_dict=col_md.value_expr,
             tbl=tbl,
+            destination=col_md.destination,
         )
         return col
 

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -234,6 +234,11 @@ class Env:
         assert self._db_url is not None  # is_local should be called only after db initialization
         return self._db_server is not None
 
+    @property
+    def cpu_count(self) -> int:
+        n_cpu = os.cpu_count()
+        return n_cpu if n_cpu is not None and n_cpu > 0 else 1
+
     @contextmanager
     def begin_xact(self, for_write: bool = False) -> Iterator[sql.Connection]:
         """

--- a/pixeltable/exec/__init__.py
+++ b/pixeltable/exec/__init__.py
@@ -8,5 +8,6 @@ from .exec_context import ExecContext
 from .exec_node import ExecNode
 from .expr_eval import ExprEvalNode
 from .in_memory_data_node import InMemoryDataNode
+from .object_store_save_node import ObjectStoreSaveNode
 from .row_update_node import RowUpdateNode
 from .sql_node import SqlAggregationNode, SqlJoinNode, SqlLookupNode, SqlNode, SqlSampleNode, SqlScanNode

--- a/pixeltable/exec/cache_prefetch_node.py
+++ b/pixeltable/exec/cache_prefetch_node.py
@@ -9,12 +9,14 @@ import urllib.request
 from collections import deque
 from concurrent import futures
 from pathlib import Path
-from typing import Any, AsyncIterator, Iterator, Optional
+from typing import AsyncIterator, Iterator, Optional
 from uuid import UUID
 
 from pixeltable import exceptions as excs, exprs
+from pixeltable.env import Env
 from pixeltable.utils.filecache import FileCache
 from pixeltable.utils.media_store import TempStore
+from pixeltable.utils.s3 import S3ClientContainer
 
 from .data_row_batch import DataRowBatch
 from .exec_node import ExecNode
@@ -26,16 +28,16 @@ class CachePrefetchNode(ExecNode):
     """Brings files with external URLs into the cache
 
     TODO:
-    - adapting the number of download threads at runtime to maximize throughput
+    - Adapt the number of download threads at runtime to maximize throughput
+    - Process a row at a time and limit the number of in-flight rows to control memory usage
     """
 
+    QUEUE_DEPTH_HIGH_WATER = 50  # target number of in-flight requests
+    QUEUE_DEPTH_LOW_WATER = 20  # target number of in-flight requests
     BATCH_SIZE = 16
-    NUM_EXECUTOR_THREADS = 16
 
     retain_input_order: bool  # if True, return rows in the exact order they were received
     file_col_info: list[exprs.ColumnSlotIdx]
-    boto_client: Optional[Any]
-    boto_client_lock: threading.Lock
 
     # execution state
     num_returned_rows: int
@@ -49,6 +51,7 @@ class CachePrefetchNode(ExecNode):
     in_flight_urls: dict[str, list[tuple[exprs.DataRow, exprs.ColumnSlotIdx]]]  # URL -> [(row, info)]
     input_finished: bool
     row_idx: Iterator[Optional[int]]
+    num_threads: int
 
     @dataclasses.dataclass
     class RowState:
@@ -64,10 +67,6 @@ class CachePrefetchNode(ExecNode):
         self.retain_input_order = retain_input_order
         self.file_col_info = file_col_info
 
-        # clients for specific services are constructed as needed, because it's time-consuming
-        self.boto_client = None
-        self.boto_client_lock = threading.Lock()
-
         self.num_returned_rows = 0
         self.ready_rows = deque()
         self.in_flight_rows = {}
@@ -75,24 +74,45 @@ class CachePrefetchNode(ExecNode):
         self.in_flight_urls = {}
         self.input_finished = False
         self.row_idx = itertools.count() if retain_input_order else itertools.repeat(None)
+        self.num_threads = max(4, Env.get().cpu_count)
+        assert self.QUEUE_DEPTH_HIGH_WATER > self.QUEUE_DEPTH_LOW_WATER
+        # Ensure that the S3ClientContainer is initialized before using threading
+        S3ClientContainer.get()
+
+    @property
+    def queued_work(self) -> int:
+        return len(self.in_flight_requests)
+
+    async def get_input_batch(self, input_iter: AsyncIterator[DataRowBatch]) -> Optional[DataRowBatch]:
+        """Get the next batch of input rows, or None if there are no more rows"""
+        try:
+            input_batch = await anext(input_iter)
+            if input_batch is None:
+                self.input_finished = True
+            return input_batch
+        except StopAsyncIteration:
+            self.input_finished = True
+            return None
 
     async def __aiter__(self) -> AsyncIterator[DataRowBatch]:
         input_iter = self.input.__aiter__()
-        with futures.ThreadPoolExecutor(max_workers=self.NUM_EXECUTOR_THREADS) as executor:
-            # we create enough in-flight requests to fill the first batch
-            while not self.input_finished and self.__num_pending_rows() < self.BATCH_SIZE:
-                await self.__submit_input_batch(input_iter, executor)
-
+        with futures.ThreadPoolExecutor(max_workers=self.num_threads) as executor:
             while True:
-                # try to assemble a full batch of output rows
-                if not self.__has_ready_batch() and len(self.in_flight_requests) > 0:
-                    self.__wait_for_requests()
+                # Create work to fill the queue to the high water mark ... ?without overrunning the in-flight row limit.
+                while not self.input_finished and self.queued_work < self.QUEUE_DEPTH_HIGH_WATER:
+                    input_batch = await self.get_input_batch(input_iter)
+                    if input_batch is not None:
+                        self.__process_input_batch(input_batch, executor)
 
-                # try to create enough in-flight requests to fill the next batch
-                while not self.input_finished and self.__num_pending_rows() < self.BATCH_SIZE:
-                    await self.__submit_input_batch(input_iter, executor)
+                # Wait for enough completions to enable more queueing or if we're done
+                while self.queued_work > self.QUEUE_DEPTH_LOW_WATER or (self.input_finished and self.queued_work > 0):
+                    done, _ = futures.wait(self.in_flight_requests, return_when=futures.FIRST_COMPLETED)
+                    self.__process_completions(done, ignore_errors=self.ctx.ignore_errors)
 
-                if len(self.ready_rows) > 0:
+                # Emit results to meet batch size requirements or empty the in-flight row queue
+                if self.__has_ready_batch() or (
+                    len(self.ready_rows) > 0 and self.input_finished and self.queued_work == 0
+                ):
                     # create DataRowBatch from the first BATCH_SIZE ready rows
                     batch = DataRowBatch(self.row_builder)
                     rows = [self.ready_rows.popleft() for _ in range(min(self.BATCH_SIZE, len(self.ready_rows)))]
@@ -103,21 +123,14 @@ class CachePrefetchNode(ExecNode):
                     _logger.debug(f'returning {len(rows)} rows')
                     yield batch
 
-                if self.input_finished and self.__num_pending_rows() == 0:
+                if self.input_finished and self.queued_work == 0 and len(self.ready_rows) == 0:
                     return
-
-    def __num_pending_rows(self) -> int:
-        return len(self.in_flight_rows) + len(self.ready_rows)
 
     def __has_ready_batch(self) -> bool:
         """True if there are >= BATCH_SIZES entries in ready_rows and the first BATCH_SIZE ones are all non-None"""
         return (
             sum(int(row is not None) for row in itertools.islice(self.ready_rows, self.BATCH_SIZE)) == self.BATCH_SIZE
         )
-
-    def __ready_prefix_len(self) -> int:
-        """Length of the non-None prefix of ready_rows (= what we can return right now)"""
-        return sum(1 for _ in itertools.takewhile(lambda x: x is not None, self.ready_rows))
 
     def __add_ready_row(self, row: exprs.DataRow, row_idx: Optional[int]) -> None:
         if row_idx is None:
@@ -129,50 +142,36 @@ class CachePrefetchNode(ExecNode):
                 self.ready_rows.extend([None] * (idx - len(self.ready_rows) + 1))
             self.ready_rows[idx] = row
 
-    def __wait_for_requests(self) -> None:
-        """Wait for in-flight requests to complete until we have a full batch of rows"""
+    def __process_completions(self, done: set[futures.Future], ignore_errors: bool) -> None:
         file_cache = FileCache.get()
-        _logger.debug(f'waiting for requests; ready_batch_size={self.__ready_prefix_len()}')
-        while not self.__has_ready_batch() and len(self.in_flight_requests) > 0:
-            done, _ = futures.wait(self.in_flight_requests, return_when=futures.FIRST_COMPLETED)
-            for f in done:
-                url = self.in_flight_requests.pop(f)
-                tmp_path, exc = f.result()
-                local_path: Optional[Path] = None
-                if tmp_path is not None:
-                    # register the file with the cache for the first column in which it's missing
-                    assert url in self.in_flight_urls
-                    _, info = self.in_flight_urls[url][0]
-                    local_path = file_cache.add(info.col.tbl.id, info.col.id, url, tmp_path)
-                    _logger.debug(f'cached {url} as {local_path}')
+        for f in done:
+            url = self.in_flight_requests.pop(f)
+            tmp_path, exc = f.result()
+            if exc is not None and not ignore_errors:
+                raise exc
+            local_path: Optional[Path] = None
+            if tmp_path is not None:
+                # register the file with the cache for the first column in which it's missing
+                assert url in self.in_flight_urls
+                _, info = self.in_flight_urls[url][0]
+                local_path = file_cache.add(info.col.tbl.id, info.col.id, url, tmp_path)
+                _logger.debug(f'cached {url} as {local_path}')
 
-                # add the local path/exception to the slots that reference the url
-                for row, info in self.in_flight_urls.pop(url):
-                    if exc is not None:
-                        self.row_builder.set_exc(row, info.slot_idx, exc)
-                    else:
-                        assert local_path is not None
-                        row.set_file_path(info.slot_idx, str(local_path))
-                    state = self.in_flight_rows[id(row)]
-                    state.num_missing -= 1
-                    if state.num_missing == 0:
-                        del self.in_flight_rows[id(row)]
-                        self.__add_ready_row(row, state.idx)
-                        _logger.debug(f'row {state.idx} is ready (ready_batch_size={self.__ready_prefix_len()})')
+            # add the local path/exception to the slots that reference the url
+            for row, info in self.in_flight_urls.pop(url):
+                if exc is not None:
+                    self.row_builder.set_exc(row, info.slot_idx, exc)
+                else:
+                    assert local_path is not None
+                    row.set_file_path(info.slot_idx, str(local_path))
+                state = self.in_flight_rows[id(row)]
+                state.num_missing -= 1
+                if state.num_missing == 0:
+                    del self.in_flight_rows[id(row)]
+                    self.__add_ready_row(row, state.idx)
 
-    async def __submit_input_batch(
-        self, input: AsyncIterator[DataRowBatch], executor: futures.ThreadPoolExecutor
-    ) -> None:
-        assert not self.input_finished
-        input_batch: Optional[DataRowBatch]
-        try:
-            input_batch = await anext(input)
-        except StopAsyncIteration:
-            input_batch = None
-        if input_batch is None:
-            self.input_finished = True
-            return
-
+    def __process_input_batch(self, input_batch: DataRowBatch, executor: futures.ThreadPoolExecutor) -> None:
+        """Process a batch of input rows, submitting URLs for download and adding ready rows to ready_rows"""
         file_cache = FileCache.get()
 
         # URLs from this input batch that aren't already in the file cache;
@@ -180,7 +179,7 @@ class CachePrefetchNode(ExecNode):
         # the time it takes to get the next batch together
         cache_misses: list[str] = []
 
-        url_pos: dict[str, int] = {}  # url -> row_idx; used for logging
+        url_pos: dict[str, Optional[int]] = {}  # url -> row_idx; used for logging
         for row in input_batch:
             # identify missing local files in input batch, or fill in their paths if they're already cached
             num_missing = 0
@@ -235,18 +234,8 @@ class CachePrefetchNode(ExecNode):
         try:
             _logger.debug(f'Downloading {url} to {tmp_path}')
             if parsed.scheme == 's3':
-                from pixeltable.utils.s3 import get_client
-
-                with self.boto_client_lock:
-                    if self.boto_client is None:
-                        config = {
-                            'max_pool_connections': self.NUM_EXECUTOR_THREADS + 4,  # +4: leave some headroom
-                            'connect_timeout': 5,
-                            'read_timeout': 30,
-                            'retries': {'max_attempts': 3, 'mode': 'adaptive'},
-                        }
-                        self.boto_client = get_client(**config)
-                self.boto_client.download_file(parsed.netloc, parsed.path.lstrip('/'), str(tmp_path))
+                client = S3ClientContainer.get().get_client(for_write=False)
+                client.download_file(parsed.netloc, parsed.path.lstrip('/'), str(tmp_path))
             elif parsed.scheme in ('http', 'https'):
                 with urllib.request.urlopen(url) as resp, open(tmp_path, 'wb') as f:
                     data = resp.read()
@@ -259,6 +248,4 @@ class CachePrefetchNode(ExecNode):
             # we want to add the file url to the exception message
             exc = excs.Error(f'Failed to download {url}: {e}')
             _logger.debug(f'Failed to download {url}: {e}', exc_info=e)
-            if not self.ctx.ignore_errors:
-                raise exc from None  # suppress original exception
             return None, exc

--- a/pixeltable/exec/object_store_save_node.py
+++ b/pixeltable/exec/object_store_save_node.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import dataclasses
+import itertools
+import logging
+from collections import defaultdict, deque
+from concurrent import futures
+from pathlib import Path
+from typing import AsyncIterator, Iterator, NamedTuple, Optional
+from uuid import UUID
+
+from pixeltable import exprs
+from pixeltable.env import Env
+from pixeltable.utils.media_destination import MediaDestination
+from pixeltable.utils.media_store import MediaStore, TempStore
+from pixeltable.utils.s3 import S3ClientContainer
+
+from .data_row_batch import DataRowBatch
+from .exec_node import ExecNode
+
+_logger = logging.getLogger('pixeltable')
+
+
+class ObjectStoreSaveNode(ExecNode):
+    """Brings files with external URLs into the cache
+
+    Each row may have multipe files that need to be saved to a destination.
+    Each file may be referenced by more than one column in the row.
+    Each file may have multiple destinations, e.g., S3 bucket and local file system.
+    If there are multiple destinations, the file cannot be moved to any destination
+    until it has been copied to all of the other destinations.
+    Diagrammatically:
+        Row -> [src_path1, src_path2, ...]
+            src_path -> [dest1, dest2, ...]
+                dest1: [row_location1, row_location2, ...]
+    Paths with multiple destinations are removed from the TempStore only after all destination copies are complete.
+
+    TODO:
+    - Adapt the number of download threads at runtime to maximize throughput
+    - Process a row at a time and limit the number of in-flight rows to control memory usage
+    """
+
+    QUEUE_DEPTH_HIGH_WATER = 50  # target number of in-flight requests
+    QUEUE_DEPTH_LOW_WATER = 20  # target number of in-flight requests
+    BATCH_SIZE = 16
+
+    class WorkDesignator(NamedTuple):
+        """Specify the source and destination for a WorkItem"""
+
+        src_path: str  # source of the file to be processed
+        destination: Optional[str]  # destination URI for the file to be processed
+
+    class WorkItem(NamedTuple):
+        src_path: Path
+        destination: Optional[str]
+        info: exprs.ColumnSlotIdx  # column info for the file being processed
+        destination_count: int = 1  # number of unique destinations for this file
+
+        def pp(self) -> str:
+            return f'WorkItem(src_path={self.src_path}, slot_idx={self.info.slot_idx}, info={self.info})'
+
+    retain_input_order: bool  # if True, return rows in the exact order they were received
+    file_col_info: list[exprs.ColumnSlotIdx]
+
+    # execution state
+    num_returned_rows: int
+
+    # ready_rows: rows that are ready to be returned, ordered by row idx;
+    # the implied row idx of ready_rows[0] is num_returned_rows
+    ready_rows: deque[Optional[exprs.DataRow]]
+
+    in_flight_rows: dict[int, ObjectStoreSaveNode.RowState]  # rows with in-flight work; id(row) -> RowState
+    in_flight_requests: dict[
+        futures.Future, WorkDesignator
+    ]  # in-flight requests to save paths: Future -> WorkDesignator
+    in_flight_work: dict[
+        WorkDesignator, list[tuple[exprs.DataRow, exprs.ColumnSlotIdx]]
+    ]  # WorkDesignator -> [(row, info)]
+
+    input_finished: bool
+    row_idx: Iterator[Optional[int]]
+    num_threads: int
+
+    @dataclasses.dataclass
+    class RowState:
+        row: exprs.DataRow
+        idx: Optional[int]  # position in input stream; None if we don't retain input order
+        num_missing: int  # number of references to media files in this row
+        delete_destinations: list[Path]  # paths to delete after all copies are complete
+
+    def __init__(
+        self, tbl_id: UUID, file_col_info: list[exprs.ColumnSlotIdx], input: ExecNode, retain_input_order: bool = True
+    ):
+        # input_/output_exprs=[]: we don't have anything to evaluate
+        super().__init__(input.row_builder, [], [], input)
+        self.retain_input_order = retain_input_order
+        self.file_col_info = file_col_info
+
+        self.num_returned_rows = 0
+        self.ready_rows = deque()
+        self.in_flight_rows = {}
+        self.in_flight_requests = {}
+        self.in_flight_work = {}
+        self.input_finished = False
+        self.row_idx = itertools.count() if retain_input_order else itertools.repeat(None)
+        self.num_threads = max(4, Env.get().cpu_count)
+        assert self.QUEUE_DEPTH_HIGH_WATER > self.QUEUE_DEPTH_LOW_WATER
+        # Ensure that the S3ClientContainer is initialized before using threading
+        S3ClientContainer.get()
+
+    @property
+    def queued_work(self) -> int:
+        return len(self.in_flight_requests)
+
+    async def get_input_batch(self, input_iter: AsyncIterator[DataRowBatch]) -> Optional[DataRowBatch]:
+        """Get the next batch of input rows, or None if there are no more rows"""
+        try:
+            input_batch = await anext(input_iter)
+            if input_batch is None:
+                self.input_finished = True
+            return input_batch
+        except StopAsyncIteration:
+            self.input_finished = True
+            return None
+
+    async def __aiter__(self) -> AsyncIterator[DataRowBatch]:
+        input_iter = self.input.__aiter__()
+        with futures.ThreadPoolExecutor(max_workers=self.num_threads) as executor:
+            while True:
+                # Create work to fill the queue to the high water mark ... ?without overrunning the in-flight row limit.
+                while not self.input_finished and self.queued_work < self.QUEUE_DEPTH_HIGH_WATER:
+                    input_batch = await self.get_input_batch(input_iter)
+                    if input_batch is not None:
+                        self.__process_input_batch(input_batch, executor)
+
+                # Wait for enough completions to enable more queueing or if we're done
+                while self.queued_work > self.QUEUE_DEPTH_LOW_WATER or (self.input_finished and self.queued_work > 0):
+                    done, _ = futures.wait(self.in_flight_requests, return_when=futures.FIRST_COMPLETED)
+                    self.__process_completions(done, ignore_errors=self.ctx.ignore_errors)
+
+                # Emit results to meet batch size requirements or empty the in-flight row queue
+                if self.__has_ready_batch() or (
+                    len(self.ready_rows) > 0 and self.input_finished and self.queued_work == 0
+                ):
+                    # create DataRowBatch from the first BATCH_SIZE ready rows
+                    batch = DataRowBatch(self.row_builder)
+                    rows = [self.ready_rows.popleft() for _ in range(min(self.BATCH_SIZE, len(self.ready_rows)))]
+                    for row in rows:
+                        assert row is not None
+                        batch.add_row(row)
+                    self.num_returned_rows += len(rows)
+                    _logger.debug(f'returning {len(rows)} rows')
+                    yield batch
+
+                if self.input_finished and self.queued_work == 0 and len(self.ready_rows) == 0:
+                    return
+
+    def __has_ready_batch(self) -> bool:
+        """True if there are >= BATCH_SIZES entries in ready_rows and the first BATCH_SIZE ones are all non-None"""
+        return (
+            sum(int(row is not None) for row in itertools.islice(self.ready_rows, self.BATCH_SIZE)) == self.BATCH_SIZE
+        )
+
+    def __add_ready_row(self, row: exprs.DataRow, row_idx: Optional[int]) -> None:
+        if row_idx is None:
+            self.ready_rows.append(row)
+        else:
+            # extend ready_rows to accommodate row_idx
+            idx = row_idx - self.num_returned_rows
+            if idx >= len(self.ready_rows):
+                self.ready_rows.extend([None] * (idx - len(self.ready_rows) + 1))
+            self.ready_rows[idx] = row
+
+    def __process_completions(self, done: set[futures.Future], ignore_errors: bool) -> None:
+        for f in done:
+            work_designator = self.in_flight_requests.pop(f)
+            new_file_url, exc = f.result()
+            if exc is not None and not ignore_errors:
+                raise exc
+            assert new_file_url is not None
+
+            # add the local path/exception to the slots that reference the url
+            for row, info in self.in_flight_work.pop(work_designator):
+                if exc is not None:
+                    self.row_builder.set_exc(row, info.slot_idx, exc)
+                else:
+                    row.file_urls[info.slot_idx] = new_file_url
+
+                state = self.in_flight_rows[id(row)]
+                state.num_missing -= 1
+                if state.num_missing == 0:
+                    # All operations for this row are complete. Delete all files which had multiple destinations
+                    for src_path in state.delete_destinations:
+                        TempStore.delete_media_file(src_path)
+                    del self.in_flight_rows[id(row)]
+                    self.__add_ready_row(row, state.idx)
+
+    def __process_input_row(self, row: exprs.DataRow) -> list[ObjectStoreSaveNode.WorkItem]:
+        """Process a batch of input rows, generating a list of work"""
+        # Create a list of work to do for media storage in this row
+        row_idx = next(self.row_idx)
+        row_to_do: list[ObjectStoreSaveNode.WorkItem] = []
+        num_missing = 0
+        unique_destinations: dict[Path, int] = defaultdict(int)  # destination -> count of unique destinations
+
+        for info in self.file_col_info:
+            col, index = info
+            # we may need to store this imagehave yet to store this image
+            if row.check_must_save(index, col):
+                row.file_urls[index] = row.save_media_object(index, col, True)
+
+            url = row.file_urls[index]
+            if url is None:
+                # nothing to do
+                continue
+
+            assert row.excs[index] is None
+            assert col.col_type.is_media_type()
+
+            destination = info.col.destination
+            if (
+                destination is not None
+                and not destination.startswith('s3://')
+                and MediaStore.get(destination).resolve_url(url) is not None
+            ):
+                # A local non-default destination was specified, and the url already points there
+                continue
+
+            src_path = MediaStore.file_url_to_path(url)
+            if src_path is None:
+                # The url does not point to a local file, do not attempt to copy/move it
+                continue
+
+            if destination is None and not TempStore.contains_path(src_path):
+                # Do not copy local file URLs to the MediaStore
+                continue
+
+            work_designator = ObjectStoreSaveNode.WorkDesignator(str(src_path), destination)
+            locations = self.in_flight_work.get(work_designator)
+            if locations is not None:
+                # we've already seen this
+                locations.append((row, info))
+                num_missing += 1
+                continue
+
+            work_item = ObjectStoreSaveNode.WorkItem(src_path, destination, info)
+            row_to_do.append(work_item)
+            self.in_flight_work[work_designator] = [(row, info)]
+            num_missing += 1
+            unique_destinations[src_path] += 1
+
+        # Update work items to reflect the number of unique destinations
+        new_to_do = []
+        for work_item in row_to_do:
+            if unique_destinations[work_item.src_path] == 1 and TempStore.contains_path(work_item.src_path):
+                new_to_do.append(work_item)
+            else:
+                new_to_do.append(
+                    ObjectStoreSaveNode.WorkItem(
+                        work_item.src_path,
+                        work_item.destination,
+                        work_item.info,
+                        destination_count=unique_destinations[work_item.src_path] + 1,
+                        # +1 for the TempStore destination
+                    )
+                )
+        delete_destinations = [k for k, v in unique_destinations.items() if v > 1 and TempStore.contains_path(k)]
+        row_to_do = new_to_do
+
+        if len(row_to_do) > 0:
+            self.in_flight_rows[id(row)] = self.RowState(
+                row, row_idx, num_missing, delete_destinations=delete_destinations
+            )
+        else:
+            self.__add_ready_row(row, row_idx)
+        return row_to_do
+
+    def __process_input_batch(self, input_batch: DataRowBatch, executor: futures.ThreadPoolExecutor) -> None:
+        """Process a batch of input rows, submitting temporary files for upload"""
+        work_to_do: list[ObjectStoreSaveNode.WorkItem] = []
+
+        for row in input_batch:
+            row_to_do = self.__process_input_row(row)
+            if len(row_to_do) > 0:
+                work_to_do.extend(row_to_do)
+
+        for work_item in work_to_do:
+            f = executor.submit(self.__persist_media_file, work_item)
+            self.in_flight_requests[f] = ObjectStoreSaveNode.WorkDesignator(
+                str(work_item.src_path), work_item.destination
+            )
+            _logger.debug(f'submitted {work_item}')
+
+    def __persist_media_file(self, work_item: WorkItem) -> tuple[Optional[str], Optional[Exception]]:
+        """Move data from the TempStore to another location"""
+        src_path = work_item.src_path
+        col = work_item.info.col
+        assert col.destination == work_item.destination
+        try:
+            new_file_url = MediaDestination.put_file(col, src_path, work_item.destination_count == 1)
+            return new_file_url, None
+        except Exception as e:
+            _logger.debug(f'Failed to move/copy {src_path}: {e}', exc_info=e)
+            return None, e

--- a/pixeltable/exprs/data_row.py
+++ b/pixeltable/exprs/data_row.py
@@ -258,41 +258,50 @@ class DataRow:
         self.has_val[idx] = True
 
     def flush_img(self, index: int, col: Optional[catalog.Column] = None) -> None:
-        """Save or discard the in-memory value (required to be a PIL.Image.Image)"""
+        if self.check_must_save(index, col):
+            assert col is not None
+            self.file_urls[index] = self.save_media_object(index, col)
+
+    def check_must_save(self, index: int, col: Optional[catalog.Column] = None) -> bool:
+        """Return true if the media object in the column needs to be saved, discard unneeded values"""
         if self.vals[index] is None:
-            return
+            return False
+
+        if self.file_urls[index] is not None:
+            return False
+
         assert self.excs[index] is None
         if self.file_paths[index] is None:
             if col is not None:
-                image = self.vals[index]
-                format = None
-                if isinstance(image, PIL.Image.Image):
-                    # Default to JPEG unless the image has a transparency layer (which isn't supported by JPEG).
-                    # In that case, use WebP instead.
-                    format = 'webp' if image.has_transparency_data else 'jpeg'
-                filepath, url = MediaStore.get().save_media_object(image, col, format=format)
-                self.file_paths[index] = str(filepath)
-                self.file_urls[index] = url
+                # This is a media object that needs to be saved
+                return True
             else:
-                # we discard the content of this cell
+                # This is a media object that we don't care about, so we discard it
                 self.has_val[index] = False
         else:
             # we already have a file for this image, nothing left to do
             pass
-        self.vals[index] = None
 
-    def move_tmp_media_file(self, index: int, col: catalog.Column) -> None:
-        """If a media url refers to data in a temporary file, move the data to a MediaStore"""
-        if self.file_urls[index] is None:
-            return
-        assert self.excs[index] is None
+        self.vals[index] = None
+        return False
+
+    def save_media_object(self, index: int, col: catalog.Column, to_temp: bool = False) -> str:
+        """Save the media object in the column to the column MediaStore file destination or TempStore.
+        Objects cannot be saved directly to general destinations."""
         assert col.col_type.is_media_type()
-        src_path = TempStore.resolve_url(self.file_urls[index])
-        if src_path is None:
-            # The media url does not point to a temporary file, leave it as is
-            return
-        new_file_url = MediaStore.get().relocate_local_media_file(src_path, col)
-        self.file_urls[index] = new_file_url
+        val = self.vals[index]
+        format = None
+        if isinstance(val, PIL.Image.Image):
+            # Default to JPEG unless the image has a transparency layer (which isn't supported by JPEG).
+            # In that case, use WebP instead.
+            format = 'webp' if val.has_transparency_data else 'jpeg'
+        if to_temp:
+            filepath, url = TempStore.save_media_object(val, col, format=format)
+        else:
+            filepath, url = MediaStore.get(col.destination).save_media_object(val, col, format=format)
+        self.file_paths[index] = str(filepath) if filepath is not None else None
+        self.vals[index] = None
+        return url
 
     @property
     def rowid(self) -> tuple[int, ...]:

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -474,11 +474,6 @@ class RowBuilder:
                     # exceptions get stored in the errortype/-msg properties of the cellmd column
                     table_row.append(ColumnPropertyRef.create_cellmd_exc(exc))
             else:
-                if col.col_type.is_media_type():
-                    if col.col_type.is_image_type() and data_row.file_urls[slot_idx] is None:
-                        # we have yet to store this image
-                        data_row.flush_img(slot_idx, col)
-                    data_row.move_tmp_media_file(slot_idx, col)
                 val = data_row.get_stored_val(slot_idx, col.get_sa_col_type())
                 table_row.append(val)
                 if col.stores_cellmd:

--- a/pixeltable/metadata/schema.py
+++ b/pixeltable/metadata/schema.py
@@ -115,6 +115,9 @@ class ColumnMd:
     # if True, the column is present in the stored table
     stored: Optional[bool]
 
+    # If present, the URI for the destination for column values
+    destination: Optional[str] = None
+
 
 @dataclasses.dataclass
 class IndexMd:

--- a/pixeltable/share/publish.py
+++ b/pixeltable/share/publish.py
@@ -83,7 +83,7 @@ def push_replica(
 
 
 def _upload_bundle_to_s3(bundle: Path, parsed_location: urllib.parse.ParseResult) -> None:
-    from pixeltable.utils.s3 import get_client
+    from pixeltable.utils.s3 import S3ClientContainer
 
     bucket = parsed_location.netloc
     remote_dir = Path(urllib.parse.unquote(urllib.request.url2pathname(parsed_location.path)))
@@ -91,8 +91,7 @@ def _upload_bundle_to_s3(bundle: Path, parsed_location: urllib.parse.ParseResult
 
     Env.get().console_logger.info(f'Uploading snapshot to: {bucket}:{remote_path}')
 
-    boto_config = {'max_pool_connections': 5, 'connect_timeout': 15, 'retries': {'max_attempts': 3, 'mode': 'adaptive'}}
-    s3_client = get_client(**boto_config)
+    s3_client = S3ClientContainer.get().get_client(for_write=True)
 
     upload_args = {'ChecksumAlgorithm': 'SHA256'}
 
@@ -140,7 +139,7 @@ def pull_replica(dest_path: str, src_tbl_uri: str) -> pxt.Table:
 
 
 def _download_bundle_from_s3(parsed_location: urllib.parse.ParseResult, bundle_filename: str) -> Path:
-    from pixeltable.utils.s3 import get_client
+    from pixeltable.utils.s3 import S3ClientContainer
 
     bucket = parsed_location.netloc
     remote_dir = Path(urllib.parse.unquote(urllib.request.url2pathname(parsed_location.path)))
@@ -148,8 +147,7 @@ def _download_bundle_from_s3(parsed_location: urllib.parse.ParseResult, bundle_f
 
     Env.get().console_logger.info(f'Downloading snapshot from: {bucket}:{remote_path}')
 
-    boto_config = {'max_pool_connections': 5, 'connect_timeout': 15, 'retries': {'max_attempts': 3, 'mode': 'adaptive'}}
-    s3_client = get_client(**boto_config)
+    s3_client = S3ClientContainer.get().get_client(for_write=False)
 
     obj = s3_client.head_object(Bucket=bucket, Key=remote_path)  # Check if the object exists
     bundle_size = obj['ContentLength']

--- a/pixeltable/utils/media_destination.py
+++ b/pixeltable/utils/media_destination.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, Union
+from uuid import UUID
+
+import PIL.Image
+
+from pixeltable import exceptions as excs
+from pixeltable.utils.media_store import MediaStore, TempStore
+
+if TYPE_CHECKING:
+    from pixeltable.catalog import Column
+
+
+class MediaDestination:
+    @classmethod
+    def validate_destination(cls, col_name: Optional[str], dest: Union[str, Path, None]) -> str:
+        """Convert a Column destination parameter to a URI, else raise errors.
+        Args:
+            col_name: Used to raise error messages
+            dest: The requested destination
+        Returns:
+            URI of destination, or raises an error
+        """
+        from pixeltable.utils.s3_store import S3Store
+
+        if dest is None or isinstance(dest, Path):
+            return MediaStore.validate_destination(col_name, dest)
+        if not isinstance(dest, str):
+            raise excs.Error(f'Column {col_name}: "destination" must be a string or path, got {dest!r}')
+        if dest.startswith('s3://'):
+            dest2 = S3Store(dest).validate_uri()
+            if dest2 is None:
+                raise excs.Error(f'Column {col_name}: invalid S3 destination {dest!r}')
+            return dest2
+        # Check for "gs://" and Azure variants here
+        return MediaStore.validate_destination(col_name, dest)
+
+    def save_media_object(self, val: Any, col: Column, to_temp: bool = False) -> tuple[Optional[Path], str]:
+        """Save the media object in the column to the destination or TempStore"""
+        assert col.col_type.is_media_type()
+        format = None
+        if isinstance(val, PIL.Image.Image):
+            # Default to JPEG unless the image has a transparency layer (which isn't supported by JPEG).
+            # In that case, use WebP instead.
+            format = 'webp' if val.has_transparency_data else 'jpeg'
+        if to_temp:
+            filepath, url = TempStore.save_media_object(val, col, format=format)
+        else:
+            filepath, url = MediaStore.get(col.destination).save_media_object(val, col, format=format)
+        return filepath, url
+
+    @classmethod
+    def put_file(cls, col: Column, src_path: Path, can_relocate: bool) -> str:
+        """Move or copy a file to the destination, returning the file's URL within the destination."""
+        from pixeltable.utils.s3_store import S3Store
+
+        destination = col.destination
+        if destination is not None and destination.startswith('s3'):
+            # If the destination is 's3', we need to copy the file to S3
+            new_file_url = S3Store(destination).copy_local_media_file(col, src_path)
+            if can_relocate:
+                # File is temporary, used only once, so we can delete it after copy
+                assert TempStore.contains_path(src_path)
+                TempStore.delete_media_file(src_path)
+            return new_file_url
+        if can_relocate:
+            new_file_url = MediaStore.get(destination).relocate_local_media_file(src_path, col)
+        else:
+            new_file_url = MediaStore.get(destination).copy_local_media_file(src_path, col)
+        return new_file_url
+
+    @classmethod
+    def delete(cls, destination: Optional[str], tbl_id: UUID, tbl_version: Optional[int] = None) -> None:
+        """Delete media files in the destination URI for a given table ID"""
+        from pixeltable.utils.s3_store import S3Store
+
+        if destination is not None and destination.startswith('s3://'):
+            S3Store(destination).delete(tbl_id, tbl_version)
+        else:
+            MediaStore.get(destination).delete(tbl_id, tbl_version)
+
+    @classmethod
+    def count(cls, uri: Optional[str], tbl_id: UUID) -> int:
+        """Return the count of media files in the destination URI for a given table ID"""
+        if uri is not None and uri.startswith('s3://'):
+            from pixeltable.utils.s3_store import S3Store
+
+            # If the URI is an S3 URI, use the S3Store to count media files
+            return S3Store(uri).count(tbl_id)
+        # Check for "gs://" and Azure variants here
+        return MediaStore.get(uri).count(tbl_id)

--- a/pixeltable/utils/media_store.py
+++ b/pixeltable/utils/media_store.py
@@ -10,12 +10,13 @@ import urllib.request
 import uuid
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 from uuid import UUID
 
 import PIL.Image
 
-from pixeltable import env
+from pixeltable import env, exceptions as excs
+from pixeltable.utils.media_path import MediaPath
 
 if TYPE_CHECKING:
     from pixeltable.catalog import Column
@@ -32,7 +33,6 @@ class MediaStore:
     or all files created for a particular version of a table
     """
 
-    pattern = re.compile(r'([0-9a-fA-F]+)_(\d+)_(\d+)_([0-9a-fA-F]+)')  # tbl_id, col_id, version, uuid
     __base_dir: Path
 
     def __init__(self, base_dir: Path):
@@ -40,12 +40,77 @@ class MediaStore:
         assert isinstance(base_dir, Path), 'Base directory must be a Path instance.'
         self.__base_dir = base_dir
 
+    @staticmethod
+    def validate_destination(col_name: str, dest: Union[str, Path]) -> str:
+        """Convert a Column destination parameter to a URI, else raise errors."""
+        if isinstance(dest, Path):
+            dest_path = dest
+        elif not isinstance(dest, str):
+            raise excs.Error(f'Column {col_name}: "destination" must be a string or path, got {dest!r}')
+        else:
+            # Check if it's already a valid URI scheme
+            valid_schemes: set[str] = set()  # {'s3', 'gs', 'azure'}
+            parsed = urllib.parse.urlparse(dest)
+            if parsed.scheme:
+                # For file:// URIs, check if it points to a directory
+                # len(parsed.scheme) == 1 handles Windows drive letters like C:\
+                if parsed.scheme.lower() == 'file' or len(parsed.scheme) == 1:
+                    path_str = urllib.parse.unquote(urllib.request.url2pathname(parsed.path))
+                    dest_path = Path(path_str)
+                elif parsed.scheme.lower() in valid_schemes:
+                    # If it's a valid scheme, treat it as a URI and do no further checking
+                    return dest
+                else:
+                    raise excs.Error(
+                        f'Column {col_name}: "destination" must be a valid URI to a supported destination, got {dest}'
+                    )
+            else:
+                # If no scheme, treat as local file path
+                dest_path = Path(dest)
+
+        # Check if path exists and validate it's a directory
+        if not dest_path.exists():
+            raise excs.Error(f'Column {col_name}: "destination" does not exist: {dest}')
+        if not dest_path.is_dir():
+            raise excs.Error(f'Column {col_name}: "destination" must be a directory, not a file: {dest}')
+
+        # Check if path is absolute
+        if dest_path.is_absolute():
+            # Convert to file URI
+            return dest_path.as_uri()
+
+        # For relative paths, convert to absolute first
+        try:
+            absolute_path = dest_path.resolve()
+            return absolute_path.as_uri()
+        except (OSError, ValueError) as e:
+            raise excs.Error(f'Column {col_name}: Invalid destination path: {dest}. Error: {str(e)!r}') from None
+
+    @staticmethod
+    def file_url_to_path(url: str) -> Optional[Path]:
+        """Convert a file:// URI to a Path object with support for Windows UNC paths."""
+        assert isinstance(url, str), type(url)
+        parsed = urllib.parse.urlparse(url)
+
+        # Verify it's a file scheme
+        # We should never be passed a local file path here. The "len > 1" ensures that Windows
+        # file paths aren't mistaken for URLs with a single-character scheme.
+        assert len(parsed.scheme) > 1, url
+        if parsed.scheme.lower() != 'file':
+            return None
+
+        path_str = urllib.parse.unquote(urllib.request.url2pathname(parsed.path))
+        return Path(path_str)
+
     @classmethod
-    def get(cls, base_uri: Optional[Path] = None) -> MediaStore:
-        """Get a MediaStore instance for the given base URI, or the environment's media_dir if None."""
+    def get(cls, base_uri: Optional[str] = None) -> MediaStore:
+        """Get a MediaStoreFile instance for the specified base URI, or the environment's media_dir if None."""
         if base_uri is None:
             return MediaStore(env.Env.get().media_dir)
-        raise NotImplementedError
+        base_path = cls.file_url_to_path(base_uri)
+        if base_path is None:
+            raise excs.Error(f"URI must have 'file' scheme: '{base_uri}'")
+        return MediaStore(base_path)
 
     @classmethod
     def _save_binary_media_file(cls, file_data: bytes, dest_path: Path, format: Optional[str]) -> Path:
@@ -75,10 +140,10 @@ class MediaStore:
         for the new Path if it does not already exist. The Path will reside in
         the environment's media_dir.
         """
-        id_hex = uuid.uuid4().hex
-        parent = self.__base_dir / tbl_id.hex / id_hex[:2] / id_hex[:4]
+        prefix, filename = MediaPath.media_prefix_file_raw(tbl_id, col_id, tbl_version, ext)
+        parent = self.__base_dir / Path(prefix)
         parent.mkdir(parents=True, exist_ok=True)
-        return parent / f'{tbl_id.hex}_{col_id}_{tbl_version}_{id_hex}{ext or ""}'
+        return parent / filename
 
     def _prepare_media_path(self, col: Column, ext: Optional[str] = None) -> Path:
         """
@@ -86,8 +151,14 @@ class MediaStore:
         for the new Path if it does not already exist. The Path will reside in
         the environment's media_dir.
         """
-        assert col.tbl is not None, 'Column must be associated with a table'
-        return self._prepare_media_path_raw(col.tbl.id, col.id, col.tbl.version, ext)
+        prefix, filename = MediaPath.media_prefix_file(col, ext)
+        parent = self.__base_dir / Path(prefix)
+        parent.mkdir(parents=True, exist_ok=True)
+        return parent / filename
+
+    def contains_path(self, file_path: Path) -> bool:
+        """Return True if the given path refers to a file managed by this MediaStore, else False."""
+        return str(file_path).startswith(str(self.__base_dir))
 
     def resolve_url(self, file_url: Optional[str]) -> Optional[Path]:
         """Return path if the given url refers to a file managed by this MediaStore, else None.
@@ -100,19 +171,13 @@ class MediaStore:
         """
         if file_url is None:
             return None
-        assert isinstance(file_url, str), type(file_url)
-        parsed = urllib.parse.urlparse(file_url)
-        # We should never be passed a local file path here. The "len > 1" ensures that Windows
-        # file paths aren't mistaken for URLs with a single-character scheme.
-        assert len(parsed.scheme) > 1, file_url
-        if parsed.scheme != 'file':
-            # remote url
+        file_path = self.file_url_to_path(file_url)
+        if file_path is None:
             return None
-        src_path = urllib.parse.unquote(urllib.request.url2pathname(parsed.path))
-        if not src_path.startswith(str(self.__base_dir)):
+        if not str(file_path).startswith(str(self.__base_dir)):
             # not a tmp file
             return None
-        return Path(src_path)
+        return file_path
 
     def relocate_local_media_file(self, src_path: Path, col: Column) -> str:
         """Relocate a local file to a MediaStore, and return its new URL"""
@@ -151,14 +216,17 @@ class MediaStore:
         """Delete all files belonging to tbl_id. If tbl_version is not None, delete
         only those files belonging to the specified tbl_version."""
         assert tbl_id is not None
+        table_prefix = MediaPath.media_table_prefix(tbl_id)
         if tbl_version is None:
             # Remove the entire folder for this table id.
-            path = self.__base_dir / tbl_id.hex
+            path = self.__base_dir / table_prefix
             if path.exists():
                 shutil.rmtree(path)
         else:
             # Remove only the elements for the specified tbl_version.
-            paths = glob.glob(str(self.__base_dir / tbl_id.hex) + f'/**/{tbl_id.hex}_*_{tbl_version}_*', recursive=True)
+            paths = glob.glob(
+                str(self.__base_dir / table_prefix) + f'/**/{table_prefix}_*_{tbl_version}_*', recursive=True
+            )
             for p in paths:
                 os.remove(p)
 
@@ -169,7 +237,8 @@ class MediaStore:
         if tbl_id is None:
             paths = glob.glob(str(self.__base_dir / '*'), recursive=True)
         else:
-            paths = glob.glob(str(self.__base_dir / tbl_id.hex) + f'/**/{tbl_id.hex}_*', recursive=True)
+            table_prefix = MediaPath.media_table_prefix(tbl_id)
+            paths = glob.glob(str(self.__base_dir / table_prefix) + f'/**/{table_prefix}_*', recursive=True)
         return len(paths)
 
     def stats(self) -> list[tuple[UUID, int, int, int]]:
@@ -178,7 +247,7 @@ class MediaStore:
         d: dict[tuple[UUID, int], list[int]] = defaultdict(lambda: [0, 0])
         for p in paths:
             if not os.path.isdir(p):
-                matched = re.match(self.pattern, Path(p).name)
+                matched = re.match(MediaPath.PATTERN, Path(p).name)
                 assert matched is not None
                 tbl_id, col_id = UUID(hex=matched[1]), int(matched[2])
                 file_info = os.stat(p)
@@ -212,6 +281,10 @@ class TempStore:
         return MediaStore(cls._tmp_dir()).count(tbl_id)
 
     @classmethod
+    def contains_path(cls, file_path: Path) -> bool:
+        return MediaStore(cls._tmp_dir()).contains_path(file_path)
+
+    @classmethod
     def resolve_url(cls, file_url: Optional[str]) -> Optional[Path]:
         return MediaStore(cls._tmp_dir()).resolve_url(file_url)
 
@@ -220,12 +293,13 @@ class TempStore:
         return MediaStore(cls._tmp_dir()).save_media_object(data, col, format)
 
     @classmethod
-    def delete_media_file(cls, obj_path: Path) -> None:
+    def delete_media_file(cls, file_path: Path) -> None:
         """Delete a media object from the temporary store."""
-        assert obj_path is not None, 'Object path must be provided'
-        assert obj_path.exists(), f'Object path does not exist: {obj_path}'
-        assert cls.resolve_url(str(obj_path)) is not None, f'Object path is not a valid media store path: {obj_path}'
-        obj_path.unlink()
+        assert file_path is not None, 'Object path must be provided'
+        assert file_path.exists(), f'Object path does not exist: {file_path}'
+        assert cls.contains_path(file_path), f'Object path must be in the TempStore: {file_path}'
+        file_path.unlink()
+        _logger.debug(f'Media Storage: deleted {file_path}')
 
     @classmethod
     def create_path(cls, tbl_id: Optional[UUID] = None, extension: str = '') -> Path:

--- a/pixeltable/utils/s3.py
+++ b/pixeltable/utils/s3.py
@@ -1,17 +1,175 @@
-from typing import Any
+from __future__ import annotations
+
+import threading
+import urllib.parse
+from typing import Any, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from pixeltable import exceptions as excs
+from pixeltable.env import Env
 
 
-def get_client(**kwargs: Any) -> Any:
-    import boto3
-    import botocore
+class S3ClientContainer:
+    """Singleton providing clients and "s3resources" for the S3 storage service
+    Client acquisition via the get_client(for_write: bool) method is thread-safe
+    S3 resource acquisition via the get_resource() method is not thread-safe
 
-    try:
-        boto3.Session().get_credentials().get_frozen_credentials()
-        config = botocore.config.Config(**kwargs)
-        return boto3.client('s3', config=config)  # credentials are available
-    except AttributeError:
-        # No credentials available, use unsigned mode
-        config_args = kwargs.copy()
-        config_args['signature_version'] = botocore.UNSIGNED
-        config = botocore.config.Config(**config_args)
-        return boto3.client('s3', config=config)
+    Implementation:
+        Clients are stored in two pools, separated by purpose (read / write)
+        The are created as requested, and kept throughout the life of the singleton
+        There is only one S3 resource, which is created on first request and reused
+
+    Clients can be used for any purpose, but it is recommended to use different clients for read and write.
+    """
+
+    class ProtectedClientPool:
+        """An array of clients which can be used to access the S3 resource (thread-safe)"""
+
+        client: list[Optional[Any]]
+        client_lock: threading.Lock  # Protects creation of the read client
+        round_robin: int  # Used to select a slot in the pool
+        client_config: dict[str, Any]  # Used when creating a new client
+
+        def __init__(self, max_clients: int = 1, client_config: Optional[dict[str, Any]] = None) -> None:
+            """This init method is not thread safe"""
+            self.client = [None for _ in range(max_clients)]
+            self.client_lock = threading.Lock()
+            self.round_robin = 0
+            self.client_config = client_config if client_config is not None else {}
+
+        def get_client(self) -> Any:
+            """Get a client, creating one if needed"""
+            # This addition below may be an unprotected increment of a state variable across threads
+            # So the result is unpredictable, though it will be an integer
+            # While written as round-robin, it may also be considered to be a random selection.
+            # Either way works.
+            # This non-issue would be different if we choose to require and use the 'atomics' module
+            self.round_robin += 1
+            index = self.round_robin % len(self.client)
+            if self.client[index] is not None:
+                return self.client[index]
+
+            with self.client_lock:
+                if self.client[index] is not None:
+                    return self.client[index]
+                client = S3ClientContainer.get_client_raw(**self.client_config)
+
+                # Do not set the visible client until it is completely created
+                self.client[index] = client
+            return self.client[index]
+
+    client_read: ProtectedClientPool
+    client_write: ProtectedClientPool
+    client_config: dict[str, Any]
+    resource: Optional[Any]
+    __instance: Optional[S3ClientContainer] = None
+
+    @classmethod
+    def get(cls) -> S3ClientContainer:
+        if cls.__instance is None:
+            cls.__instance = cls()
+        return cls.__instance
+
+    def __init__(self, max_clients: Optional[int] = None, max_pool_connections: Optional[int] = None) -> None:
+        cpu_count = Env.get().cpu_count
+        if max_clients is None:
+            max_clients = min(3, cpu_count)
+        if max_pool_connections is None:
+            total_connections = max(5, 2 * cpu_count)
+        else:
+            total_connections = max_pool_connections * max_clients
+        max_pool_connections = total_connections // max_clients
+        self.client_config = {
+            'max_pool_connections': max_pool_connections,
+            'connect_timeout': 15,
+            'read_timeout': 30,
+            'retries': {'max_attempts': 3, 'mode': 'adaptive'},
+        }
+        self.client_read = self.ProtectedClientPool(max_clients, self.client_config)
+        self.client_write = self.ProtectedClientPool(max_clients, self.client_config)
+        self.resource = None
+
+    @classmethod
+    def get_client_raw(cls, **kwargs: Any) -> Any:
+        """Get a raw client without any locking"""
+        import botocore
+
+        try:
+            boto3.Session().get_credentials().get_frozen_credentials()
+            config = botocore.config.Config(**kwargs)
+            return boto3.client('s3', config=config)  # credentials are available
+        except AttributeError:
+            # No credentials available, use unsigned mode
+            config_args = kwargs.copy()
+            config_args['signature_version'] = botocore.UNSIGNED
+            config = botocore.config.Config(**config_args)
+            return boto3.client('s3', config=config)
+
+    def get_client(self, for_write: bool) -> Any:
+        """Get a client, creating one if needed"""
+        if for_write:
+            return self.client_write.get_client()
+        else:
+            return self.client_read.get_client()
+
+    def get_resource(self) -> Any:
+        """Return the current S3 resource, creating it if needed"""
+        if self.resource is None:
+            self.resource = boto3.resource('s3')
+        return self.resource
+
+    @classmethod
+    def parse_uri(cls, source_uri: str) -> tuple[str, str, str]:
+        """Parse a URI and return scheme, bucket_name, prefix"""
+        parsed = urllib.parse.urlparse(source_uri)
+        bucket_name = parsed.netloc
+        prefix = parsed.path.lstrip('/')
+        return parsed.scheme, bucket_name, prefix
+
+    def list_objects(self, source_uri: str, return_uri: bool, n_max: int = 10) -> list[str]:
+        """Return a list of objects found with the specified S3 uri
+        Each returned object includes the full set of prefixes.
+        if return_uri is True, the full S3 URI is returned; otherwise, just the object key.
+        """
+        scheme, bucket_name, prefix = self.parse_uri(source_uri)
+        # I think the n_max parameter should be passed into the list_objects_v2 call
+        assert scheme == 's3'
+        p = f'{scheme}://{bucket_name}/' if return_uri else ''
+        s3_client = self.get_client(for_write=False)
+        r: list[str] = []
+        try:
+            # Use paginator to handle more than 1000 objects
+            paginator = s3_client.get_paginator('list_objects_v2')
+            for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+                if 'Contents' not in page:
+                    continue
+                for obj in page['Contents']:
+                    if len(r) >= n_max:
+                        return r
+                    r.append(f'{p}{obj["Key"]}')
+        except ClientError as e:
+            self.handle_s3_error(e, bucket_name, f'list objects from {source_uri}')
+        return r
+
+    def list_uris(self, source_uri: str, n_max: int = 10) -> list[str]:
+        """Return a list of URIs found within the specified S3 uri"""
+        return self.list_objects(source_uri, True, n_max)
+
+    @classmethod
+    def handle_s3_error(
+        cls, e: ClientError, bucket_name: str, operation: str = '', *, ignore_404: bool = False
+    ) -> None:
+        error_code = e.response.get('Error', {}).get('Code')
+        error_message = e.response.get('Error', {}).get('Message', str(e))
+        if ignore_404 and error_code == '404':
+            return
+        if error_code == '404':
+            raise excs.Error(f'Bucket {bucket_name} not found during {operation}: {error_message}')
+        elif error_code == '403':
+            raise excs.Error(f'Access denied to bucket {bucket_name} during {operation}: {error_message}')
+        elif error_code == 'PreconditionFailed' or 'PreconditionFailed' in error_message:
+            raise excs.Error(f'Precondition failed for bucket {bucket_name} during {operation}: {error_message}')
+        else:
+            raise excs.Error(f'Error during {operation} in bucket {bucket_name}: {error_code} - {error_message}')

--- a/pixeltable/utils/s3_store.py
+++ b/pixeltable/utils/s3_store.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import logging
+import re
+import urllib.parse
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterator, Optional
+
+from botocore.exceptions import ClientError
+
+from pixeltable.utils.media_path import MediaPath
+from pixeltable.utils.s3 import S3ClientContainer
+
+if TYPE_CHECKING:
+    from pixeltable.catalog import Column
+
+_logger = logging.getLogger('pixeltable')
+
+
+class S3Store:
+    """Class to handle S3 storage operations."""
+
+    # URI of the S3 bucket in the format s3://bucket_name/prefix/
+    # Always ends with a slash
+    __base_uri: str
+
+    # bucket name extracted from the URI
+    __bucket_name: str
+
+    # prefix path within the bucket, either empty or ending with a slash
+    __prefix_name: str
+
+    def __init__(self, uri: str):
+        assert uri.startswith('s3'), "URI must start with 's3'"
+        parsed_uri = urllib.parse.urlparse(uri)
+        assert parsed_uri.scheme == 's3', 'URI must be an S3 URI'
+        self.__base_uri = uri.rstrip('/')
+        self.__bucket_name = parsed_uri.netloc
+        self.__prefix_name = parsed_uri.path.lstrip('/').rstrip('/')
+        if len(self.__prefix_name) > 0:
+            self.__prefix_name += '/'
+        self.__base_uri += '/'
+        if 0:
+            print(
+                f'Initialized S3Store with base URI: {self.__base_uri},',
+                f'bucket: {self.__bucket_name}, prefix: {self.__prefix_name}',
+            )
+
+    def client(self, for_write: bool = False) -> Any:
+        """Return the S3 client."""
+        return S3ClientContainer.get().get_client(for_write=for_write)
+
+    @property
+    def bucket_name(self) -> str:
+        """Return the bucket name from the base URI."""
+        return self.__bucket_name
+
+    @property
+    def prefix(self) -> str:
+        """Return the prefix from the base URI."""
+        return self.__prefix_name
+
+    def validate_uri(self) -> Optional[str]:
+        """
+        Checks if the URI exists.
+
+        Returns:
+            bool: True if the S3 URI exists and is accessible, False otherwise.
+        """
+        try:
+            self.client().head_bucket(Bucket=self.bucket_name)
+            return self.__base_uri
+        except ClientError as e:
+            S3ClientContainer.handle_s3_error(e, self.bucket_name, 'validate bucket')
+        return None
+
+    def _prepare_media_uri_raw(
+        self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: Optional[str] = None
+    ) -> str:
+        """
+        Construct a new, unique URI for a persisted media file.
+        """
+        prefix, filename = MediaPath.media_prefix_file_raw(tbl_id, col_id, tbl_version, ext)
+        parent = f'{self.__base_uri}{prefix}'
+        return f'{parent}/{filename}'
+
+    def _prepare_media_uri(self, col: Column, ext: Optional[str] = None) -> str:
+        """
+        Construct a new, unique URI for a persisted media file.
+        """
+        assert col.tbl is not None, 'Column must be associated with a table'
+        return self._prepare_media_uri_raw(col.tbl.id, col.id, col.tbl.version, ext=ext)
+
+    def copy_local_media_file(self, col: Column, src_path: Path) -> str:
+        """Copy a local file, and return its new URL"""
+        new_file_uri = self._prepare_media_uri(col, ext=src_path.suffix)
+        parsed = urllib.parse.urlparse(new_file_uri)
+        try:
+            self.client(for_write=True).upload_file(
+                Filename=str(src_path), Bucket=parsed.netloc, Key=parsed.path.lstrip('/')
+            )
+            _logger.debug(f'Media Storage: copied {src_path} to {new_file_uri}')
+            return new_file_uri
+        except ClientError as e:
+            S3ClientContainer.handle_s3_error(e, self.bucket_name, f'setup iterator {self.prefix}')
+            raise
+
+    def _get_filtered_objects(self, tbl_id: uuid.UUID, tbl_version: Optional[int] = None) -> tuple[Iterator, Any]:
+        """Private method to get filtered objects for a table, optionally filtered by version.
+
+        Args:
+            tbl_id: Table UUID to filter by
+            tbl_version: Optional table version to filter by
+
+        Returns:
+            Tuple of (iterator over S3 objects matching the criteria, bucket object)
+        """
+        # Use MediaPath to construct the prefix for this table
+
+        table_prefix = MediaPath.media_table_prefix(tbl_id)
+        prefix = f'{self.prefix}{table_prefix}/'
+
+        try:
+            # Use S3 resource interface for filtering
+            s3_resource = S3ClientContainer.get().get_resource()
+            bucket = s3_resource.Bucket(self.bucket_name)
+
+            if tbl_version is None:
+                # Return all objects with the table prefix
+                object_iterator = bucket.objects.filter(Prefix=prefix)
+            else:
+                # Filter by both table_id and table_version using the MediaPath pattern
+                # Pattern: tbl_id_col_id_version_uuid
+                version_pattern = re.compile(
+                    rf'{re.escape(table_prefix)}_\d+_{re.escape(str(tbl_version))}_[0-9a-fA-F]+.*'
+                )
+                # Return filtered collection - this still uses lazy loading
+                object_iterator = (
+                    obj for obj in bucket.objects.filter(Prefix=prefix) if version_pattern.match(obj.key.split('/')[-1])
+                )
+
+            return object_iterator, bucket
+
+        except ClientError as e:
+            S3ClientContainer.handle_s3_error(e, self.bucket_name, f'setup iterator {self.prefix}')
+            raise
+
+    def count(self, tbl_id: uuid.UUID, tbl_version: Optional[int] = None) -> int:
+        """Count the number of files belonging to tbl_id. If tbl_version is not None,
+        count only those files belonging to the specified tbl_version.
+
+        Args:
+            tbl_id: Table UUID to count objects for
+            tbl_version: Optional table version to filter by
+
+        Returns:
+            Number of objects matching the criteria
+        """
+        assert tbl_id is not None
+
+        object_iterator, _ = self._get_filtered_objects(tbl_id, tbl_version)
+
+        return sum(1 for _ in object_iterator)
+
+    def delete(self, tbl_id: uuid.UUID, tbl_version: Optional[int] = None) -> int:
+        """Delete all files belonging to tbl_id. If tbl_version is not None, delete
+        only those files belonging to the specified tbl_version.
+
+        Args:
+            tbl_id: Table UUID to delete objects for
+            tbl_version: Optional table version to filter by
+
+        Returns:
+            Number of objects deleted
+        """
+        assert tbl_id is not None
+
+        # Use shared method to get filtered objects and bucket
+        object_iterator, bucket = self._get_filtered_objects(tbl_id, tbl_version)
+
+        total_deleted = 0
+
+        try:
+            objects_to_delete = []
+
+            # Process objects in batches as we iterate (memory efficient)
+            for obj in object_iterator:
+                objects_to_delete.append({'Key': obj.key})
+
+                # Delete in batches of 1000 (S3 limit)
+                if len(objects_to_delete) >= 1000:
+                    bucket.delete_objects(Delete={'Objects': objects_to_delete, 'Quiet': True})
+                    total_deleted += len(objects_to_delete)
+                    objects_to_delete = []
+
+            # Delete any remaining objects in the final batch
+            if len(objects_to_delete) > 0:
+                bucket.delete_objects(Delete={'Objects': objects_to_delete, 'Quiet': True})
+                total_deleted += len(objects_to_delete)
+
+            print(f"Deleted {total_deleted} objects from bucket '{self.bucket_name}'.")
+            return total_deleted
+
+        except ClientError as e:
+            S3ClientContainer.handle_s3_error(e, self.bucket_name, f'deleting with {self.prefix}')
+            raise

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -1,0 +1,224 @@
+from pathlib import Path
+from typing import Optional, Union
+from uuid import UUID
+
+import pytest
+
+import pixeltable as pxt
+import pixeltable.exceptions as excs
+from pixeltable import env
+from pixeltable.utils.media_destination import MediaDestination
+
+
+class TestDestination:
+    USE_S3 = False
+
+    @classmethod
+    def base_dest(cls) -> Path:
+        """Return the base destination directory for tests"""
+        base_path = env.Env.get().tmp_dir / '..' / 'test_dest'
+        base_path.mkdir(exist_ok=True)
+        return base_path
+
+    @classmethod
+    def dest(cls, n: int) -> tuple[Union[Path, str], str]:
+        """Return the destination directory for test images"""
+        if cls.USE_S3:
+            s3_uri = f's3://jimpeterson-test/img_rot{n}'
+            return s3_uri, s3_uri
+        else:
+            dest_path = cls.base_dest() / f'img_rot{n}'
+            if not dest_path.exists():
+                dest_path.mkdir()
+            dest_uri = dest_path.resolve().as_uri()
+            return dest_path, dest_uri
+
+    @classmethod
+    def count(cls, uri: Optional[str], tbl_id: UUID) -> int:
+        """Return the count of media files in the destination for a given table ID"""
+        return MediaDestination.count(uri, tbl_id)
+
+    def pr_us(self, us: pxt.UpdateStatus, op: str = '') -> None:
+        """Print contents of UpdateStatus"""
+        print(f'=========================== pr_us =========================== op: {op}')
+        print(f'num_rows: {us.num_rows}')
+        print(f'num_computed_values: {us.num_computed_values}')
+        print(f'num_excs: {us.num_excs}')
+        print(f'updated_cols: {us.updated_cols}')
+        print(f'cols_with_excs: {us.cols_with_excs}')
+        print(us.row_count_stats)
+        print(us.cascade_row_count_stats)
+        print('============================================================')
+
+    def test_dest_errors(self, reset_db: None) -> None:
+        t = pxt.create_table('test_dest_errors', schema={'img': pxt.Image})
+        valid_dest = 'tests/data/'
+
+        # Basic tests of the destination parameter: types and store / computed
+        with pytest.raises(excs.Error, match='must be a string or path'):
+            t.add_computed_column(img_rot=t.img.rotate(90), destination=27)
+
+        with pytest.raises(excs.Error, match='only applies to stored computed columns'):
+            t.add_computed_column(img_rot=t.img.rotate(90), stored=False, destination=valid_dest)
+
+        with pytest.raises(excs.Error, match='only applies to stored computed columns'):
+            _ = pxt.create_table('test_dest_bad', schema={'img': {'type': pxt.Image, 'destination': f'{valid_dest}'}})
+
+        # Test destination with a non-existent directory
+        with pytest.raises(excs.Error, match='does not exist'):
+            t.add_computed_column(img_rot=t.img.rotate(90), destination='non_existent_dir/img_rot')
+
+        # Test destination with a file path instead of a directory
+        with pytest.raises(excs.Error, match='must be a directory, not a file'):
+            t.add_computed_column(
+                img_rot=t.img.rotate(90), destination='tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'
+            )
+
+        # Test with invalid scheme
+        with pytest.raises(excs.Error, match='must be a valid URI to a supported'):
+            t.add_computed_column(img_rot=t.img.rotate(90), destination='https://anything/')
+
+    def test_dest_local_2(self, reset_db: None) -> None:
+        """Test destination with two local directories"""
+
+        # Create two valid local file Paths for images
+        valid_dest_1, dest1_uri = self.dest(1)
+        valid_dest_2, dest2_uri = self.dest(2)
+
+        t = pxt.create_table('test_dest', schema={'img': pxt.Image})
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        t.add_computed_column(img_rot1=t.img.rotate(90), destination=None)
+        t.add_computed_column(img_rot2=t.img.rotate(180), destination=valid_dest_1)
+        t.add_computed_column(img_rot3=t.img.rotate(270), destination=valid_dest_2)
+        print(t.collect())
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        r = t.collect()
+        print(r)
+
+        r_dest = t.select(t.img.fileurl, t.img_rot1.fileurl, t.img_rot2.fileurl, t.img_rot3.fileurl).collect()
+        print(r_dest)
+
+        assert len(r) == 2
+        assert len(r) == self.count(None, t._id)
+        assert len(r) == self.count(dest1_uri, t._id)
+        assert len(r) == self.count(dest2_uri, t._id)
+
+        # Ensure that all media is removed when the table is dropped
+        save_id = t._id
+        pxt.drop_table(t)
+
+        assert self.count(None, save_id) == 0
+        assert self.count(dest1_uri, save_id) == 0
+        assert self.count(dest2_uri, save_id) == 0
+
+    def test_dest_local_3x3(self, reset_db: None) -> None:
+        """Test destination with two local Paths receiving copies of the same computed image"""
+
+        # Create two valid local file Paths for images
+        valid_dest_1, dest1_uri = self.dest(1)
+        valid_dest_2, dest2_uri = self.dest(2)
+
+        t = pxt.create_table('test_dest', schema={'img': pxt.Image})
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        t.add_computed_column(img_rot1=t.img.rotate(90), destination=None)
+        t.add_computed_column(img_rot2=t.img.rotate(90), destination=valid_dest_1)
+        t.add_computed_column(img_rot3=t.img.rotate(90), destination=valid_dest_2)
+        t.add_computed_column(img_rot4=t.img.rotate(90), destination=valid_dest_2)  # Try to copy twice to the same dest
+        print(t.collect())
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        r = t.collect()
+        print(r)
+
+        r_dest = t.select(t.img_rot1.fileurl, t.img_rot2.fileurl, t.img_rot3.fileurl, t.img_rot4.fileurl).collect()
+        print(r_dest)
+
+        assert len(r) == 2
+        assert len(r) == self.count(None, t._id)
+        assert len(r) == self.count(dest1_uri, t._id)
+
+        # The outcome of this test is unusual:
+        # When the column img_rot4 is ADDED, the computed result for existing rows is not identified
+        # as a duplicate, so it is double copied to the destination.
+        # When new rows are INSERTED, the results and destinations for img_rot3 and img_rot4 are identified
+        # as duplicates, so they are not double copied to the destination.
+        assert len(r) + 1 == self.count(dest2_uri, t._id)
+
+    def test_dest_local_uri(self, reset_db: None) -> None:
+        """Test destination with local URI"""
+
+        # Create valid local file Paths and URIs for images
+        _, dest1_uri = self.dest(1)
+
+        t = pxt.create_table('test_dest', schema={'img': pxt.Image})
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        t.add_computed_column(img_rot1=t.img.rotate(90), destination=None)
+        t.add_computed_column(img_rot2=t.img.rotate(180), destination=dest1_uri)
+        print(t.collect())
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        r = t.collect()
+        print(r)
+
+        assert len(r) == 2
+        assert len(r) == self.count(None, t._id)
+        assert len(r) == self.count(dest1_uri, t._id)
+
+    def test_dest_local_copy(self, reset_db: None) -> None:
+        """Test destination attempting to copy a local file to another destination"""
+
+        # Create valid local file Paths and URIs for images
+        valid_dest_1, dest1_uri = self.dest(1)
+
+        # The intent of this test is to copy the same image to two different destinations
+        t = pxt.create_table('test_dest', schema={'img': pxt.Image})
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        t.add_computed_column(img_rot1=t.img, destination=None)
+        t.add_computed_column(img_rot2=t.img, destination=valid_dest_1)
+        print(t.collect())
+        t.insert([{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}])
+        r = t.collect()
+        print(r)
+
+        r_dest = t.select(t.img.fileurl, t.img_rot1.fileurl, t.img_rot2.fileurl).collect()
+        print(r_dest)
+
+        assert len(r) == 2
+
+        # Copying a local file to the MediaStore is not allowed
+        assert self.count(None, t._id) == 0
+
+        # Ensure that local file is copied to a specified destination
+        assert len(r) == self.count(dest1_uri, t._id)
+
+    def test_dest_write_perf(self, reset_db: None) -> None:
+        """Test write performance with multiple concurrent requests"""
+
+        img_data = 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'  # ~10 KB
+        # img_data = 'tests/data/images/sewing-threads.heic'  # ~1.5 MB
+        # img_data = 'tests/data/imagenette2-160/ILSVRC2012_val_00015787.JPEG'  # ~3 KB
+        data_rows = 1000
+        number_of_inserts = 1
+
+        s3_cols = 0
+        t = pxt.create_table('test_dest', schema={'img': pxt.Image})
+        for i in range(1, 4):
+            _, dest_uri = self.dest(i)
+            t.add_computed_column(**{f'img_rot_1_{i}': t.img.rotate(90)}, destination=dest_uri)
+            t.add_computed_column(**{f'img_rot_2_{i}': t.img.rotate(180)}, destination=dest_uri)
+            t.add_computed_column(**{f'img_rot_3_{i}': t.img.rotate(270)}, destination=dest_uri)
+            s3_cols += 3
+        data = [{'img': img_data} for _ in range(data_rows)]
+        for _ in range(number_of_inserts):
+            t.insert(data)
+        n = t.count()
+
+        assert n == number_of_inserts * data_rows
+        for i in range(1, 4):
+            _, dest_uri = self.dest(i)
+            assert 3 * n == self.count(dest_uri, t._id)
+
+        # Ensure that all media is removed when the table is dropped
+        save_id = t._id
+        pxt.drop_table(t)
+        for i in range(1, 4):
+            _, dest_uri = self.dest(i)
+            assert self.count(dest_uri, save_id) == 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,6 @@ import glob
 import json
 import os
 import random
-import urllib.parse
 from pathlib import Path
 from typing import Any, Callable, Optional
 from unittest import TestCase
@@ -16,11 +15,11 @@ import pytest
 
 import pixeltable as pxt
 import pixeltable.type_system as ts
-import pixeltable.utils.s3 as s3_util
 from pixeltable.catalog import Catalog
 from pixeltable.dataframe import DataFrameResultSet
 from pixeltable.env import Env
 from pixeltable.utils import sha256sum
+from pixeltable.utils.s3 import S3ClientContainer
 
 TESTS_DIR = Path(os.path.dirname(__file__))
 
@@ -342,23 +341,7 @@ def __image_mode(path: str) -> str:
 
 def get_multimedia_commons_video_uris(n: int = 10) -> list[str]:
     uri = 's3://multimedia-commons/data/videos/mp4/'
-    parsed = urllib.parse.urlparse(uri)
-    bucket_name = parsed.netloc
-    prefix = parsed.path.lstrip('/')
-    s3_client = s3_util.get_client()
-    uris: list[str] = []
-    # Use paginator to handle more than 1000 objects
-    paginator = s3_client.get_paginator('list_objects_v2')
-
-    for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
-        if 'Contents' not in page:
-            continue
-        for obj in page['Contents']:
-            if len(uris) >= n:
-                return uris
-            uri = f's3://{bucket_name}/{obj["Key"]}'
-            uris.append(uri)
-    return uris
+    return S3ClientContainer.get().list_uris(uri, n_max=n)
 
 
 def get_audio_files(include_bad_audio: bool = False) -> list[str]:


### PR DESCRIPTION
The destination specification on stored, computed columns can take the form of a string describing a file path, a python Path object, or a string specifying an S3 bucket with optional prefixes.
Syntax examples:
t.add_computed_column(img_rot2=t.img.rotate(180), destination='s3://bucket_name/prefix_1/prefix_2/')
t.add_computed_column(img_rot2=t.img.rotate(180), destination='/Users/name/dir_1/dir_2/')
Computed data for the column is stored in the URI or local Path specified by the destination.
When a table is dropped, the computed values are deleted from the associated destination(s) for all columns in
the table.
If no destination parameter or the value None is supplied, then the computed values are sent to the default location for pixeltable data: .pixeltable/media