### PR TITLE
Streamline Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,18 @@
-# Detect OS and set shell accordingly
-ifeq ($(OS),Windows_NT)
-    SHELL := pwsh.exe
-    # PowerShell command to get directory name
-    # Define Windows-specific commands
-    SHELL_PREFIX := pwsh.exe
-    MKDIR := powershell -Command New-Item -ItemType Directory -Path
-    TOUCH := powershell -Command New-Item -ItemType File -Path -Force
-    RM := powershell -Command Remove-Item -Force
-    RMDIR := powershell -Command Remove-Item -Force -Recurse
-    SET_ENV := set
-    KERNEL_NAME := $(shell powershell -Command "(Get-Item .).Name")
-    ULIMIT_CMD :=
-else
-    SHELL := /bin/bash
-    # Define Unix-specific commands
-    SHELL_PREFIX :=
-    MKDIR := mkdir -p
-    TOUCH := touch
-    RM := rm -f
-    RMDIR := rm -rf
-    SET_ENV := export
-    KERNEL_NAME := $(shell basename `pwd`)
-    ULIMIT_CMD := ulimit -n 4000;
-endif
-
-# Defaults
+# Parameter defaults
 DURATION := 120
 UV_ARGS := --group extra-dev
 WORKERS := 12
 
-# Common test parameters
+# Common test args
 PYTEST_COMMON_ARGS := -v -n auto --dist loadgroup --maxprocesses 6 --reruns 2 \
 	--only-rerun 'That Pixeltable operation could not be completed because it conflicted with'
 
-# We ensure the TQDM progress bar is updated exactly once per cell execution, by setting the refresh rate equal to the timeout
-NB_CELL_TIMEOUT := 3600
-TQDM_MININTERVAL := $(NB_CELL_TIMEOUT)
-
 # Needed for LLaMA build to work correctly on some Linux systems
 CMAKE_ARGS := -DLLAVA_BUILD=OFF
+NB_CELL_TIMEOUT := 3600
+# We ensure the TQDM progress bar is updated exactly once per cell execution, by setting the refresh rate equal to the timeout
+TQDM_MININTERVAL := $(NB_CELL_TIMEOUT)
+ULIMIT_CMD := ulimit -n 4000;
 
 .DEFAULT_GOAL := help
 
@@ -91,11 +65,7 @@ help:
 
 .PHONY: setup-install
 setup-install:
-ifeq ($(OS),Windows_NT)
-	@powershell -Command "if (-not (Test-Path '.make-install')) { New-Item -ItemType Directory -Path '.make-install' }"
-else
-	@$(MKDIR) .make-install
-endif
+	@mkdir -p .make-install
 ifdef CONDA_DEFAULT_ENV
 ifeq ($(CONDA_DEFAULT_ENV),base)
 	$(error Pixeltable must be installed from a conda environment (not `base`))
@@ -121,19 +91,19 @@ endif
 		target=$$(basename $$dir); \
 		ln -sf $$dir $(CONDA_PREFIX)/share/$$target 2>/dev/null || true; \
 	done
-	@$(TOUCH) .make-install/env
+	@touch .make-install/env
 
 .PHONY: install-deps
 install-deps:
 	@echo 'Installing dependencies from uv ...'
-	@$(TOUCH) pyproject.toml
-	@$(SET_ENV) VIRTUAL_ENV="$(CONDA_PREFIX)"; uv sync --active $(UV_ARGS)
+	@touch pyproject.toml
+	@VIRTUAL_ENV="$(CONDA_PREFIX)" uv sync --active $(UV_ARGS)
 
 # After running `uv sync`
 .make-install/others:
 	@echo 'Installing Jupyter kernel ...'
-	@python -m ipykernel install --user --name=$(KERNEL_NAME)
-	@$(TOUCH) .make-install/others
+	@python -m ipykernel install --user --name=pixeltable
+	@touch .make-install/others
 
 .PHONY: install
 install: setup-install .make-install/env install-deps .make-install/others
@@ -172,12 +142,12 @@ slimpytest: install
 .PHONY: nbtest
 nbtest: install
 	@echo 'Running `pytest` on notebooks ...'
-	@$(SHELL_PREFIX) scripts/prepare-nb-tests.sh --no-pip tests/target/nb-tests docs/notebooks tests
+	@scripts/prepare-nb-tests.sh --no-pip tests/target/nb-tests docs/notebooks tests
 	@$(ULIMIT_CMD) pytest -v --nbmake --nbmake-timeout=$(NB_CELL_TIMEOUT) --nbmake-kernel=$(KERNEL_NAME) tests/target/nb-tests/*.ipynb
 
 .PHONY: stresstest
 stresstest: install
-	@$(SHELL_PREFIX) scripts/stress-tests.sh $(WORKERS) $(DURATION)
+	@scripts/stress-tests.sh $(WORKERS) $(DURATION)
 
 .PHONY: typecheck
 typecheck: install
@@ -210,13 +180,13 @@ format: install
 
 .PHONY: release
 release: install
-	@$(SHELL_PREFIX) scripts/release.sh
+	@scripts/release.sh
 
 MINTLIFY_FILES := $(shell find docs/mintlify -name '*.md' -o -name '*.mdx' -o -name '*.json')
 NOTEBOOK_FILES := $(shell find docs/notebooks -name '*.ipynb' | grep -v .ipynb_checkpoints)
 
 target/docs/docs.json: docs/public_api.opml $(MINTLIFY_FILES) $(NOTEBOOK_FILES)
-	@$(SET_ENV) VIRTUAL_ENV="$(CONDA_PREFIX)"; uv sync --active $(UV_ARGS) --upgrade-package pixeltable-doctools
+	@VIRTUAL_ENV="$(CONDA_PREFIX)" uv sync --active $(UV_ARGS) --upgrade-package pixeltable-doctools
 	@python -m pixeltable_doctools.build
 
 .PHONY: docs
@@ -237,8 +207,8 @@ endif
 
 .PHONY: clean
 clean:
-	@$(RM) *.mp4 docs/source/tutorials/*.mp4 || true
-	@$(RMDIR) .make-install || true
-	@$(RMDIR) site || true
-	@$(RMDIR) target || true
-	@$(RMDIR) tests/target || true
+	@rm -f *.mp4 docs/source/tutorials/*.mp4 || true
+	@rm -rf .make-install || true
+	@rm -rf site || true
+	@rm -rf target || true
+	@rm -rf tests/target || true

--- a/docs/notebooks/.gitignore
+++ b/docs/notebooks/.gitignore
@@ -1,2 +1,0 @@
-/.quarto/
-**/*.quarto_ipynb

--- a/uv.lock
+++ b/uv.lock
@@ -5052,7 +5052,7 @@ test = [
 [[package]]
 name = "pixeltable-doctools"
 version = "0.1.0"
-source = { git = "https://github.com/pixeltable/pixeltable-doctools#bcea1bf8ccb620579e2976e87e999e4b7e18260c" }
+source = { git = "https://github.com/pixeltable/pixeltable-doctools#340ef204a5334dc7de21b11607cabc705131a37d" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "griffe" },


### PR DESCRIPTION
No one seems to be using or maintaining the Windows hooks in our Makefile, and they're already broken in several places. This backs them out so that the Makefile is once again Linux/MacOS only, which streamlines the Makefile and makes it easier to maintain. If Windows support becomes important again we'll need to redo it anyway.

(This won't affect any customers using Pixeltable on Windows.)