### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docs/local
 local
 site
 target
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
Updated gitignore macOS .DS_Store files throughout the codebase to prevent them from being accidentally committed.