### PR TITLE
[PXT-837] Support creating/inserting directly from an existing Table

### DIFF
--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         Path,  # OS paths, filenames, URLs
         Iterable[dict[str, Any]],  # dictionaries of values
         Iterable[pydantic.BaseModel],  # Pydantic model instances
+        catalog.Table,  # Pixeltable Table
         DataFrame,  # Pixeltable DataFrame
         pd.DataFrame,  # pandas DataFrame
         datasets.Dataset,
@@ -72,7 +73,7 @@ def create_table(
     Args:
         path: Pixeltable path (qualified name) of the table, such as `'my_table'` or `'my_dir.my_subdir.my_table'`.
         schema: Schema for the new table, mapping column names to Pixeltable types.
-        source: A data source (file, URL, DataFrame, or list of rows) to import from.
+        source: A data source (file, URL, Table, DataFrame, or list of rows) to import from.
         source_format: Must be used in conjunction with a `source`.
             If specified, then the given format will be used to read the source data. (Otherwise,
             Pixeltable will attempt to infer the format from the source data.)

--- a/pixeltable/io/table_data_conduit.py
+++ b/pixeltable/io/table_data_conduit.py
@@ -4,7 +4,6 @@ import enum
 import json
 import logging
 import math
-import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -135,8 +134,11 @@ class DFTableDataConduit(TableDataConduit):
         tds_fields = {f.name for f in fields(tds)}
         kwargs = {k: v for k, v in tds.__dict__.items() if k in tds_fields}
         t = cls(**kwargs)
-        assert isinstance(tds.source, pxt.DataFrame)
-        t.pxt_df = tds.source
+        if isinstance(tds.source, pxt.Table):
+            t.pxt_df = tds.source.select()
+        else:
+            assert isinstance(tds.source, pxt.DataFrame)
+            t.pxt_df = tds.source
         return t
 
     def infer_schema(self) -> dict[str, ts.ColumnType]:
@@ -542,7 +544,7 @@ class UnkTableDataConduit(TableDataConduit):
     """Source type is not known at the time of creation"""
 
     def specialize(self) -> TableDataConduit:
-        if isinstance(self.source, pxt.DataFrame):
+        if isinstance(self.source, (pxt.Table, pxt.DataFrame)):
             return DFTableDataConduit.from_tds(self)
         if isinstance(self.source, pd.DataFrame):
             return PandasTableDataConduit.from_tds(self)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -550,25 +550,28 @@ class TestTable:
         assert_resultset_eq(on_read_res_1, on_read_res_2)
 
     def test_create_from_df(self, test_tbl: pxt.Table) -> None:
-        t = pxt.get_table('test_tbl')
+        t = test_tbl
         df1 = t.where(t.c2 >= 50).order_by(t.c2, asc=False).select(t.c2, t.c3, t.c7, t.c2 + 26, t.c1.contains('19'))
         t1 = pxt.create_table('test1', source=df1)
         assert t1._get_schema() == df1.schema
         assert t1.collect() == df1.collect()
 
-        from pixeltable.functions import sum
-
         t.add_computed_column(c2mod=t.c2 % 5)
-        df2 = t.group_by(t.c2mod).select(t.c2mod, sum(t.c2))
+        df2 = t.group_by(t.c2mod).select(t.c2mod, pxtf.sum(t.c2))
         t2 = pxt.create_table('test2', source=df2)
         assert t2._get_schema() == df2.schema
         assert t2.collect() == df2.collect()
+
+        # Create from table directly
+        t3 = pxt.create_table('test3', source=t)
+        assert t3._get_schema() == t._get_schema()
+        assert t3.collect() == t.collect()
 
         with pytest.raises(pxt.Error, match='must be a non-empty dictionary'):
             _ = pxt.create_table('test3', ['I am a string.'])  # type: ignore[arg-type]
 
     def test_insert_df(self, test_tbl: pxt.Table) -> None:
-        t = pxt.get_table('test_tbl')
+        t = test_tbl
         df1 = t.where(t.c2 >= 50).order_by(t.c2, asc=False).select(t.c2, t.c3, t.c7, t.c2 + 26, t.c1.contains('19'))
         t1 = pxt.create_table('test1', source=df1)
         assert t1._get_schema() == df1.schema
@@ -576,6 +579,11 @@ class TestTable:
 
         t1.insert(df1)
         assert len(t1.collect()) == 2 * len(df1.collect())
+
+        # Insert from table directly
+        t2 = pxt.create_table('test2', source=t)
+        t2.insert(t)
+        assert len(t2.collect()) == 2 * len(t.collect())
 
     def test_insert_pydantic_scalars(self, reset_db: None) -> None:
         schema = {


### PR DESCRIPTION
Adds support for `pxt.create_table('name', source=tbl)` and `pxt.insert(tbl)`, where `tbl: pxt.Table`. (Previously, it was necessary to do `source=tbl.select()`, etc.)