### PR TITLE
Document API Key Requirement in `publish()` Function

### DIFF
--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -407,6 +407,15 @@ def publish(
     Publishes a replica of a local Pixeltable table to Pixeltable cloud. A given table can be published to at most one
     URI per Pixeltable cloud database.
 
+    .. note::
+        **API Key Required**: This function requires a Pixeltable API key to authenticate with Pixeltable cloud.
+        Set your API key using one of these methods:
+        
+        * Environment variable: ``PIXELTABLE_API_KEY``
+        * Config file: Add ``api_key = 'your-key'`` to the ``[pixeltable]`` section in ``~/.pixeltable/config.toml``
+        
+        Without a valid API key, this function will fail when attempting to publish to the cloud.
+
     Args:
         source: Path or table handle of the local table to be published.
         destination_uri: Remote URI where the replica will be published, such as `'pxt://org_name/my_dir/my_table'`.


### PR DESCRIPTION
> [!NOTE]
> LLM generated PR


### **What**
Added documentation to the `publish()` function explaining that users need a Pixeltable API key to publish tables to Pixeltable cloud.

### **Why**
The function requires a Pixeltable API key to work, but this wasn't documented in the function's docstring.

### **How**
Added a `.. note::` section to the function's docstring that:
- States the API key requirement
- Shows two ways to set it up:
  - Environment variable: `PIXELTABLE_API_KEY`
  - Config file: Add `api_key = 'your-key'` to the `[pixeltable]` section in `~/.pixeltable/config.toml`
- Explains that the function will fail without a valid API key

### **Result**
Users will now see this information when they:
- Look up the function with `help(pxt.publish)`
- Use IDE tooltips or auto-completion
- View the documentation website

This helps users understand the requirement before they try to use the function.