### PR TITLE
[PXT-925] Fix spurious exception when `if_not_exists='ignore'` is used with a missing parent dir

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -925,8 +925,10 @@ class Catalog:
                 # Dir does not exist; raise an appropriate error.
                 if add_dir_path is not None or add_name is not None:
                     raise excs.Error(f'Directory {p!r} does not exist. Create it first with:\npxt.create_dir({p!r})')
-                else:
+                elif raise_if_not_exists:
                     raise excs.Error(f'Directory {p!r} does not exist.')
+                else:
+                    return None, None, None  # parent dir does not exist; nothing to do
             if p == add_dir_path:
                 add_dir = dir
             if p == drop_dir_path:
@@ -1017,7 +1019,10 @@ class Catalog:
         parent_path = path.parent
         parent_dir = self._get_dir(parent_path, lock_dir=lock_parent)
         if parent_dir is None:
-            raise excs.Error(f'Directory {parent_path!r} does not exist.')
+            if raise_if_not_exists:
+                raise excs.Error(f'Directory {parent_path!r} does not exist.')
+            else:
+                return None
         obj = self._get_dir_entry(parent_dir.id, path.name, path.version, lock_entry=lock_obj)
 
         if obj is None and raise_if_not_exists:

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -175,6 +175,7 @@ class TestDirs:
             pxt.drop_dir('dir1:120')
         # doesn't exist
         self._test_drop_if_not_exists('dir2')
+        self._test_drop_if_not_exists('not_a_parent_dir.subdir')
         # not empty
         with pytest.raises(pxt.Error, match='is not empty'):
             pxt.drop_dir('dir1')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1096,6 +1096,9 @@ class TestTable:
         pxt.drop_table(non_existing_t, if_not_exists='ignore')
         # force=True should not raise an error, irrespective of if_not_exists value
         pxt.drop_table(non_existing_t, force=True)
+        # same if the parent dir does not exist
+        pxt.drop_table('not_a_parent_dir.non_existing_table', if_not_exists='ignore')
+        pxt.drop_table('not_a_parent_dir.non_existing_table', force=True)
         assert table_list == pxt.list_tables()
 
     def test_image_table(self, reset_db: None) -> None:


### PR DESCRIPTION
Fixes both `drop_table()` and `drop_dir()`.