### PR TITLE
Fixed incorrect documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The only open source Python library providing declarative data infrastructure fo
 [![PyPI Package](https://img.shields.io/pypi/v/pixeltable?color=4D148C)](https://pypi.org/project/pixeltable/)
 [![My Discord (1306431018890166272)](https://img.shields.io/badge/💬-Discord-%235865F2.svg)](https://discord.gg/QPyqFYx2UN)
 
-[**Quick Start**](https://docs.pixeltable.com/docs/overview/quick-start) |
+[**Quick Start**](https://docs.pixeltable.com/overview/quick-start) |
 [**Documentation**](https://docs.pixeltable.com/) |
 [**API Reference**](https://pixeltable.github.io/pixeltable/) |
 [**Sample Apps**](https://github.com/pixeltable/pixeltable/tree/main/docs/sample-apps) |
@@ -39,8 +39,8 @@ https://github.com/user-attachments/assets/b50fd6df-5169-4881-9dbe-1b6e5d06cede
 ## Quick Start
 
 With Pixeltable, you define your *entire* data processing and AI workflow declaratively using
-**[computed columns](https://docs.pixeltable.com/docs/datastore/computed-columns)** on
-**[tables](https://docs.pixeltable.com/docs/datastore/tables-and-operations)**.
+**[computed columns](https://docs.pixeltable.com/datastore/computed-columns)** on
+**[tables](https://docs.pixeltable.com/datastore/tables-and-operations)**.
 Focus on your application logic, not the data plumbing.
 
 ```python
@@ -94,17 +94,17 @@ results = t.select(
 
 ## What Happened?
 
-* **Data Ingestion & Storage:** References [files](https://docs.pixeltable.com/docs/datastore/bringing-data)
+* **Data Ingestion & Storage:** References [files](https://docs.pixeltable.com/datastore/bringing-data)
     (images, videos, audio, docs) in place, handles structured data.
-* **Transformation & Processing:** Applies *any* Python function ([UDFs](https://docs.pixeltable.com/docs/datastore/custom-functions))
-    or built-in operations ([chunking, frame extraction](https://docs.pixeltable.com/docs/datastore/iterators)) automatically.
-* **AI Model Integration:** Runs inference ([embeddings](https://docs.pixeltable.com/docs/datastore/embedding-index),
-    [object detection](https://docs.pixeltable.com/docs/examples/vision/yolox),
-    [LLMs](https://docs.pixeltable.com/docs/integrations/frameworks#cloud-llm-providers)) as part of the data pipeline.
+* **Transformation & Processing:** Applies *any* Python function ([UDFs](https://docs.pixeltable.com/datastore/custom-functions))
+    or built-in operations ([chunking, frame extraction](https://docs.pixeltable.com/datastore/iterators)) automatically.
+* **AI Model Integration:** Runs inference ([embeddings](https://docs.pixeltable.com/datastore/vector-database),
+    [object detection](https://docs.pixeltable.com/examples/vision/yolox),
+    [LLMs](https://docs.pixeltable.com/integrations/frameworks#cloud-llm-providers)) as part of the data pipeline.
 * **Indexing & Retrieval:** Creates and manages vector indexes for fast
-    [semantic search](https://docs.pixeltable.com/docs/datastore/embedding-index#phase-3%3A-query)
+    [semantic search](https://docs.pixeltable.com/datastore/vector-database#phase-3%3A-query)
     alongside traditional filtering.
-* **Incremental Computation:** Only [recomputes](https://docs.pixeltable.com/docs/overview/quick-start) what's
+* **Incremental Computation:** Only [recomputes](https://docs.pixeltable.com/overview/quick-start) what's
     necessary when data or code changes, saving time and cost.
 * **Versioning & Lineage:** Automatically tracks data and schema changes for reproducibility. See below for an example
     that uses "time travel" to query an older version of a table.
@@ -128,7 +128,7 @@ managed by Pixeltable and is intended to be accessed through the Pixeltable Pyth
 
 ## Key Principles
 
-**[Unified Multimodal Interface:](https://docs.pixeltable.com/docs/datastore/tables-and-operations)** `pxt.Image`,
+**[Unified Multimodal Interface:](https://docs.pixeltable.com/datastore/tables-and-operations)** `pxt.Image`,
 `pxt.Video`, `pxt.Audio`, `pxt.Document`, etc. – manage diverse data consistently.
 
 ```python
@@ -141,7 +141,7 @@ t = pxt.create_table(
 )
 ```
 
-**[Declarative Computed Columns:](https://docs.pixeltable.com/docs/datastore/computed-columns)** Define processing
+**[Declarative Computed Columns:](https://docs.pixeltable.com/datastore/computed-columns)** Define processing
 steps once; they run automatically on new/updated data.
 
 ```python
@@ -152,7 +152,7 @@ t.add_computed_column(
 )
 ```
 
-**[Built-in Vector Search:](https://docs.pixeltable.com/docs/datastore/embedding-index)** Add embedding indexes and
+**[Built-in Vector Search:](https://docs.pixeltable.com/datastore/vector-database)** Add embedding indexes and
 perform similarity searches directly on tables/views.
 
 ```python
@@ -166,7 +166,7 @@ t.add_embedding_index(
 sim = t.img.similarity("cat playing with yarn")
 ```
 
-**[Incremental View Maintenance:](https://docs.pixeltable.com/docs/datastore/views)** Create virtual tables using iterators
+**[Incremental View Maintenance:](https://docs.pixeltable.com/datastore/views)** Create virtual tables using iterators
 for efficient processing without data duplication.
 
 ```python
@@ -183,7 +183,7 @@ frames = pxt.create_view('frames', videos,
    iterator=FrameIterator.create(video=videos.video, fps=0.5))
 ```
 
-**[Seamless AI Integration:](https://docs.pixeltable.com/docs/integrations/frameworks)** Built-in functions for
+**[Seamless AI Integration:](https://docs.pixeltable.com/integrations/frameworks)** Built-in functions for
 OpenAI, Anthropic, Hugging Face, CLIP, YOLOX, and more.
 
 ```python
@@ -207,7 +207,7 @@ t.add_computed_column(
 )
 ```
 
-**[Bring Your Own Code:](https://docs.pixeltable.com/docs/datastore/custom-functions)** Extend Pixeltable with UDFs, batch processing, and custom aggregators.
+**[Bring Your Own Code:](https://docs.pixeltable.com/datastore/custom-functions)** Extend Pixeltable with UDFs, batch processing, and custom aggregators.
 
 ```python
 @pxt.udf
@@ -215,7 +215,7 @@ def format_prompt(context: list, question: str) -> str:
    return f"Context: {context}\nQuestion: {question}"
 ```
 
-**[Agentic Workflows / Tool Calling:](https://docs.pixeltable.com/docs/examples/chat/tools)** Register `@pxt.udf`, 
+**[Agentic Workflows / Tool Calling:](https://docs.pixeltable.com/examples/chat/tools)** Register `@pxt.udf`, 
 `@pxt.query` functions, or **MCP tools** as tools.
 
 ```python
@@ -229,7 +229,7 @@ t.add_computed_column(
 )
 ```
 
-**[Data Persistence:](https://docs.pixeltable.com/docs/datastore/tables-and-operations#data-operations)** All data,
+**[Data Persistence:](https://docs.pixeltable.com/datastore/tables-and-operations#data-operations)** All data,
 metadata, and computed results are automatically stored and versioned.
 
 ```python
@@ -238,7 +238,7 @@ t.select(t.account, t.balance).collect()  # Query its contents
 t.revert()  # Undo the last modification to the table and restore its previous state
 ```
 
-**[Time Travel:](https://docs.pixeltable.com/docs/datastore/tables-and-operations#data-operations)** By default,
+**[Time Travel:](https://docs.pixeltable.com/datastore/tables-and-operations#data-operations)** By default,
 Pixeltable preserves the full change history of each table, and any prior version can be selected and queried.
 
 ```python
@@ -247,7 +247,7 @@ old_version = pxt.get_table('my_table:472')  # Get a handle to a specific table 
 old_version.select(t.account, t.balance).collect()  # Query the older version
 ```
 
-**[SQL-like Python Querying:](https://docs.pixeltable.com/docs/datastore/filtering-and-selecting)** Familiar syntax
+**[SQL-like Python Querying:](https://docs.pixeltable.com/datastore/filtering-and-selecting)** Familiar syntax
 combined with powerful AI capabilities.
 
 ```python
@@ -284,7 +284,7 @@ pxt.export_images_as_fo_dataset(table, table.image)   # FiftyOne
 
 ## Key Examples
 
-*(See the [Full Quick Start](https://docs.pixeltable.com/docs/overview/quick-start) or
+*(See the [Full Quick Start](https://docs.pixeltable.com/overview/quick-start) or
 [Notebook Gallery](#-notebook-gallery) for more details)*
 
 **1. Multimodal Data Store and Data Transformation (Computed Column):**
@@ -485,7 +485,7 @@ Explore Pixeltable's capabilities interactively:
 | 10-Min Tour | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/pixeltable-basics.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | OpenAI | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-openai.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> |
 | Tables & Ops | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/fundamentals/tables-and-data-operations.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Anthropic | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-anthropic.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> |
 | UDFs | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/udfs-in-pixeltable.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Together AI | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-together.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> |
-| Embedding Index | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/embedding-and-vector-indexes.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Label Studio | <a target="_blank" href="https://docs.pixeltable.com/docs/cookbooks/vision/label-studio"> <img src="https://img.shields.io/badge/📚%20Docs-013056" alt="Visit Docs"/></a> |
+| Embedding Index | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/embedding-and-vector-indexes.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Label Studio | <a target="_blank" href="https://docs.pixeltable.com/examples/vision/label-studio"> <img src="https://img.shields.io/badge/📚%20Docs-013056" alt="Visit Docs"/></a> |
 | External Files | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/working-with-external-files.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Mistral | <a target="_blank" href="https://colab.research.google.com/github/mistralai/cookbook/blob/main/third_party/Pixeltable/incremental_prompt_engineering_and_model_comparison.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Github"/> |
 | **Use Cases** | | **Sample Apps** | |
 | RAG Demo | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/use-cases/rag-demo.ipynb">  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> | Multimodal Agent | <a target="_blank" href="https://huggingface.co/spaces/Pixeltable/Multimodal-Powerhouse"> <img src="https://img.shields.io/badge/🤗%20Demo-FF7D04" alt="HF Space"/></a> |
@@ -494,7 +494,7 @@ Explore Pixeltable's capabilities interactively:
 
 ## Maintaining Production-Ready Multimodal AI Apps is Still Too Hard
 
-Building robust AI applications, especially [multimodal](https://docs.pixeltable.com/docs/datastore/bringing-data) ones,
+Building robust AI applications, especially [multimodal](https://docs.pixeltable.com/datastore/bringing-data) ones,
 requires stitching together numerous tools:
 
 * ETL pipelines for data loading and transformation.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,7 +11,7 @@
     iterators for data transformation
 - [pixeltable.functions](https://pixeltable.github.io/pixeltable/pixeltable/functions/audio/): Pre-built functions for
     common operations
-- [Configuration Options](https://docs.pixeltable.com/docs/overview/configuration): Most options can be specified either
+- [Configuration Options](https://docs.pixeltable.com/overview/configuration): Most options can be specified either
     as an environment variable or in `config.toml`
 
 ## Resources

--- a/docs/mintlify/docs/integrations/frameworks.mdx
+++ b/docs/mintlify/docs/integrations/frameworks.mdx
@@ -153,7 +153,7 @@ If you have a framework that you want us to integrate with, please reach out and
 <Card
   title="Whisper/WhisperX"
   icon="waveform"
-  href="http://localhost:3000/docs/examples/search/audio"
+  href="https://docs.pixeltable.com/examples/search/audio"
 >
   High-quality speech recognition and transcription using OpenAI's Whisper models
 </Card>

--- a/docs/mintlify/docs/overview/building-pixeltable-with-llms.mdx
+++ b/docs/mintlify/docs/overview/building-pixeltable-with-llms.mdx
@@ -8,9 +8,9 @@ icon: 'hammer'
 
 You can use large language models (LLMs) to assist in building Pixeltable integrations. We provide a set of tools and best practices if you use LLMs during development.
 
-## Plain text docs 
+## Plain text docs
 
-You can access all of our documentation as plain text markdown files by adding `.md` to the end of any url. For example, you can find the plain text version of this page itself at [https://docs.pixeltable.com/docs/overview/building-pixeltable-with-llms.md](https://docs.pixeltable.com/docs/overview/building-pixeltable-with-llms.md).
+You can access all of our documentation as plain text markdown files by adding `.md` to the end of any url. For example, you can find the plain text version of this page itself at [https://docs.pixeltable.com/overview/building-pixeltable-with-llms.md](https://docs.pixeltable.com/overview/building-pixeltable-with-llms.md).
 
 This helps AI tools and agents consume our content and allows you to copy and paste the entire contents of a doc into an LLM. This format is preferable to scraping or copying from our HTML and JavaScript-rendered pages because:
 
@@ -26,7 +26,7 @@ We host two files to assist AI tools and agents:
 
 These files help AI tools navigate and understand our documentation more effectively.
 
-## Pixeltable Model Context Protocol (MCP) Server 
+## Pixeltable Model Context Protocol (MCP) Server
 
 For developers using code editors that use AI, such as Cursor or Windsurf, or general purpose tools such as Claude Desktop, we provide the [Pixeltable Model Context Protocol (MCP)](/docs/libraries/mcp) server. The MCP server provides AI agents a set of tools for calling the Pixeltable API and searching our knowledge base (documentation, support articles, and so on).
 
@@ -41,7 +41,7 @@ For developers using code editors that use AI, such as Cursor or Windsurf, or ge
 
 ## Pixelagent Toolkit
 
-If you're building agentic software, we provide an SDK for adding Pixeltable functionality to your agent's capabilities. 
+If you're building agentic software, we provide an SDK for adding Pixeltable functionality to your agent's capabilities.
 
 <Card title="Pixelagent" icon="github" href="https://github.com/pixeltable/pixelagent">
   Agent engineering blueprint powered on Pixeltable

--- a/docs/mintlify/docs/sdk/latest/io.mdx
+++ b/docs/mintlify/docs/sdk/latest/io.mdx
@@ -112,7 +112,7 @@ Export images from a Pixeltable table as a Voxel51 dataset. The data must consis
 
 (or expression) containing image data, along with optional additional columns containing labels. Currently, only classification and detection labels are supported.
 
-The [Working with Voxel51 in Pixeltable](https://docs.pixeltable.com/docs/working-with-voxel51) tutorial contains a fully worked example showing how to export data from a Pixeltable table and load it into Voxel51.
+The [Working with Voxel51 in Pixeltable](https://docs.pixeltable.com/examples/vision/voxel51) tutorial contains a fully worked example showing how to export data from a Pixeltable table and load it into Voxel51.
 
 Images in the dataset that already exist on disk will be exported directly, in whatever format they are stored in. Images that are not already on disk (such as frames extracted using a [`FrameIterator`](pixeltable.iterators.FrameIterator)) will first be written to disk in the specified `image_format`.
 

--- a/docs/notebooks/feature-guides/embedding-indexes.ipynb
+++ b/docs/notebooks/feature-guides/embedding-indexes.ipynb
@@ -851,7 +851,7 @@
     "Our example UDF is very simple, but it would perform poorly in a production setting. To make our UDF production-ready, we'd want to do two things:\n",
     "\n",
     "- Cache the model: the current version calls `hub.load()` on every UDF invocation. In a real application, we'd want to instantiate the model just once, then reuse it on subsequent UDF calls.\n",
-    "- Batch our inputs: we'd use Pixeltable's batching capability to ensure we're making efficient use of the model. Batched UDFs are described in depth in the [User-Defined Functions](https://docs.pixeltable.com/docs/user-defined-functions-udfs) how-to guide.\n",
+    "- Batch our inputs: we'd use Pixeltable's batching capability to ensure we're making efficient use of the model. Batched UDFs are described in depth in the [User-Defined Functions](https://docs.pixeltable.com/datastore/custom-functions) how-to guide.\n",
     "\n",
     "You might have noticed that the updates to `bert_idx` seem sluggish; that's why!"
    ]

--- a/docs/notebooks/fundamentals/computed-columns.ipynb
+++ b/docs/notebooks/fundamentals/computed-columns.ipynb
@@ -292,7 +292,7 @@
    "id": "512a5b14-998a-458f-8cd1-a8cec212c1b7",
    "metadata": {},
    "source": [
-    "Now let's suppose we want to add a new column for the year-over-year population change from 2022 to 2023. In the previous tutorial section, [Tables and Data Operations](https://docs.pixeltable.com/docs/tables-and-data-operations), we saw how one might `select()` such a quantity into a Pixeltable `DataFrame`, giving it the name `yoy_change` (year-over-year change):"
+    "Now let's suppose we want to add a new column for the year-over-year population change from 2022 to 2023. In the previous tutorial section, [Tables and Data Operations](https://docs.pixeltable.com/datastore/tables-and-operations), we saw how one might `select()` such a quantity into a Pixeltable `DataFrame`, giving it the name `yoy_change` (year-over-year change):"
    ]
   },
   {

--- a/docs/notebooks/fundamentals/queries-and-expressions.ipynb
+++ b/docs/notebooks/fundamentals/queries-and-expressions.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "Welcome to Section 3 of the __Pixeltable Fundamentals__ tutorial, __Queries and Expressions__.\n",
     "\n",
-    "In the previous section of this tutorial, [Computed Columns](https://docs.pixeltable.com/docs/computed-columns), we saw how to issue queries over Pixeltable tables, such as:\n",
+    "In the previous section of this tutorial, [Computed Columns](https://docs.pixeltable.com/datastore/computed-columns), we saw how to issue queries over Pixeltable tables, such as:\n",
     "\n",
     "```python\n",
     "pop_t.select(yoy_change=(pop_t.pop_2023 - pop_t.pop_2022)).collect()\n",
@@ -983,7 +983,7 @@
     ")\n",
     "```\n",
     "\n",
-    "This calls the `vit_for_image_classification` UDF in the `pxt.functions.huggingface` module. Note that `vit_for_image_classification` is a Pixeltable UDF, not an ordinary Python function. (UDFs were first discussed in the [Tables and Data Operations](https://docs.pixeltable.com/docs/computed-columns) section of this tutorial.) You can think of a Pixeltable UDF as a function that operates on columns of data, iteratively applying an underlying operation to each row in the column (or columns). In this case, `vit_for_image_classification` operates on `t.image`, running the model against every image in the column.\n",
+    "This calls the `vit_for_image_classification` UDF in the `pxt.functions.huggingface` module. Note that `vit_for_image_classification` is a Pixeltable UDF, not an ordinary Python function. (UDFs were first discussed in the [Tables and Data Operations](https://docs.pixeltable.com/datastore/computed-columns) section of this tutorial.) You can think of a Pixeltable UDF as a function that operates on columns of data, iteratively applying an underlying operation to each row in the column (or columns). In this case, `vit_for_image_classification` operates on `t.image`, running the model against every image in the column.\n",
     "\n",
     "Notice that in addition to the column `t.image`, this call to `vit_for_image_classification` also takes a constant argument specifying the `model_id`. Any UDF call argument may be a constant, and the constant value simply means \"use this value for every row being evaluated\".\n",
     "\n",
@@ -1938,7 +1938,7 @@
    "id": "a40c5c17-239f-466d-863f-efdbf52ff8ad",
    "metadata": {},
    "source": [
-    "More details on Pixeltable's error handling can be found in the [Working with External Files](https://docs.pixeltable.com/docs/working-with-external-files) how-to guide."
+    "More details on Pixeltable's error handling can be found in the [Working with External Files](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/working-with-external-files.ipynb) how-to guide."
    ]
   },
   {

--- a/docs/notebooks/fundamentals/tables-and-data-operations.ipynb
+++ b/docs/notebooks/fundamentals/tables-and-data-operations.ipynb
@@ -1816,7 +1816,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll discuss the various Pixeltable functions and expressions more thoroughly in the next tutorial section, [Computed Columns](https://docs.pixeltable.com/docs/computed-columns), and they're exhaustively documented in the [Pixeltable API](https://pixeltable.github.io/pixeltable/)."
+    "We'll discuss the various Pixeltable functions and expressions more thoroughly in the next tutorial section, [Computed Columns](https://docs.pixeltable.com/datastore/computed-columns), and they're exhaustively documented in the [Pixeltable API](https://pixeltable.github.io/pixeltable/)."
    ]
   },
   {

--- a/docs/notebooks/integrations/working-with-hugging-face.ipynb
+++ b/docs/notebooks/integrations/working-with-hugging-face.ipynb
@@ -311,7 +311,7 @@
    "source": [
     "Pixeltable can also create and populate an index with `table.add_embedding_index()` for string and image embeddings. That definition is persisted as part of the table's metadata, which allows Pixeltable to maintain the index in response to updates to the table.\n",
     "\n",
-    "In this example we are using `CLIP`. You can use any embedding function you like, via Pixeltable's UDF mechanism (which is described in detail our [guide to user-defined functions](https://docs.pixeltable.com/docs/user-defined-functions-udfs))."
+    "In this example we are using `CLIP`. You can use any embedding function you like, via Pixeltable's UDF mechanism (which is described in detail our [guide to user-defined functions](https://docs.pixeltable.com/datastore/custom-functions))."
    ]
   },
   {
@@ -517,7 +517,7 @@
     "id": "R6ZeK8fG_rbg"
    },
    "source": [
-    "You can learn more about how to leverage indexes in detail with our tutorial: [Working with Embedding and Vector Indexes](https://docs.pixeltable.com/docs/embedding-vector-indexes)"
+    "You can learn more about how to leverage indexes in detail with our tutorial: [Working with Embedding and Vector Indexes](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/embedding-indexes.ipynb)"
    ]
   }
  ],

--- a/docs/notebooks/integrations/working-with-llama-cpp.ipynb
+++ b/docs/notebooks/integrations/working-with-llama-cpp.ipynb
@@ -92,7 +92,7 @@
    "source": [
     "Next, we add a computed column that calls the Pixeltable `create_chat_completion` UDF, which adapts the corresponding llama.cpp API call. In our examples, we'll use pretrained models from the Hugging Face repository. llama.cpp makes it easy to do this by specifying a repo_id (from the URL of the model) and filename from the model repo; the model will then be downloaded and cached automatically.\n",
     "\n",
-    "(If this is your first time using Pixeltable, the <a href=\"https://docs.pixeltable.com/docs/tables-and-data-operations\">Pixeltable Fundamentals</a> tutorial contains more details about table creation, computed columns, and UDFs.)\n",
+    "(If this is your first time using Pixeltable, the <a href=\"https://docs.pixeltable.com/datastore/tables-and-operations\">Pixeltable Fundamentals</a> tutorial contains more details about table creation, computed columns, and UDFs.)\n",
     "\n",
     "For this demo we'll use `Qwen2.5-0.5B`, a very small (0.5-billion parameter) model that still produces decent results. We'll use `Q5_K_M` (5-bit) quantization, which gives an excellent balance of quality and efficiency."
    ]

--- a/docs/notebooks/pixeltable-basics.ipynb
+++ b/docs/notebooks/pixeltable-basics.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "If you want to follow along with this tutorial interactively, there are two ways to go.\n",
     "- Use a Kaggle or Colab container (easiest): Click on one of the badges above.\n",
-    "- Locally in a self-managed Python environment: You'll probably want to create your own empty notebook, then copy-paste each command from the website. Be sure your Jupyter kernel is running in a Python virtual environment; you can check out the [Getting Started with Pixeltable](https://docs.pixeltable.com/docs/pixeltable-basics) guide for step-by-step instructions.\n",
+    "- Locally in a self-managed Python environment: You'll probably want to create your own empty notebook, then copy-paste each command from the website. Be sure your Jupyter kernel is running in a Python virtual environment; you can check out the [Getting Started with Pixeltable](https://docs.pixeltable.com/overview/pixeltable) guide for step-by-step instructions.\n",
     "\n",
     "## Install Python Packages\n",
     "\n",

--- a/docs/notebooks/use-cases/object-detection-in-videos.ipynb
+++ b/docs/notebooks/use-cases/object-detection-in-videos.ipynb
@@ -17,7 +17,7 @@
     "* reassembling frames back into videos\n",
     "We'll be working with a single video file from Pixeltable's test data repository.\n",
     "\n",
-    "This tutorial assumes you're at least somewhat familiar with Pixeltable; a good place to learn more is the [Pixeltable Documentation](https://docs.pixeltable.com/docs/overview/pixeltable).\n",
+    "This tutorial assumes you're at least somewhat familiar with Pixeltable; a good place to learn more is the [Pixeltable Documentation](https://docs.pixeltable.com/overview/pixeltable).\n",
     "\n",
     "**If you are running this tutorial in Colab:**\n",
     "In order to make the tutorial run a bit snappier, let's switch to a GPU-equipped instance for this Colab session. To do that, click on the `Runtime -> Change runtime type` menu item at the top, then select the `GPU` radio button and click on `Save`."

--- a/docs/notebooks/use-cases/rag-demo.ipynb
+++ b/docs/notebooks/use-cases/rag-demo.ipynb
@@ -873,7 +873,7 @@
    "source": [
     "Now let's compute vector embeddings for the document chunks and store them in a vector index. Pixeltable has built-in support for vector indexing using a variety of embedding model families, and it's easy for users to add new ones via UDFs. In this demo, we're going to use the E5 model from the Huggingface `sentence_transformers` library, which runs locally. \n",
     "\n",
-    "The following command creates a vector index on the `text` column in the `chunks` table, using the E5 embedding model. (For details on index creation, see the [Embedding and Vector Indices](https://docs.pixeltable.com/docs/embedding-vector-indexes) guide.) Note that defining the index is sufficient in order to load it with the existing data (and also to update it when the underlying data changes, as we'll see later)."
+    "The following command creates a vector index on the `text` column in the `chunks` table, using the E5 embedding model. (For details on index creation, see the [Embedding and Vector Indices](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/embedding-indexes.ipynb) guide.) Note that defining the index is sufficient in order to load it with the existing data (and also to update it when the underlying data changes, as we'll see later)."
    ]
   },
   {

--- a/docs/sample-apps/context-aware-discord-bot/README.md
+++ b/docs/sample-apps/context-aware-discord-bot/README.md
@@ -181,8 +181,8 @@ chat_table.add_computed_column(response=openai.chat_completions(
 
 - 🖼️ **Image Understanding**: [Add image search and analysis](https://github.com/pixeltable/pixeltable/tree/main/examples/text-and-image-similarity-search-nextjs-fastapi)
 - 🎥 **Video Processing**: [Index and search video content](https://huggingface.co/spaces/Pixeltable/Call-Analysis-AI-Tool)
-- 🔊 **Audio Analysis**: [Transcribe and analyze voice messages](https://docs.pixeltable.com/docs/transcribing-and-indexing-audio-and-video)
-- 💻 **Local Deployment**: Run entirely on your hardware with [Ollama](https://docs.pixeltable.com/docs/working-with-ollama)/[Llama.cpp](https://docs.pixeltable.com/docs/working-with-llamacpp)
+- 🔊 **Audio Analysis**: [Transcribe and analyze voice messages](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/use-cases/audio-transcriptions.ipynb)
+- 💻 **Local Deployment**: Run entirely on your hardware with [Ollama](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-ollama.ipynb)/[Llama.cpp](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-llama-cpp.ipynb)
 
 More examples available on our [Hugging Face Spaces](https://huggingface.co/Pixeltable).
 

--- a/docs/sample-apps/jfk-files-mcp-server/README.md
+++ b/docs/sample-apps/jfk-files-mcp-server/README.md
@@ -130,6 +130,6 @@ Pixeltable handles the entire workflow from data ingest to search, allowing you 
 
 ## Learn More
 
-- [MCP Servers Documentation](https://docs.pixeltable.com/docs/cookbooks/mcp/overview)
+- [MCP Servers Documentation](https://docs.pixeltable.com/libraries/mcp)
 - [More Pixeltable MCP servers](https://github.com/pixeltable/pixeltable-mcp-server)
 - [Pixeltable Documentation](https://docs.pixeltable.com/)

--- a/docs/sample-apps/multimodal-chat/README.md
+++ b/docs/sample-apps/multimodal-chat/README.md
@@ -30,9 +30,9 @@ sequenceDiagram
 - **Multimodal Data Support**: Process and analyze documents, videos, and audio files
 - **Advanced Processing**: Leverages [Pixeltable's data types and formats](https://docs.pixeltable.com/docs/data-types-and-formats)
 - **Flexible LLM Integration**: 
-  - Default: [OpenAI](https://docs.pixeltable.com/docs/working-with-openai)
-  - Alternative options: [Ollama](https://docs.pixeltable.com/docs/working-with-ollama), [LLama.cpp](https://docs.pixeltable.com/docs/working-with-llamacpp)
-- **Local Processing Options**: Use [Whisper/WhisperX](https://docs.pixeltable.com/docs/whisper) for local transcription
+  - Default: [OpenAI](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-openai.ipynb)
+  - Alternative options: [Ollama](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-ollama.ipynb), [LLama.cpp](https://github.com/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-llama-cpp.ipynb)
+- **Local Processing Options**: Use [Whisper/WhisperX](https://docs.pixeltable.com/examples/search/audio) for local transcription
 
 ## Deployment Options
 

--- a/docs/sample-apps/reddit-agentic-bot/README.md
+++ b/docs/sample-apps/reddit-agentic-bot/README.md
@@ -160,4 +160,4 @@ Reddit Bot finished.
 *   **👍👎 Feedback Loop:** Allow users to rate answers (`!good_answer`).
 *   **🌐 Multi-Subreddit / Conditional Logic:** Monitor more subs with varying rules.
 
-See [Pixeltable examples](https://docs.pixeltable.com/docs/examples/use-cases) for different implementations of the above that you can add to this Reddit bot from maintaining short-term and long-term memory to additional interactions.
+See [Pixeltable examples](https://docs.pixeltable.com/examples/use-cases) for different implementations of the above that you can add to this Reddit bot from maintaining short-term and long-term memory to additional interactions.

--- a/docs/sample-apps/reddit-agentic-bot/content/pixeltable_readme.md
+++ b/docs/sample-apps/reddit-agentic-bot/content/pixeltable_readme.md
@@ -14,11 +14,11 @@
 [![PyPI Package](https://img.shields.io/pypi/v/pixeltable?color=4D148C)](https://pypi.org/project/pixeltable/)
 [![My Discord (1306431018890166272)](https://img.shields.io/badge/💬-Discord-%235865F2.svg)](https://discord.gg/QPyqFYx2UN)
 
-[**Installation**](https://docs.pixeltable.com/docs/overview/installation) |
-[**Quick Start**](https://docs.pixeltable.com/docs/overview/quick-start) |
+[**Installation**](https://docs.pixeltable.com/overview/installation) |
+[**Quick Start**](https://docs.pixeltable.com/overview/quick-start) |
 [**Documentation**](https://docs.pixeltable.com/) |
 [**API Reference**](https://pixeltable.github.io/pixeltable/) |
-[**Examples**](https://docs.pixeltable.com/docs/examples/use-cases) |
+[**Examples**](https://docs.pixeltable.com/examples/use-cases) |
 [**Discord Community**](https://discord.gg/QPyqFYx2UN)
 
 </div>
@@ -29,7 +29,7 @@ Pixeltable is the only Python framework that provides incremental storage, trans
 
 ## 😩 Maintaining Production-Ready Multimodal AI Apps is Still Too Hard
 
-Building robust AI applications, especially [multimodal](https://docs.pixeltable.com/docs/datastore/bringing-data) ones, requires stitching together numerous tools:
+Building robust AI applications, especially [multimodal](https://docs.pixeltable.com/datastore/bringing-data) ones, requires stitching together numerous tools:
 *   ETL pipelines for data loading and transformation.
 *   Vector databases for semantic search.
 *   Feature stores for ML models.
@@ -45,17 +45,17 @@ This complex "data plumbing" slows down development, increases costs, and makes 
 pip install pixeltable
 ```
 
-**Pixeltable is a database.** It stores metadata and computed results persistently, typically in a `.pixeltable` directory in your workspace. See [configuration](https://docs.pixeltable.com/docs/overview/configuration) options for your setup.
+**Pixeltable is a database.** It stores metadata and computed results persistently, typically in a `.pixeltable` directory in your workspace. See [configuration](https://docs.pixeltable.com/overview/configuration) options for your setup.
 
 ## ✨ What is Pixeltable?
 
-With Pixeltable, you define your *entire* data processing and AI workflow declaratively using **[computed columns](https://docs.pixeltable.com/docs/datastore/computed-columns)** on **[tables](https://docs.pixeltable.com/docs/datastore/tables-and-operations)**. Pixeltable's engine then automatically handles:
+With Pixeltable, you define your *entire* data processing and AI workflow declaratively using **[computed columns](https://docs.pixeltable.com/datastore/computed-columns)** on **[tables](https://docs.pixeltable.com/datastore/tables-and-operations)**. Pixeltable's engine then automatically handles:
 
-*   **Data Ingestion & Storage:** References [files](https://docs.pixeltable.com/docs/datastore/bringing-data) (images, videos, audio, docs) in place, handles structured data.
-*   **Transformation & Processing:** Applies *any* Python function ([UDFs](https://docs.pixeltable.com/docs/datastore/custom-functions)) or built-in operations ([chunking, frame extraction](https://docs.pixeltable.com/docs/datastore/iterators)) automatically.
-*   **AI Model Integration:** Runs inference ([embeddings](https://docs.pixeltable.com/docs/datastore/embedding-index), [object detection](https://docs.pixeltable.com/docs/examples/vision/yolox), [LLMs](https://docs.pixeltable.com/docs/integrations/frameworks#cloud-llm-providers)) as part of the data pipeline.
-*   **Indexing & Retrieval:** Creates and manages vector indexes for fast [semantic search](https://docs.pixeltable.com/docs/datastore/embedding-index#phase-3%3A-query) alongside traditional filtering.
-*   **Incremental Computation:** Only [recomputes](https://docs.pixeltable.com/docs/overview/quick-start) what's necessary when data or code changes, saving time and cost.
+*   **Data Ingestion & Storage:** References [files](https://docs.pixeltable.com/datastore/bringing-data) (images, videos, audio, docs) in place, handles structured data.
+*   **Transformation & Processing:** Applies *any* Python function ([UDFs](https://docs.pixeltable.com/datastore/custom-functions)) or built-in operations ([chunking, frame extraction](https://docs.pixeltable.com/datastore/iterators)) automatically.
+*   **AI Model Integration:** Runs inference ([embeddings](https://docs.pixeltable.com/datastore/vector-database), [object detection](https://docs.pixeltable.com/examples/vision/yolox), [LLMs](https://docs.pixeltable.com/integrations/frameworks#cloud-llm-providers)) as part of the data pipeline.
+*   **Indexing & Retrieval:** Creates and manages vector indexes for fast [semantic search](https://docs.pixeltable.com/datastore/vector-database#phase-3%3A-query) alongside traditional filtering.
+*   **Incremental Computation:** Only [recomputes](https://docs.pixeltable.com/overview/quick-start) what's necessary when data or code changes, saving time and cost.
 *   **Versioning & Lineage:** Automatically tracks data and schema changes for reproducibility.
 
 **Focus on your application logic, not the infrastructure.**
@@ -63,7 +63,7 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
 
 ## 🚀 Key Features
 
-* **[Unified Multimodal Interface:](https://docs.pixeltable.com/docs/datastore/tables-and-operations)** `pxt.Image`, `pxt.Video`, `pxt.Audio`, `pxt.Document`, etc. – manage diverse data consistently.
+* **[Unified Multimodal Interface:](https://docs.pixeltable.com/datastore/tables-and-operations)** `pxt.Image`, `pxt.Video`, `pxt.Audio`, `pxt.Document`, etc. – manage diverse data consistently.
   ```python
   t = pxt.create_table(
     'media',
@@ -74,7 +74,7 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
   )
   ```
 
-* **[Declarative Computed Columns:](https://docs.pixeltable.com/docs/datastore/computed-columns)** Define processing steps once; they run automatically on new/updated data.
+* **[Declarative Computed Columns:](https://docs.pixeltable.com/datastore/computed-columns)** Define processing steps once; they run automatically on new/updated data.
   ```python
   t.add_computed_column(
     classification=huggingface.vit_for_image_classification(
@@ -83,7 +83,7 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
   )
   ```
 
-* **[Built-in Vector Search:](https://docs.pixeltable.com/docs/datastore/embedding-index)** Add embedding indexes and perform similarity searches directly on tables/views.
+* **[Built-in Vector Search:](https://docs.pixeltable.com/datastore/vector-database)** Add embedding indexes and perform similarity searches directly on tables/views.
   ```python
   t.add_embedding_index(
     'img',
@@ -95,7 +95,7 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
   sim = t.img.similarity("cat playing with yarn")
   ```
 
-* **[On-the-Fly Data Views:](https://docs.pixeltable.com/docs/datastore/views)** Create virtual tables using iterators for efficient processing without data duplication.
+* **[On-the-Fly Data Views:](https://docs.pixeltable.com/datastore/views)** Create virtual tables using iterators for efficient processing without data duplication.
   ```python
   frames = pxt.create_view(
     'frames',
@@ -107,7 +107,7 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
   )
   ```
 
-* **[Seamless AI Integration:](https://docs.pixeltable.com/docs/integrations/frameworks)** Built-in functions for OpenAI, Anthropic, Hugging Face, CLIP, YOLOX, and more.
+* **[Seamless AI Integration:](https://docs.pixeltable.com/integrations/frameworks)** Built-in functions for OpenAI, Anthropic, Hugging Face, CLIP, YOLOX, and more.
   ```python
   t.add_computed_column(
     response=openai.chat_completions(
@@ -116,14 +116,14 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
   )
   ```
 
-* **[Bring Your Own Code:](https://docs.pixeltable.com/docs/datastore/custom-functions)** Extend Pixeltable with simple Python User-Defined Functions.
+* **[Bring Your Own Code:](https://docs.pixeltable.com/datastore/custom-functions)** Extend Pixeltable with simple Python User-Defined Functions.
   ```python
   @pxt.udf
   def format_prompt(context: list, question: str) -> str:
       return f"Context: {context}\nQuestion: {question}"
   ```
 
-* **[Agentic Workflows / Tool Calling:](https://docs.pixeltable.com/docs/examples/chat/tools)** Register `@pxt.udf` or `@pxt.query` functions as tools and orchestrate LLM-based tool use (incl. multimodal).
+* **[Agentic Workflows / Tool Calling:](https://docs.pixeltable.com/examples/chat/tools)** Register `@pxt.udf` or `@pxt.query` functions as tools and orchestrate LLM-based tool use (incl. multimodal).
   ```python
   # Example tools: a UDF and a Query function for RAG
   tools = pxt.tools(get_weather_udf, search_context_query)
@@ -134,13 +134,13 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
   )
   ```
 
-* **[Persistent & Versioned:](https://docs.pixeltable.com/docs/datastore/tables-and-operations#data-operations)** All data, metadata, and computed results are automatically stored.
+* **[Persistent & Versioned:](https://docs.pixeltable.com/datastore/tables-and-operations#data-operations)** All data, metadata, and computed results are automatically stored.
   ```python
   t.revert()  # Revert to a previous version
   stored_table = pxt.get_table('my_existing_table')  # Retrieve persisted table
   ```
 
-* **[SQL-like Python Querying:](https://docs.pixeltable.com/docs/datastore/filtering-and-selecting)** Familiar syntax combined with powerful AI capabilities.
+* **[SQL-like Python Querying:](https://docs.pixeltable.com/datastore/filtering-and-selecting)** Familiar syntax combined with powerful AI capabilities.
   ```python
   results = (
     t.where(t.score > 0.8)
@@ -153,7 +153,7 @@ With Pixeltable, you define your *entire* data processing and AI workflow declar
 
 ## 💡 Key Examples
 
-*(See the [Full Quick Start](https://docs.pixeltable.com/docs/overview/quick-start) or [Notebook Gallery](#-notebook-gallery) for more details)*
+*(See the [Full Quick Start](https://docs.pixeltable.com/overview/quick-start) or [Notebook Gallery](#-notebook-gallery) for more details)*
 
 **1. Multimodal Data Store and Data Transformation (Computed Column):**
 ```bash
@@ -352,7 +352,7 @@ Explore Pixeltable's capabilities interactively:
 | 10-Min Tour | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/pixeltable-basics.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | OpenAI | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-openai.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> |
 | Tables & Ops | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/fundamentals/tables-and-data-operations.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Anthropic | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-anthropic.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> |
 | UDFs | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/udfs-in-pixeltable.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Together AI | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/integrations/working-with-together.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> |
-| Embedding Index | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/embedding-and-vector-indexes.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Label Studio | <a target="_blank" href="https://docs.pixeltable.com/docs/cookbooks/vision/label-studio"> <img src="https://img.shields.io/badge/📚%20Docs-013056" alt="Visit Docs"/></a> |
+| Embedding Index | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/embedding-and-vector-indexes.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Label Studio | <a target="_blank" href="https://docs.pixeltable.com/examples/vision/label-studio"> <img src="https://img.shields.io/badge/📚%20Docs-013056" alt="Visit Docs"/></a> |
 | External Files | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/feature-guides/working-with-external-files.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> </a> | Mistral | <a target="_blank" href="https://colab.research.google.com/github/mistralai/cookbook/blob/main/third_party/Pixeltable/incremental_prompt_engineering_and_model_comparison.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Github"/> |
 | **Use Cases** | | **Sample Apps** | |
 | RAG Demo | <a target="_blank" href="https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/notebooks/use-cases/rag-demo.ipynb">  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/> | Multimodal Agent | <a target="_blank" href="https://huggingface.co/spaces/Pixeltable/Multimodal-Powerhouse"> <img src="https://img.shields.io/badge/🤗%20Demo-FF7D04" alt="HF Space"/></a> |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ extra_css:
 nav:
   - Home: index.md
   - 'API Cheat Sheet': api-cheat-sheet.md
-  - 'Configuration Options': https://docs.pixeltable.com/docs/overview/configuration
+  - 'Configuration Options': https://docs.pixeltable.com/overview/configuration
   - 'API Reference':
     - pixeltable: pixeltable/pixeltable.md
     - pixeltable.io: pixeltable/io.md

--- a/pixeltable/io/globals.py
+++ b/pixeltable/io/globals.py
@@ -152,7 +152,7 @@ def export_images_as_fo_dataset(
     (or expression) containing image data, along with optional additional columns containing labels. Currently, only
     classification and detection labels are supported.
 
-    The [Working with Voxel51 in Pixeltable](https://docs.pixeltable.com/docs/working-with-voxel51) tutorial contains a
+    The [Working with Voxel51 in Pixeltable](https://docs.pixeltable.com/examples/vision/voxel51) tutorial contains a
     fully worked example showing how to export data from a Pixeltable table and load it into Voxel51.
 
     Images in the dataset that already exist on disk will be exported directly, in whatever format they
@@ -211,7 +211,7 @@ def export_images_as_fo_dataset(
         ...     classifications=tbl.classifications
         ... )
 
-        See the [Working with Voxel51 in Pixeltable](https://docs.pixeltable.com/docs/working-with-voxel51) tutorial
+        See the [Working with Voxel51 in Pixeltable](https://docs.pixeltable.com/examples/vision/voxel51) tutorial
         for a fully worked example.
     """
     Env.get().require_package('fiftyone')


### PR DESCRIPTION
Browsing the Pixeltable README in GitHub, I noticed many broken documentation links. It seems like the docs used to be at `https://docs.pixeltable.com/docs/`, but that `docs/` path no longer exists. It bugged me enough that I spent a few minutes fixing almost all of them. Most of the mappings were straightforward - simply removing `docs/` - but some were more involved, for example, it looks like some web pages are now notebooks in GitHub.

There is one remaining reference to `https://docs.pixeltable.com/docs/`, in `docs/sample-apps/multimodal-chat/README.md`. I couldn't figure out the correct link for `https://docs.pixeltable.com/docs/data-types-and-formats`.

I hope this is useful!