### PR TITLE
Repro for pxt.move() concurrency issue

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -790,17 +790,17 @@ class Catalog:
         return result
 
     @retry_loop(for_write=True)
-    def move(self, path: Path, new_path: Path) -> None:
-        self._move(path, new_path)
+    def move(self, path: Path, new_path: Path, if_exists: IfExistsParam, if_not_exists: IfNotExistsParam) -> None:
+        self._move(path, new_path, if_exists, if_not_exists)
 
-    def _move(self, path: Path, new_path: Path) -> None:
+    def _move(self, path: Path, new_path: Path, if_exists: IfExistsParam, if_not_exists: IfNotExistsParam) -> None:
         _, dest_dir, src_obj = self._prepare_dir_op(
             add_dir_path=new_path.parent,
             add_name=new_path.name,
             drop_dir_path=path.parent,
             drop_name=path.name,
-            raise_if_exists=True,
-            raise_if_not_exists=True,
+            raise_if_exists=(if_exists == 'abort'),
+            raise_if_not_exists=(if_not_exists == 'abort'),
         )
         src_obj._move(new_path.name, dest_dir._id)
 

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -802,10 +802,13 @@ class Catalog:
             raise_if_exists=(if_exists == IfExistsParam.ERROR),
             raise_if_not_exists=(if_not_exists == IfNotExistsParam.ERROR),
         )
-        if src_obj is None or dest_obj is not None:
-            # one if `if_exists` or `if_not_exists` is 'ignore', and the corresponding condition was met
-            return
-        src_obj._move(new_path.name, dest_dir._id)
+        assert dest_obj is None or if_exists == IfExistsParam.IGNORE
+        assert src_obj is not None or if_not_exists == IfNotExistsParam.IGNORE
+        if dest_obj is None and src_obj is not None:
+            # If dest_obj is not None, it means `if_exists='ignore'` and the destination already exists.
+            # If src_obj is None, it means `if_not_exists='ignore'` and the source doesn't exist.
+            # If dest_obj is None and src_obj is not None, then we can proceed with the move.
+            src_obj._move(new_path.name, dest_dir._id)
 
     def _prepare_dir_op(
         self,

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -433,7 +433,7 @@ class Catalog:
 
         The function should not raise exceptions; if it does, they are logged and ignored.
         """
-        assert Env.get().in_xact
+        assert self.in_write_xact
         self._undo_actions.append(func)
         return func
 
@@ -790,25 +790,19 @@ class Catalog:
         return result
 
     @retry_loop(for_write=True)
-    def move(self, path: Path, new_path: Path, if_exists: IfExistsParam, if_not_exists: IfNotExistsParam) -> None:
-        self._move(path, new_path, if_exists, if_not_exists)
+    def move(self, path: Path, new_path: Path) -> None:
+        self._move(path, new_path)
 
-    def _move(self, path: Path, new_path: Path, if_exists: IfExistsParam, if_not_exists: IfNotExistsParam) -> None:
-        dest_obj, dest_dir, src_obj = self._prepare_dir_op(
+    def _move(self, path: Path, new_path: Path) -> None:
+        _, dest_dir, src_obj = self._prepare_dir_op(
             add_dir_path=new_path.parent,
             add_name=new_path.name,
             drop_dir_path=path.parent,
             drop_name=path.name,
-            raise_if_exists=(if_exists == IfExistsParam.ERROR),
-            raise_if_not_exists=(if_not_exists == IfNotExistsParam.ERROR),
+            raise_if_exists=True,
+            raise_if_not_exists=True,
         )
-        assert dest_obj is None or if_exists == IfExistsParam.IGNORE
-        assert src_obj is not None or if_not_exists == IfNotExistsParam.IGNORE
-        if dest_obj is None and src_obj is not None:
-            # If dest_obj is not None, it means `if_exists='ignore'` and the destination already exists.
-            # If src_obj is None, it means `if_not_exists='ignore'` and the source doesn't exist.
-            # If dest_obj is None and src_obj is not None, then we can proceed with the move.
-            src_obj._move(new_path.name, dest_dir._id)
+        src_obj._move(new_path.name, dest_dir._id)
 
     def _prepare_dir_op(
         self,
@@ -819,7 +813,7 @@ class Catalog:
         drop_expected: Optional[type[SchemaObject]] = None,
         raise_if_exists: bool = False,
         raise_if_not_exists: bool = False,
-    ) -> tuple[Optional[SchemaObject], Optional[Dir], Optional[SchemaObject]]:
+    ) -> tuple[Optional[SchemaObject], Optional[SchemaObject], Optional[SchemaObject]]:
         """
         Validates paths and acquires locks needed for a directory operation, ie, add/drop/rename (add + drop) of a
         directory entry.
@@ -906,10 +900,9 @@ class Catalog:
             schema.Table.md['name'].astext == name,
             schema.Table.md['user'].astext == user,
         )
