### PR TITLE
Basic support for concurrent pixeltable metadata creation/upgrade

### DIFF
--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -515,6 +515,7 @@ class Env:
         assert self._sa_engine is not None
         from pixeltable import metadata
 
+        self._logger.debug('Creating pixeltable metadata')
         metadata.schema.base_metadata.create_all(self._sa_engine, checkfirst=True)
         metadata.create_system_info(self._sa_engine)
 

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -110,8 +110,6 @@ class Env:
             env._set_up(reinit_db=reinit_db)
             env._upgrade_metadata()
             cls._instance = env
-        except BaseException as e:  # Catch all exceptions
-            raise e
         finally:
             cls.__initializing = False
 

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -505,7 +505,7 @@ class Env:
 
     @retry(
         stop=stop_after_attempt(3),  # Stop after 3 attempts
-        wait=wait_exponential_jitter(exp_base=0.1, multiplier=2, max=1),  # Exponential backoff with jitter
+        wait=wait_exponential_jitter(initial=0.2, max=1.0, jitter=0.2),  # Exponential backoff with jitter
     )
     def _init_metadata(self) -> None:
         """

--- a/pixeltable/metadata/__init__.py
+++ b/pixeltable/metadata/__init__.py
@@ -25,6 +25,7 @@ def create_system_info(engine: sql.engine.Engine) -> None:
     """Create the system metadata record"""
     system_md = SystemInfoMd(schema_version=VERSION)
     record = SystemInfo(md=dataclasses.asdict(system_md))
+    _logger.debug(f'Creating pixeltable system info record {record}')
     with orm.Session(engine, future=True) as session:
         # Write system metadata only once for idempotency
         if session.query(SystemInfo).count() == 0:

--- a/pixeltable/metadata/__init__.py
+++ b/pixeltable/metadata/__init__.py
@@ -54,7 +54,8 @@ for _, modname, _ in pkgutil.iter_modules([os.path.dirname(__file__) + '/convert
 def upgrade_md(engine: sql.engine.Engine) -> None:
     """Upgrade the metadata schema to the current version"""
     with orm.Session(engine) as session:
-        system_info = session.query(SystemInfo).one().md
+        # Get exclusive lock on SystemInfo row
+        system_info = (session.query(SystemInfo).with_for_update().one()).md
         md_version = system_info['schema_version']
         assert isinstance(md_version, int)
         _logger.info(f'Current database version: {md_version}, installed version: {VERSION}')

--- a/pixeltable/metadata/__init__.py
+++ b/pixeltable/metadata/__init__.py
@@ -55,7 +55,7 @@ def upgrade_md(engine: sql.engine.Engine) -> None:
     """Upgrade the metadata schema to the current version"""
     with orm.Session(engine) as session:
         # Get exclusive lock on SystemInfo row
-        system_info = (session.query(SystemInfo).with_for_update().one()).md
+        system_info = session.query(SystemInfo).with_for_update().one().md
         md_version = system_info['schema_version']
         assert isinstance(md_version, int)
         _logger.info(f'Current database version: {md_version}, installed version: {VERSION}')


### PR DESCRIPTION
There is a race condition when more than one pixeltable processes try to create schema tables at the same time.
Similar issue when upgrading metadata.

Adding retry with backoff for schema table creations
Adding exclusive lock on system info row for upgrade metadata 

Env._init_env() will only set the class instance only if env setup completes without error