### PR TITLE
Use high performance endpoint for Tigris

### DIFF
--- a/docs/release/integrations/cloud-storage.mdx
+++ b/docs/release/integrations/cloud-storage.mdx
@@ -286,7 +286,7 @@ Destinations are resolved in this order:
 <Tabs>
   <Tab title="URI Format">
     ```
-    https://fly.storage.tigris.dev/bucket-name/prefix/
+    https://t3.storage.dev/bucket-name/prefix/
     ```
   </Tab>
   <Tab title="Authentication">
@@ -311,7 +311,7 @@ Destinations are resolved in this order:
 
     t.add_computed_column(
         thumbnail=t.file.resize((128, 128)),
-        destination='https://fly.storage.tigris.dev/my-bucket/thumbnails/'
+        destination='https://t3.storage.dev/my-bucket/thumbnails/'
     )
     ```
   </Tab>


### PR DESCRIPTION
Current docs recommend the Tigris fly endpoint, which is only recommend for apps running within fly. The general purpose (and higher performance) endpoint is [t3.storage.dev](http://t3.storage.dev/).

https://docs.pixeltable.com/integrations/cloud-storage#tigris