### PR TITLE
Fixes for nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -148,7 +148,7 @@ jobs:
           df -h
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /opt/hostedtoolcache /opt/az /opt/microsoft
           df -h
       - name: Install ollama
         run: |
@@ -163,9 +163,3 @@ jobs:
           use-only-tar-bz2: true  # Needed to use conda with cache action
       - name: Run isolated notebook tests
         run: ./scripts/run-isolated-nb-tests.sh ${{ matrix.python-version }}
-      - name: Print debugging info
-        if: ${{ always() }}
-        run: |
-          conda activate nb-test-env
-          conda info
-          pip list

--- a/scripts/run-isolated-nb-tests.sh
+++ b/scripts/run-isolated-nb-tests.sh
@@ -20,30 +20,41 @@ export PIXELTABLE_DB="isolatednbtests"
 
 "$SCRIPT_DIR/prepare-nb-tests.sh" docs/notebooks
 rm -f "$TEST_PATH"/audio-transcriptions.ipynb  # temporary workaround
-rm -f "$TEST_PATH"/rag-demo.ipynb  # failing in CI for unknown reasons
 
+NB_CONDA_ENV=nb-test-env
 FAILURES=0
 
 for nb in "$TEST_PATH"/*.ipynb; do
     echo "Testing notebook: $nb"
-    echo "Creating conda environment ..."
-    conda create -y --name nb-test-env python="$PY_VERSION"
+
+    echo "Creating conda environment $NB_CONDA_ENV ..."
+    conda create -y --name "$NB_CONDA_ENV" python="$PY_VERSION"
+
     echo "Activating conda environment ..."
-    conda activate nb-test-env
+    conda activate "$NB_CONDA_ENV"
     conda info
+
     echo "Installing pytest ..."
     pip install -qU pip
     pip install -q pytest nbmake
-    echo "Installing pixeltable ..."
-    pip install -q pixeltable
+
     echo "Running notebook $nb ..."
-    pytest -v -m '' --nbmake --nbmake-timeout=1800 "$nb" || (( FAILURES++ ))
+    pytest -v -m '' --nbmake --nbmake-timeout=1800 "$nb" || (( FAILURES++ )) || true
+
     echo "Cleaning $PIXELTABLE_DB postgres DB ..."
     POSTGRES_BIN_PATH=$(python -c 'import pixeltable_pgserver; import sys; sys.stdout.write(str(pixeltable_pgserver._commands.POSTGRES_BIN_PATH))')
     PIXELTABLE_URL="postgresql://postgres:@/postgres?host=$PIXELTABLE_HOME/pgdata"
-    "$POSTGRES_BIN_PATH/psql" "$PIXELTABLE_URL" -U postgres -c "DROP DATABASE $PIXELTABLE_DB;"
+    "$POSTGRES_BIN_PATH/psql" "$PIXELTABLE_URL" -U postgres -c "DROP DATABASE IF EXISTS $PIXELTABLE_DB;"
+
+    echo "Cleaning Hugging Face cache ..."
+    rm -rf ~/.cache/huggingface
+
     echo "Deactivating conda environment ..."
     conda deactivate
+
+    echo "Removing conda environment ..."
+    conda remove -y --name "$NB_CONDA_ENV" --all
+
     echo "Done!"
 done
 


### PR DESCRIPTION
Fixes for isolated notebook tests:
- Free up more space on actions runners
- Clear Huggingface cache after each notebook run
- Better error handling
- Revert old workarounds