### PR TITLE
SDK changes/fixes for data sharing

### DIFF
--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -606,11 +606,6 @@ class Env:
 
     @property
     def pxt_api_key(self) -> str:
-        if self._pxt_api_key is None:
-            raise excs.Error(
-                'No API key is configured. Set the PIXELTABLE_API_KEY environment variable, or add an entry to '
-                'config.toml as described here:\nhttps://pixeltable.github.io/pixeltable/config/'
-            )
         return self._pxt_api_key
 
     def get_client(self, name: str) -> Any:

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -542,9 +542,14 @@ def drop_table(
         assert isinstance(table, str)
         tbl_path = table
 
-    path_obj = catalog.Path.parse(tbl_path)
-    if_not_exists_ = catalog.IfNotExistsParam.validated(if_not_exists, 'if_not_exists')
-    Catalog.get().drop_table(path_obj, force=force, if_not_exists=if_not_exists_)
+    if tbl_path.startswith('pxt://'):
+        # Remote table
+        share.delete_replica(tbl_path)
+    else:
+        # Local table
+        path_obj = catalog.Path.parse(tbl_path)
+        if_not_exists_ = catalog.IfNotExistsParam.validated(if_not_exists, 'if_not_exists')
+        Catalog.get().drop_table(path_obj, force=force, if_not_exists=if_not_exists_)
 
 
 def get_dir_contents(dir_path: str = '', recursive: bool = True) -> 'DirContents':

--- a/pixeltable/share/__init__.py
+++ b/pixeltable/share/__init__.py
@@ -1,3 +1,3 @@
 # ruff: noqa: F401
 
-from .publish import pull_replica, push_replica
+from .publish import delete_replica, pull_replica, push_replica

--- a/pixeltable/share/publish.py
+++ b/pixeltable/share/publish.py
@@ -34,8 +34,7 @@ def push_replica(
         src_tbl, additional_md={'table_uri': dest_tbl_uri, 'bucket_name': bucket, 'is_public': access == 'public'}
     )
     request_json = packager.md | {'operation_type': 'publish_snapshot'}
-    headers_json = {'X-api-key': Env.get().pxt_api_key, 'Content-Type': 'application/json'}
-    response = requests.post(PIXELTABLE_API_URL, json=request_json, headers=headers_json)
+    response = requests.post(PIXELTABLE_API_URL, json=request_json, headers=_api_headers())
     if response.status_code != 200:
         raise excs.Error(f'Error publishing snapshot: {response.text}')
     response_json = response.json()
@@ -70,7 +69,7 @@ def push_replica(
         'preview_data': packager.md['preview_data'],
     }
     # TODO: Use Pydantic for validation
-    finalize_response = requests.post(PIXELTABLE_API_URL, json=finalize_request_json, headers=headers_json)
+    finalize_response = requests.post(PIXELTABLE_API_URL, json=finalize_request_json, headers=_api_headers())
     if finalize_response.status_code != 200:
         raise excs.Error(f'Error finalizing snapshot: {finalize_response.text}')
     finalize_response_json = finalize_response.json()
@@ -112,9 +111,8 @@ def _upload_bundle_to_s3(bundle: Path, parsed_location: urllib.parse.ParseResult
 
 
 def pull_replica(dest_path: str, src_tbl_uri: str) -> pxt.Table:
-    headers_json = {'X-api-key': Env.get().pxt_api_key, 'Content-Type': 'application/json'}
     clone_request_json = {'operation_type': 'clone_snapshot', 'table_uri': src_tbl_uri}
-    response = requests.post(PIXELTABLE_API_URL, json=clone_request_json, headers=headers_json)
+    response = requests.post(PIXELTABLE_API_URL, json=clone_request_json, headers=_api_headers())
     if response.status_code != 200:
         raise excs.Error(f'Error cloning snapshot: {response.text}')
     response_json = response.json()
@@ -268,11 +266,18 @@ def _download_from_presigned_url(
 # TODO: This will be replaced by drop_table with cloud table uri
 def delete_replica(dest_path: str) -> None:
     """Delete cloud replica"""
-    headers_json = {'X-api-key': Env.get().pxt_api_key, 'Content-Type': 'application/json'}
     delete_request_json = {'operation_type': 'delete_snapshot', 'table_uri': dest_path}
-    response = requests.post(PIXELTABLE_API_URL, json=delete_request_json, headers=headers_json)
+    response = requests.post(PIXELTABLE_API_URL, json=delete_request_json, headers=_api_headers())
     if response.status_code != 200:
         raise excs.Error(f'Error deleting replica: {response.text}')
     response_json = response.json()
     if not isinstance(response_json, dict) or 'table_uri' not in response_json:
         raise excs.Error(f'Error deleting replica: unexpected response from server.\n{response_json}')
+
+
+def _api_headers() -> dict[str, str]:
+    headers = {'Content-Type': 'application/json'}
+    api_key = Env.get().pxt_api_key
+    if api_key is not None:
+        headers['X-api-key'] = api_key
+    return headers


### PR DESCRIPTION
- Allow cloning public tables without an API key
- Wire `delete_replica()` command up to `globals.drop_table()`