-        tbl_id = conn.execute(q).scalars().all()
-        assert len(tbl_id) <= 1, name
-        if len(tbl_id) == 1:
-            return self.get_table_by_id(tbl_id[0], version)
+        tbl_id = conn.execute(q).scalar_one_or_none()
+        if tbl_id is not None:
+            return self.get_table_by_id(tbl_id, version)
 
         return None
 
@@ -1089,7 +1082,7 @@ class Catalog:
         The metadata should be presented in standard "ancestor order", with the table being replicated at
         list position 0 and the (root) base table at list position -1.
         """
-        assert Env.get().in_xact
+        assert self.in_write_xact
 
         tbl_id = UUID(md[0].tbl_md.tbl_id)
 
@@ -1159,7 +1152,7 @@ class Catalog:
             existing_path = Path.parse(existing._path(), allow_system_path=True)
             if existing_path != path:
                 assert existing_path.is_system_path
-                self._move(existing_path, path, IfExistsParam.ERROR, IfNotExistsParam.ERROR)
+                self._move(existing_path, path)
 
     def __ensure_system_dir_exists(self) -> Dir:
         system_path = Path.parse('_system', allow_system_path=True)

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -77,6 +77,14 @@ class Table(SchemaObject):
         self._tbl_version = None
 
     def _move(self, new_name: str, new_dir_id: UUID) -> None:
+        old_name = self._name
+        old_dir_id = self._dir_id
+
+        cat = catalog.Catalog.get()
+        @cat.register_undo_action
+        def _() -> None:
+            super()._move(old_name, old_dir_id)
+
         super()._move(new_name, new_dir_id)
         conn = env.Env.get().conn
         stmt = sql.text(

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -81,9 +81,11 @@ class Table(SchemaObject):
         old_dir_id = self._dir_id
 
         cat = catalog.Catalog.get()
+
         @cat.register_undo_action
         def _() -> None:
-            super()._move(old_name, old_dir_id)
+            self._name = old_name
+            self._dir_id = old_dir_id
 
         super()._move(new_name, new_dir_id)
         conn = env.Env.get().conn

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -487,12 +487,22 @@ def get_table(path: str, if_not_exists: Literal['error', 'ignore'] = 'error') ->
     return tbl
 
 
-def move(path: str, new_path: str) -> None:
+def move(path: str, new_path: str, *, if_exists: Literal['error', 'ignore'] = 'error', if_not_exists: Literal['error', 'ignore'] = 'error') -> None:
     """Move a schema object to a new directory and/or rename a schema object.
 
     Args:
         path: absolute path to the existing schema object.
         new_path: absolute new path for the schema object.
+        if_exists: Directive regarding how to handle if a schema object already exists at the new path.
+            Must be one of the following:
+
+            - `'error'`: raise an error
+            - `'ignore'`: do nothing and return
+        if_not_exists: Directive regarding how to handle if the source path does not exist.
+            Must be one of the following:
+
+            - `'error'`: raise an error
+            - `'ignore'`: do nothing and return
 
     Raises:
         Error: If path does not exist or new_path already exists.
