### PR TITLE
Circularity detection in view creation with if_exists='replace'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ fullpytest: install
 .PHONY: slimpytest
 slimpytest: install
 	@echo 'Running `pytest` on a slim configuration ...'
-	@$(ULIMIT_CMD) pytest $(PYTEST_COMMON_ARGS) tests/test_{catalog,dirs,env,exprs,function,index,packager,snapshot,table,view}.py
+	@$(ULIMIT_CMD) pytest $(PYTEST_COMMON_ARGS) tests/test_{catalog,dirs,env,exprs,function,index,snapshot,table,view}.py tests/share/test_packager.py
 
 .PHONY: nbtest
 nbtest: install


### PR DESCRIPTION
Checks for a specific scenario in which:
- A view `my_view` is created
- A subview of `my_view` is created with the identical name `my_view`, using if_exists='replace'

If this situation not detected, it leads to permanent catalog corruption.