### PR TITLE
Add SDK documentation generation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ site
 target
 .DS_Store
 **/.DS_Store
+docs/mintlify/backups_from_generation/

--- a/docs/public_api.opml
+++ b/docs/public_api.opml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head>
+    <title>Pixeltable SDK Documentation Structure</title>
+    <description>Module-first OPML with top-level grouping for Mintlify SDK documentation</description>
+    <dateCreated>Mon, 19 Aug 2025 00:00:00 GMT</dateCreated>
+  </head>
+  <body>
+    
+    <outline text="tab|Pixeltable SDK">
+      
+      <!-- Core API group with main module -->
+      <outline text="group|Core API">
+        <outline text="module|pixeltable">
+          <!-- Core functions at module level -->
+          <outline text="func|pixeltable.create_table" />
+          <outline text="func|pixeltable.create_view" />
+          <outline text="func|pixeltable.create_snapshot" />
+          <outline text="func|pixeltable.drop_table" />
+          <outline text="func|pixeltable.get_table" />
+          <outline text="func|pixeltable.create_dir" />
+          <outline text="func|pixeltable.drop_dir" />
+          <outline text="func|pixeltable.get_dir_contents" />
+          <outline text="func|pixeltable.ls" />
+          <outline text="func|pixeltable.move" />
+          <outline text="func|pixeltable.configure_logging" />
+          <outline text="func|pixeltable.init" />
+          <outline text="func|pixeltable.udf" />
+          <outline text="func|pixeltable.query" />
+          
+          <!-- Core classes with ALL their methods (no sub-grouping) -->
+          <outline text="class|pixeltable.Table">
+            <outline text="method|pixeltable.Table.add_column" />
+            <outline text="method|pixeltable.Table.drop_column" />
+            <outline text="method|pixeltable.Table.rename_column" />
+            <outline text="method|pixeltable.Table.recompute_columns" />
+            <outline text="method|pixeltable.Table.insert" />
+            <outline text="method|pixeltable.Table.update" />
+            <outline text="method|pixeltable.Table.delete" />
+            <outline text="method|pixeltable.Table.add_embedding_index" />
+            <outline text="method|pixeltable.Table.drop_embedding_index" />
+            <outline text="method|pixeltable.Table.drop_index" />
+            <outline text="method|pixeltable.Table.revert" />
+          </outline>
+          
+          <outline text="class|pixeltable.DataFrame">
+            <outline text="method|pixeltable.DataFrame.select" />
+            <outline text="method|pixeltable.DataFrame.where" />
+            <outline text="method|pixeltable.DataFrame.join" />
+            <outline text="method|pixeltable.DataFrame.group_by" />
+            <outline text="method|pixeltable.DataFrame.order_by" />
+            <outline text="method|pixeltable.DataFrame.limit" />
+            <outline text="method|pixeltable.DataFrame.distinct" />
+            <outline text="method|pixeltable.DataFrame.sample" />
+            <outline text="method|pixeltable.DataFrame.collect" />
+            <outline text="method|pixeltable.DataFrame.show" />
+            <outline text="method|pixeltable.DataFrame.head" />
+            <outline text="method|pixeltable.DataFrame.tail" />
+            <outline text="method|pixeltable.DataFrame.to_pytorch_dataset" />
+            <outline text="method|pixeltable.DataFrame.to_coco_dataset" />
+          </outline>
+
+          <outline text="class|pixeltable.ColumnMetadata" />
+          <outline text="class|pixeltable.DirContents" />
+          <outline text="class|pixeltable.IndexMetadata" />
+          <outline text="class|pixeltable.TableMetadata" />
+          <outline text="class|pixeltable.UpdateStatus" />
+          <outline text="class|pixeltable.VersionMetadata" />
+        </outline>
+      </outline>
+
+      <!-- Built-in Functions and Operators group -->
+      <outline text="group|Built-in Functions and Operators">
+        <outline text="module|pixeltable.functions.audio" />
+        <outline text="module|pixeltable.functions.date" />
+        <outline text="module|pixeltable.functions.image" />
+        <outline text="module|pixeltable.functions.json" />
+        <outline text="module|pixeltable.functions.math" />
+        <outline text="module|pixeltable.functions.string" />
+        <outline text="module|pixeltable.functions.timestamp" />
+        <outline text="module|pixeltable.functions.video" />
+      </outline>
+
+      <!-- AI Integrations group -->
+      <outline text="group|AI Integrations">
+        <outline text="module|pixeltable.functions.openai">
+          <outline text="func|pixeltable.functions.openai.speech" />
+          <outline text="func|pixeltable.functions.openai.transcriptions" />
+          <outline text="func|pixeltable.functions.openai.translations" />
+          <outline text="func|pixeltable.functions.openai.chat_completions" />
+          <outline text="func|pixeltable.functions.openai.vision" />
+          <outline text="func|pixeltable.functions.openai.embeddings" />
+          <outline text="func|pixeltable.functions.openai.image_generations" />
+          <outline text="func|pixeltable.functions.openai.moderations" />
+          <outline text="func|pixeltable.functions.openai.invoke_tools" />
+        </outline>
+        <outline text="module|pixeltable.functions.anthropic">
+          <outline text="func|pixeltable.functions.anthropic.messages" />
+          <outline text="func|pixeltable.functions.anthropic.invoke_tools" />
+        </outline>
+        <outline text="module|pixeltable.functions.huggingface">
+          <!-- Add specific functions when known -->
+        </outline>
+        <outline text="module|pixeltable.functions.gemini">
+          <outline text="func|pixeltable.functions.gemini.generate_content" />
+          <outline text="func|pixeltable.functions.gemini.generate_images" />
+          <outline text="func|pixeltable.functions.gemini.generate_videos" />
+          <outline text="func|pixeltable.functions.gemini.invoke_tools" />
+        </outline>
+        <outline text="module|pixeltable.functions.bedrock">
+          <outline text="func|pixeltable.functions.bedrock.converse" />
+          <outline text="func|pixeltable.functions.bedrock.invoke_tools" />
+        </outline>
+        <outline text="module|pixeltable.functions.groq">
+          <outline text="func|pixeltable.functions.groq.chat_completions" />
+          <outline text="func|pixeltable.functions.groq.invoke_tools" />
+        </outline>
+        <outline text="module|pixeltable.functions.replicate">
+          <outline text="func|pixeltable.functions.replicate.run" />
+        </outline>
+        <outline text="module|pixeltable.functions.together">
+          <outline text="func|pixeltable.functions.together.completions" />
+          <outline text="func|pixeltable.functions.together.chat_completions" />
+          <outline text="func|pixeltable.functions.together.embeddings" />
+          <outline text="func|pixeltable.functions.together.image_generations" />
+        </outline>
+        <outline text="module|pixeltable.functions.fireworks">
+          <outline text="func|pixeltable.functions.fireworks.chat_completions" />
+        </outline>
+        <outline text="module|pixeltable.functions.mistralai">
+          <outline text="func|pixeltable.functions.mistralai.chat_completions" />
+          <outline text="func|pixeltable.functions.mistralai.fim_completions" />
+          <outline text="func|pixeltable.functions.mistralai.embeddings" />
+        </outline>
+        <outline text="module|pixeltable.functions.deepseek">
+          <outline text="func|pixeltable.functions.deepseek.chat_completions" />
+        </outline>
+        <outline text="module|pixeltable.functions.ollama">
+          <outline text="func|pixeltable.functions.ollama.generate" />
+          <outline text="func|pixeltable.functions.ollama.chat" />
+          <outline text="func|pixeltable.functions.ollama.embed" />
+        </outline>
+        <outline text="module|pixeltable.functions.llama_cpp">
+          <outline text="func|pixeltable.functions.llama_cpp.create_chat_completion" />
+          <outline text="func|pixeltable.functions.llama_cpp.cleanup" />
+        </outline>
+        <outline text="module|pixeltable.functions.whisper">
+          <outline text="func|pixeltable.functions.whisper.transcribe" />
+        </outline>
+        <outline text="module|pixeltable.functions.vision">
+          <outline text="func|pixeltable.functions.vision.eval_detections" />
+          <outline text="func|pixeltable.functions.vision.draw_bounding_boxes" />
+        </outline>
+        <outline text="module|pixeltable.functions.yolox" />
+        <outline text="module|pixeltable.functions.whisperx" />
+      </outline>
+
+
+      <!-- Iterators group -->
+      <outline text="group|Iterators">
+        <outline text="module|pixeltable.iterators">
+          <!-- Iterator classes listed alphabetically -->
+          <outline text="class|pixeltable.iterators.AudioSplitter" />
+          <outline text="class|pixeltable.iterators.ComponentIterator" />
+          <outline text="class|pixeltable.iterators.DocumentSplitter" />
+          <outline text="class|pixeltable.iterators.FrameIterator" />
+          <outline text="class|pixeltable.iterators.StringSplitter" />
+          <outline text="class|pixeltable.iterators.TileIterator" />
+          <outline text="class|pixeltable.iterators.VideoSplitter" />
+        </outline>
+      </outline>
+
+      <!-- Import/Export group -->
+      <outline text="group|Import/Export">
+        <outline text="module|pixeltable.io">
+          <!-- Import functions -->
+          <outline text="func|pixeltable.io.import_csv" />
+          <outline text="func|pixeltable.io.import_excel" />
+          <outline text="func|pixeltable.io.import_json" />
+          <outline text="func|pixeltable.io.import_pandas" />
+          <outline text="func|pixeltable.io.import_parquet" />
+          <outline text="func|pixeltable.io.import_rows" />
+          <outline text="func|pixeltable.io.import_huggingface_dataset" />
+          <!-- Export functions -->
+          <outline text="func|pixeltable.io.export_parquet" />
+          <outline text="func|pixeltable.io.export_lancedb" />
+          <outline text="func|pixeltable.io.export_images_as_fo_dataset" />
+          <outline text="func|pixeltable.io.create_label_studio_project" />
+        </outline>
+      </outline>
+      
+    </outline>
+  </body>
+</opml>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,8 @@ dev = [
     "lancedb>=0.20",
     "google-cloud-storage>=2.18.0",
     "sqlalchemy-cockroachdb>=2.0.3",
-    "psycopg2-binary>=2.9.10"
+    "psycopg2-binary>=2.9.10",
+    "pixeltable-doctools @ git+https://github.com/pixeltable/pixeltable-doctools"
 ]
 test = [
     "pytest>=8.4",


### PR DESCRIPTION
This PR integrates the new pixeltable-doctools package for automated SDK documentation generation.

Changes

  - Add docs/public_api.opml - Defines the public API structure for documentation generation
  - Add pixeltable-doctools to dev dependencies - Installs documentation generation tools via uv sync
  - Add .gitignore entry - Ignores backup files created during documentation generation

Usage

Engineers can now generate and preview SDK documentation locally:

# Install dev dependencies (first time only)
conda activate pxt
uv sync

# Generate SDK documentation
mintlifier

# Preview locally (optional)
cd docs/mintlify
mintlify dev

The mintlifier command:
 - Reads docs/public_api.opml to determine what to document
 - Introspects Pixeltable classes to generate documentation
 - Creates SDK docs in docs/mintlify/docs/sdk/latest/
 - Updates navigation in docs/mintlify/docs.json
 - Stores backups in docs/mintlify/backups_from_generation/ (gitignored)
 - Note: Do not commit the generated documentation to main unless you want to publish
 
  Architecture

 - Documentation tools live in separate repo: https://github.com/pixeltable/pixeltable-doctools
 - API structure (public_api.opml) lives in this repo and is the source of truth for public api. This should be updated to add new methods/classes to the documentation. Public methods and functions are automatically generated. 
 - Generated docs are not committed in this PR - they will be generated by CI on release

