### PR TITLE
Fix local_public_names() to properly exclude private functions

### DIFF
--- a/pixeltable/utils/code.py
+++ b/pixeltable/utils/code.py
@@ -19,12 +19,18 @@ def local_public_names(mod_name: str, exclude: Optional[list[str]] = None) -> li
     mod = importlib.import_module(mod_name)
     names = []
     for obj in mod.__dict__.values():
+        # Check for private/protected names at the top
+        if hasattr(obj, '__name__') and obj.__name__.startswith('_'):
+            continue
+        
         if isinstance(obj, Function):
-            # Pixeltable function
+            # Pixeltable function - check name attribute for private functions
+            if obj.name.startswith('_'):
+                continue
             names.append(obj.name)
         elif isinstance(obj, types.FunctionType):
             # Python function
-            if obj.__module__ == mod.__name__ and not obj.__name__.startswith('_'):
+            if obj.__module__ == mod.__name__:
                 names.append(obj.__name__)
         elif isinstance(obj, types.ModuleType):
             # Module

--- a/pixeltable/utils/code.py
+++ b/pixeltable/utils/code.py
@@ -19,18 +19,13 @@ def local_public_names(mod_name: str, exclude: Optional[list[str]] = None) -> li
     mod = importlib.import_module(mod_name)
     names = []
     for obj in mod.__dict__.values():
-        # Check for private/protected names at the top
-        if hasattr(obj, '__name__') and obj.__name__.startswith('_'):
-            continue
-        
         if isinstance(obj, Function):
-            # Pixeltable function - check name attribute for private functions
-            if obj.name.startswith('_'):
-                continue
-            names.append(obj.name)
+            # Pixeltable function
+            if not obj.name.startswith('_'):
+                names.append(obj.name)
         elif isinstance(obj, types.FunctionType):
             # Python function
-            if obj.__module__ == mod.__name__:
+            if obj.__module__ == mod.__name__ and not obj.__name__.startswith('_'):
                 names.append(obj.__name__)
         elif isinstance(obj, types.ModuleType):
             # Module


### PR DESCRIPTION
The function was incorrectly including private functions (prefixed with _) in the public API when they were Pixeltable Function objects. This caused private functions like _anthropic_response_to_pxt_tool_calls to appear in documentation.

Added underscore check for Function objects to match the existing behavior for Python functions.