@@ -506,13 +516,17 @@ def move(path: str, new_path: str) -> None:
 
         >>>> pxt.move('dir1.my_table', 'dir1.new_name')
     """
+    if_exists_ = catalog.IfExistsParam.validated(if_exists, 'if_exists')
+    if if_exists_ not in (catalog.IfExistsParam.ERROR, catalog.IfExistsParam.IGNORE):
+        raise excs.Error("`if_exists` must be one of 'error' or 'ignore'")
+    if_not_exists_ = catalog.IfNotExistsParam.validated(if_not_exists, 'if_not_exists')
     if path == new_path:
         raise excs.Error('move(): source and destination cannot be identical')
     path_obj, new_path_obj = catalog.Path.parse(path), catalog.Path.parse(new_path)
     if path_obj.is_ancestor(new_path_obj):
         raise excs.Error(f'move(): cannot move {path!r} into its own subdirectory')
     cat = Catalog.get()
-    cat.move(path_obj, new_path_obj)
+    cat.move(path_obj, new_path_obj, if_exists_, if_not_exists_)
 
 
 def drop_table(
@@ -660,7 +674,7 @@ def _list_tables(dir_path: str = '', recursive: bool = True, allow_system_paths:
 
 
 def create_dir(
-    path: str, if_exists: Literal['error', 'ignore', 'replace', 'replace_force'] = 'error', parents: bool = False
+    path: str, *, if_exists: Literal['error', 'ignore', 'replace', 'replace_force'] = 'error', parents: bool = False
 ) -> Optional[catalog.Dir]:
     """Create a directory.
 

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -525,8 +525,7 @@ def move(path: str, new_path: str, *, if_exists: Literal['error', 'ignore'] = 'e
     path_obj, new_path_obj = catalog.Path.parse(path), catalog.Path.parse(new_path)
     if path_obj.is_ancestor(new_path_obj):
         raise excs.Error(f'move(): cannot move {path!r} into its own subdirectory')
-    cat = Catalog.get()
-    cat.move(path_obj, new_path_obj, if_exists_, if_not_exists_)
+    Catalog.get().move(path_obj, new_path_obj, if_exists_, if_not_exists_)
 
 
 def drop_table(

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -487,22 +487,12 @@ def get_table(path: str, if_not_exists: Literal['error', 'ignore'] = 'error') ->
     return tbl
 
 
-def move(path: str, new_path: str, *, if_exists: Literal['error', 'ignore'] = 'error', if_not_exists: Literal['error', 'ignore'] = 'error') -> None:
+def move(path: str, new_path: str) -> None:
     """Move a schema object to a new directory and/or rename a schema object.
 
     Args:
         path: absolute path to the existing schema object.
         new_path: absolute new path for the schema object.
-        if_exists: Directive regarding how to handle if a schema object already exists at the new path.
-            Must be one of the following:
-
-            - `'error'`: raise an error
-            - `'ignore'`: do nothing and return
-        if_not_exists: Directive regarding how to handle if the source path does not exist.
-            Must be one of the following:
-
-            - `'error'`: raise an error
-            - `'ignore'`: do nothing and return
 
     Raises:
         Error: If path does not exist or new_path already exists.
@@ -516,16 +506,13 @@ def move(path: str, new_path: str, *, if_exists: Literal['error', 'ignore'] = 'e
 
         >>>> pxt.move('dir1.my_table', 'dir1.new_name')
     """
-    if_exists_ = catalog.IfExistsParam.validated(if_exists, 'if_exists')
-    if if_exists_ not in (catalog.IfExistsParam.ERROR, catalog.IfExistsParam.IGNORE):
-        raise excs.Error("`if_exists` must be one of 'error' or 'ignore'")
-    if_not_exists_ = catalog.IfNotExistsParam.validated(if_not_exists, 'if_not_exists')
     if path == new_path:
         raise excs.Error('move(): source and destination cannot be identical')
     path_obj, new_path_obj = catalog.Path.parse(path), catalog.Path.parse(new_path)
     if path_obj.is_ancestor(new_path_obj):
         raise excs.Error(f'move(): cannot move {path!r} into its own subdirectory')
-    Catalog.get().move(path_obj, new_path_obj, if_exists_, if_not_exists_)
+    cat = Catalog.get()
+    cat.move(path_obj, new_path_obj)
 
 
 def drop_table(
@@ -673,7 +660,7 @@ def _list_tables(dir_path: str = '', recursive: bool = True, allow_system_paths:
 
 
 def create_dir(
-    path: str, *, if_exists: Literal['error', 'ignore', 'replace', 'replace_force'] = 'error', parents: bool = False
+    path: str, if_exists: Literal['error', 'ignore', 'replace', 'replace_force'] = 'error', parents: bool = False
 ) -> Optional[catalog.Dir]:
     """Create a directory.
 

--- a/tests/test_replica.py
+++ b/tests/test_replica.py
@@ -25,6 +25,7 @@ class TestReplica:
 
         pxt.drop_table(test_tbl, force=True)
         reload_catalog()
+        cat = Catalog.get()
 
         with cat.begin_xact(for_write=True):
             cat.create_replica(Path.parse('replica_1'), md1)
@@ -93,6 +94,7 @@ class TestReplica:
 
         pxt.drop_table('base_tbl', force=True)
         reload_catalog()
+        cat = Catalog.get()
 
         for i, md in enumerate(s11_md):
             print(f'\n{i}: {md}')

--- a/tool/random_tbl_ops_2.py
+++ b/tool/random_tbl_ops_2.py
@@ -192,7 +192,7 @@ class RandomTblOps:
             n = (n + 1) % 100  # Ensure new name is different
         new_name = f'view_{n}'  # This will occasionally lead to name collisions, which is intended
         yield f'Rename view {self.tbl_descr(t)} to {new_name!r}: '
-        pxt.move(t._name, new_name, if_exists='ignore')
+        pxt.move(t._name, new_name, if_exists='ignore', if_not_exists='ignore')
         yield 'Success.'
 
     def drop_view(self) -> Iterator[str]:

--- a/tool/random_tbl_ops_2.py
+++ b/tool/random_tbl_ops_2.py
@@ -197,6 +197,7 @@ class RandomTblOps:
         try:
             pxt.move(t._name, new_name)
         except pxt.Error as e:
+            # Catch all pxt.Errors here, not just concurrency errors (because we don't have if_exists/if_not_exists yet)
             yield f'pxt.Error: {e}'
             return
         yield 'Success.'

--- a/tool/random_tbl_ops_2.py
+++ b/tool/random_tbl_ops_2.py
@@ -58,7 +58,8 @@ class RandomTblOps:
         ('add_computed_column', 5, False),
         ('drop_column', 3, False),
         ('create_view', 5, False),
-        ('drop_view', 3, False),
+        ('rename_view', 5, False),
+        ('drop_view', 1, False),
         ('drop_table', 0.25, False),
     )
 
@@ -179,6 +180,19 @@ class RandomTblOps:
         yield f'Create view {vname!r} on {self.tbl_descr(t)}: '
         # TODO: Change 'ignore' to 'replace-force' after fixing PXT-774
         pxt.create_view(vname, t.where(t.c0 % p == 0), if_exists='ignore')
+        yield 'Success.'
+
+    def rename_view(self) -> Iterator[str]:
+        t = self.get_random_tbl(allow_base_tbl=False)  # Must be a view
+        if t is None:
+            yield 'No views to rename.'
+            return
+        n = int(random.uniform(0, 100))
+        if f'view_{n}' == t._name:
+            n = (n + 1) % 100  # Ensure new name is different
+        new_name = f'view_{n}'  # This will occasionally lead to name collisions, which is intended
+        yield f'Rename view {self.tbl_descr(t)} to {new_name!r}: '
+        pxt.move(t._name, new_name, if_exists='ignore')
         yield 'Success.'
 
     def drop_view(self) -> Iterator[str]:


### PR DESCRIPTION
Repro:
```
git checkout pxt-move-concurrency
./scripts/run-random-tbl-ops.sh 6 3600
```
It will reliably fail within 10 minutes or so.

There is only one code change, which is to add an undo action to `Table._move()`. I tested both with and without this change.