### PR TITLE
Revert two uses of `Optional` in unit tests

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, ClassVar, Dict, List, Literal, Union
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
 import jsonschema.exceptions
 import numpy as np
@@ -172,14 +172,14 @@ class TestTypes:
 
             assert ColumnType.from_python_type(py_type) == pxt_type
             assert ColumnType.from_python_type(Required[py_type]) == non_nullable_pxt_type  # type: ignore[valid-type]
-            assert ColumnType.from_python_type(py_type | None) == nullable_pxt_type
+            assert ColumnType.from_python_type(Optional[py_type]) == nullable_pxt_type
             assert ColumnType.from_python_type(Union[None, py_type]) == nullable_pxt_type  # noqa: RUF036
             assert ColumnType.from_python_type(py_type | None) == nullable_pxt_type
             assert ColumnType.from_python_type(None | py_type) == nullable_pxt_type  # noqa: RUF036
 
             assert ColumnType.from_python_type(py_type, nullable_default=True) == nullable_pxt_type
             assert ColumnType.from_python_type(Required[py_type], nullable_default=True) == non_nullable_pxt_type  # type: ignore[valid-type]
-            assert ColumnType.from_python_type(py_type | None, nullable_default=True) == nullable_pxt_type
+            assert ColumnType.from_python_type(Optional[py_type], nullable_default=True) == nullable_pxt_type
             assert ColumnType.from_python_type(Union[None, py_type], nullable_default=True) == nullable_pxt_type  # noqa: RUF036
             assert ColumnType.from_python_type(py_type | None, nullable_default=True) == nullable_pxt_type
             assert ColumnType.from_python_type(None | py_type, nullable_default=True) == nullable_pxt_type  # noqa: RUF036


### PR DESCRIPTION
I'd forgotten there are two places where we *do* want to use `Optional` - in the tests that verify Pixeltable schemas will accept `Optional[T]` as a type specifier.