### PR TITLE
Adjust down max connections on OpenAI client

### DIFF
--- a/pixeltable/functions/openai.py
+++ b/pixeltable/functions/openai.py
@@ -37,7 +37,7 @@ _logger = logging.getLogger('pixeltable')
 def _(api_key: str, base_url: str | None = None, api_version: str | None = None) -> 'openai.AsyncOpenAI':
     import openai
 
-    max_connections = Config.get().get_int_value('openai.max_connections') or 2000
+    max_connections = Config.get().get_int_value('openai.max_connections') or 1000
     max_keepalive_connections = Config.get().get_int_value('openai.max_keepalive_connections') or 100
     set_file_descriptor_limit(max_connections * 2)
     default_query = None if api_version is None else {'api-version': api_version}


### PR DESCRIPTION
Perftest shows that with the default settings on Ubuntu, 2000 connections likely exhaust some limit somewhere, possibly the max number of ephemeral ports.