### PR TITLE
Add config parameter for global media destination

### DIFF
--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -163,6 +163,7 @@ KNOWN_CONFIG_OPTIONS = {
         'api_key': 'API key for Pixeltable cloud',
         'r2_profile': 'AWS config profile name used to access R2 storage',
         's3_profile': 'AWS config profile name used to access S3 storage',
+        'media_destination': 'Storage location for generated / inserted media files',
     },
     'anthropic': {'api_key': 'Anthropic API key'},
     'bedrock': {'api_key': 'AWS Bedrock API key'},

--- a/pixeltable/exprs/data_row.py
+++ b/pixeltable/exprs/data_row.py
@@ -285,13 +285,12 @@ class DataRow:
         self.vals[index] = None
         return False
 
-    def save_media_to_temp(self, index: int, col: catalog.Column) -> str:
+    def save_media_to_temp(self, index: int, col: catalog.Column, format: Optional[str] = None) -> str:
         """Save the media object in the column to the TempStore.
         Objects cannot be saved directly to general destinations."""
         assert col.col_type.is_media_type()
         val = self.vals[index]
-        format = None
-        if isinstance(val, PIL.Image.Image):
+        if format is None and isinstance(val, PIL.Image.Image):
             # Default to JPEG unless the image has a transparency layer (which isn't supported by JPEG).
             # In that case, use WebP instead.
             format = 'webp' if val.has_transparency_data else 'jpeg'

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1265,7 +1265,10 @@ class TestTable:
         cache_stats = FileCache.get().stats()
         assert cache_stats.num_requests == 0, f'{cache_stats} tbl_id={tbl._id}'
         # add computed column to make sure that external files are cached locally during insert
-        tbl.add_computed_column(rotated=tbl.img.rotate(30), stored=True)
+        # This computed column should not creeate a new image in case the default media destination
+        # is located in an object service. In this case the filecache stats will be different, as the
+        # computed results will need to fetched from storage as well as the original images.
+        tbl.add_computed_column(img_width=tbl.img.width, stored=True)
         urls = [
             's3://open-images-dataset/validation/3c02ca9ec9b2b77b.jpg',
             's3://open-images-dataset/validation/3c13e0015b6c3bcf.jpg',


### PR DESCRIPTION
The configuration parameter pixeltable, media_destination can be used setup a global media destination. 
The environment variable PIXELTABLE_MEDIA_DESTINATION can set this configuration, or the user can put it a value for media_destination in the pixeltable section of their config.toml file. 

The format of the string is the same as that used in the media_destination parameter to a table column. 
These destination parameters must at least identify the service and the bucket. Sometimes account numbers are required, or URI destinations. Optional prefixes are possible in all cases. Local file paths or strings are possible as well.

Access credentials are checked on the first attempt to read from or write to the designated destination. 
Prefixes / directories are created as needed.

For files:
PIXELTABLE_MEDIA_DESTINATION=/Users/<a name>/<some directories>

For S3:
PIXELTABLE_MEDIA_DESTINATION=s3://<bucket>/<optional prefixes>

For R2:
PIXELTABLE_MEDIA_DESTINATION=https://<account>.r2.cloudflarestorage.com/<bucket>/<optional prefixes>

For GCS:
PIXELTABLE_MEDIA_DESTINATION=gs://<bucket>/<optional prefixes>
