### PR TITLE
Fix broken links at the bottom of basics notebook

### DIFF
--- a/docs/notebooks/pixeltable-basics.ipynb
+++ b/docs/notebooks/pixeltable-basics.ipynb
@@ -1054,9 +1054,9 @@
    "metadata": {},
    "source": [
     "Congratulations! You've reached the end of the tutorial. Hopefully, this gives a good overview of the capabilities of Pixeltable, but there's much more to explore. As a next step, you might check out one of the other tutorials, depending on your interests:\n",
-    "- [Object Detection in Videos](https://pixeltable.readme.io/docs/object-detection-in-videos/)\n",
-    "- [RAG Operations in Pixeltable](https://pixeltable.readme.io/docs/rag-operations/)\n",
-    "- [Working with OpenAI in Pixeltable](https://pixeltable.readme.io/docs/working-with-openai/)"
+    "- [Object Detection in Videos](https://github.com/pixeltable/pixeltable/blob/main/docs/notebooks/use-cases/object-detection-in-videos.ipynb)\n",
+    "- [RAG Operations in Pixeltable](https://github.com/pixeltable/pixeltable/blob/main/docs/notebooks/use-cases/rag-operations.ipynb)\n",
+    "- [Working with OpenAI in Pixeltable](https://github.com/pixeltable/pixeltable/blob/main/docs/notebooks/integrations/working-with-openai.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
**Updated notebook reference links in pixeltable-basics.ipynb**

Replaced outdated ReadMe.io documentation links with direct GitHub repository links for three tutorial notebooks:
- Object Detection in Videos: Now points to `use-cases/object-detection-in-videos.ipynb`
- RAG Operations: Now points to `use-cases/rag-operations.ipynb`  
- Working with OpenAI: Now points to `integrations/working-with-openai.ipynb`

All links now reference the notebooks directly in the GitHub repository (`github.com/pixeltable/pixeltable/blob/main/docs/notebooks/...`) instead of the legacy ReadMe.io URLs.

Closes https://github.com/pixeltable/pixeltable/issues/845