### PR TITLE
Migrate docs to `uuid7()` UDF

### DIFF
--- a/docs/release/howto/cookbooks/core/workflow-uuid-identity.ipynb
+++ b/docs/release/howto/cookbooks/core/workflow-uuid-identity.ipynb
@@ -1,459 +1,439 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Add unique identifiers to your tables\n",
-    "\n",
-    "Generate UUIDs for automatic row identification."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Problem\n",
-    "\n",
-    "You need unique identifiers for rows in your data pipeline. Maybe you're building an API that returns specific records, tracking processing status across systems, or joining data from multiple sources.\n",
-    "\n",
-    "| Use case | Why UUIDs help |\n",
-    "|----------|----------------|\n",
-    "| API responses | Return stable IDs clients can reference |\n",
-    "| Distributed systems | Generate IDs without coordination |\n",
-    "| Data lineage | Track records across pipeline stages |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Solution\n",
-    "\n",
-    "**What's in this recipe:**\n",
-    "\n",
-    "- Create tables with auto-generated UUID primary keys\n",
-    "- Add UUID columns to existing tables\n",
-    "- Generate UUIDs with `uuid4()`\n",
-    "\n",
-    "You use `uuid4()` to generate UUIDs for each row. Define it in the schema with `{'column_name': uuid4()}` syntax, or add it to existing tables with `add_computed_column()`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:42:58.310921Z",
-     "start_time": "2025-12-09T23:42:54.395643Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%pip install -qU pixeltable"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:42:59.604673Z",
-     "start_time": "2025-12-09T23:42:58.319265Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import pixeltable as pxt\n",
-    "from pixeltable.functions.uuid import uuid4"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:42:59.687076Z",
-     "start_time": "2025-12-09T23:42:59.625260Z"
-    }
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Connected to Pixeltable database at: postgresql+psycopg://postgres:@/pixeltable?host=/Users/pjlb/.pixeltable/pgdata\n",
-      "Created directory 'uuid_demo'.\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Add unique identifiers to your tables\n",
+        "\n",
+        "Generate UUIDs for automatic row identification."
+      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "<pixeltable.catalog.dir.Dir at 0x104e3c810>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Problem\n",
+        "\n",
+        "You need unique identifiers for rows in your data pipeline. Maybe you're building an API that returns specific records, tracking processing status across systems, or joining data from multiple sources.\n",
+        "\n",
+        "| Use case | Why UUIDs help |\n",
+        "|----------|----------------|\n",
+        "| API responses | Return stable IDs clients can reference |\n",
+        "| Distributed systems | Generate IDs without coordination |\n",
+        "| Data lineage | Track records across pipeline stages |"
       ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Create a fresh directory\n",
-    "pxt.drop_dir('uuid_demo', force=True)\n",
-    "pxt.create_dir('uuid_demo')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Create a table with a UUID primary key\n",
-    "\n",
-    "Use `uuid4()` in your schema to create a column that auto-generates UUIDs:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:42:59.817635Z",
-     "start_time": "2025-12-09T23:42:59.692347Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created table 'products'.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create table with auto-generated UUID primary key\n",
-    "products = pxt.create_table(\n",
-    "    'uuid_demo/products',\n",
-    "    {\n",
-    "        'id': uuid4(),  # Auto-generates UUID for each row\n",
-    "        'name': pxt.String,\n",
-    "        'price': pxt.Float,\n",
-    "    },\n",
-    "    primary_key=['id'],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:43:00.032561Z",
-     "start_time": "2025-12-09T23:42:59.829719Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inserting rows into `products`: 3 rows [00:00, 338.71 rows/s]\n",
-      "Inserted 3 rows with 0 errors.\n"
-     ]
     },
     {
-     "data": {
-      "text/plain": [
-       "3 rows inserted, 6 values computed."
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Solution\n",
+        "\n",
+        "**What's in this recipe:**\n",
+        "\n",
+        "- Create tables with auto-generated UUID primary keys\n",
+        "- Add UUID columns to existing tables\n",
+        "- Generate UUIDs with `uuid7()`\n",
+        "\n",
+        "You use `uuid7()` to generate UUIDs for each row. Define it in the schema with `{'column_name': uuid7()}` syntax, or add it to existing tables with `add_computed_column()`."
       ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Insert data - no need to provide 'id', it's auto-generated\n",
-    "products.insert(\n",
-    "    [\n",
-    "        {'name': 'Laptop', 'price': 999.99},\n",
-    "        {'name': 'Mouse', 'price': 29.99},\n",
-    "        {'name': 'Keyboard', 'price': 79.99},\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:43:00.057807Z",
-     "start_time": "2025-12-09T23:43:00.045903Z"
-    }
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th>id</th>\n",
-       "      <th>name</th>\n",
-       "      <th>price</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>0beebcb6-1a63-4c8c-a802-346b01f7ec6d</td>\n",
-       "      <td>Laptop</td>\n",
-       "      <td>999.99</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>a6fd0a8b-0156-492f-baa8-a4d1017de831</td>\n",
-       "      <td>Mouse</td>\n",
-       "      <td>29.99</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>0f2a8c94-0bcd-442e-af22-50213edb08c1</td>\n",
-       "      <td>Keyboard</td>\n",
-       "      <td>79.99</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:42:58.310921Z",
+          "start_time": "2025-12-09T23:42:54.395643Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "%pip install -qU pixeltable"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:42:59.604673Z",
+          "start_time": "2025-12-09T23:42:58.319265Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "import pixeltable as pxt\n",
+        "from pixeltable.functions.uuid import uuid7"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:42:59.687076Z",
+          "start_time": "2025-12-09T23:42:59.625260Z"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Create a fresh directory\n",
+        "pxt.drop_dir('uuid_demo', force=True)\n",
+        "pxt.create_dir('uuid_demo')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Create a table with a UUID primary key\n",
+        "\n",
+        "Use `uuid7()` in your schema to create a column that auto-generates UUIDs:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:42:59.817635Z",
+          "start_time": "2025-12-09T23:42:59.692347Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Created table 'products'.\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "                                     id      name   price\n",
-       "0  0beebcb6-1a63-4c8c-a802-346b01f7ec6d    Laptop  999.99\n",
-       "1  a6fd0a8b-0156-492f-baa8-a4d1017de831     Mouse   29.99\n",
-       "2  0f2a8c94-0bcd-442e-af22-50213edb08c1  Keyboard   79.99"
+      "source": [
+        "# Create table with auto-generated UUID primary key\n",
+        "products = pxt.create_table(\n",
+        "    'uuid_demo/products',\n",
+        "    {\n",
+        "        'id': uuid7(),  # Auto-generates UUID for each row\n",
+        "        'name': pxt.String,\n",
+        "        'price': pxt.Float,\n",
+        "    },\n",
+        "    primary_key=['id'],\n",
+        ")"
       ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# View the data - each row has a unique UUID\n",
-    "products.collect()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Add a UUID column to an existing table\n",
-    "\n",
-    "You can add a UUID column to a table that already exists using `add_computed_column()`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:43:00.111274Z",
-     "start_time": "2025-12-09T23:43:00.066890Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created table 'orders'.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create a table without a UUID column\n",
-    "orders = pxt.create_table(\n",
-    "    'uuid_demo/orders', {'customer': pxt.String, 'amount': pxt.Float}\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:43:00.142035Z",
-     "start_time": "2025-12-09T23:43:00.128371Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inserting rows into `orders`: 2 rows [00:00, 1070.66 rows/s]\n",
-      "Inserted 2 rows with 0 errors.\n"
-     ]
     },
     {
-     "data": {
-      "text/plain": [
-       "2 rows inserted, 2 values computed."
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Insert some data\n",
-    "orders.insert(\n",
-    "    [\n",
-    "        {'customer': 'Alice', 'amount': 150.00},\n",
-    "        {'customer': 'Bob', 'amount': 75.50},\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:43:00.209577Z",
-     "start_time": "2025-12-09T23:43:00.171054Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added 2 column values with 0 errors.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2 rows updated, 4 values computed."
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Add a UUID column to existing table\n",
-    "orders.add_computed_column(order_id=uuid4())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-12-09T23:43:00.233841Z",
-     "start_time": "2025-12-09T23:43:00.224110Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th>customer</th>\n",
-       "      <th>amount</th>\n",
-       "      <th>order_id</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>Alice</td>\n",
-       "      <td>150.</td>\n",
-       "      <td>b68ab3ab-5e4b-402e-8b9e-5fbd17830851</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>Bob</td>\n",
-       "      <td>75.5</td>\n",
-       "      <td>8edd6548-3ad5-4d0a-b23b-c03c6f791d90</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:43:00.032561Z",
+          "start_time": "2025-12-09T23:42:59.829719Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Inserted 3 rows with 0 errors in 0.02 s (191.21 rows/s)\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "3 rows inserted."
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "  customer  amount                              order_id\n",
-       "0    Alice   150.0  b68ab3ab-5e4b-402e-8b9e-5fbd17830851\n",
-       "1      Bob    75.5  8edd6548-3ad5-4d0a-b23b-c03c6f791d90"
+      "source": [
+        "# Insert data - no need to provide 'id', it's auto-generated\n",
+        "products.insert(\n",
+        "    [\n",
+        "        {'name': 'Laptop', 'price': 999.99},\n",
+        "        {'name': 'Mouse', 'price': 29.99},\n",
+        "        {'name': 'Keyboard', 'price': 79.99},\n",
+        "    ]\n",
+        ")"
       ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:43:00.057807Z",
+          "start_time": "2025-12-09T23:43:00.045903Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th>id</th>\n",
+              "      <th>name</th>\n",
+              "      <th>price</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <td>019c00eb-b464-7170-8fc8-d96bddf56508</td>\n",
+              "      <td>Laptop</td>\n",
+              "      <td>999.99</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>019c00eb-b464-7170-8fc8-d96c137f00f4</td>\n",
+              "      <td>Mouse</td>\n",
+              "      <td>29.99</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>019c00eb-b464-7170-8fc8-d96dfaad1c2a</td>\n",
+              "      <td>Keyboard</td>\n",
+              "      <td>79.99</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>"
+            ],
+            "text/plain": [
+              "                                     id      name   price\n",
+              "0  019c00eb-b464-7170-8fc8-d96bddf56508    Laptop  999.99\n",
+              "1  019c00eb-b464-7170-8fc8-d96c137f00f4     Mouse   29.99\n",
+              "2  019c00eb-b464-7170-8fc8-d96dfaad1c2a  Keyboard   79.99"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# View the data - each row has a unique UUID\n",
+        "products.collect()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Add a UUID column to an existing table\n",
+        "\n",
+        "You can add a UUID column to a table that already exists using `add_computed_column()`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:43:00.111274Z",
+          "start_time": "2025-12-09T23:43:00.066890Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Created table 'orders'.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Create a table without a UUID column\n",
+        "orders = pxt.create_table(\n",
+        "    'uuid_demo/orders', {'customer': pxt.String, 'amount': pxt.Float}\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:43:00.142035Z",
+          "start_time": "2025-12-09T23:43:00.128371Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Inserted 2 rows with 0 errors in 0.01 s (310.49 rows/s)\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "2 rows inserted."
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Insert some data\n",
+        "orders.insert(\n",
+        "    [\n",
+        "        {'customer': 'Alice', 'amount': 150.00},\n",
+        "        {'customer': 'Bob', 'amount': 75.50},\n",
+        "    ]\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:43:00.209577Z",
+          "start_time": "2025-12-09T23:43:00.171054Z"
+        }
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Added 2 column values with 0 errors in 0.02 s (98.14 rows/s)\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "2 rows updated."
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Add a UUID column to existing table\n",
+        "orders.add_computed_column(order_id=uuid7())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "ExecuteTime": {
+          "end_time": "2025-12-09T23:43:00.233841Z",
+          "start_time": "2025-12-09T23:43:00.224110Z"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th>customer</th>\n",
+              "      <th>amount</th>\n",
+              "      <th>order_id</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <td>Alice</td>\n",
+              "      <td>150.</td>\n",
+              "      <td>019c00eb-e605-7112-81bd-90a8e8e40943</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>Bob</td>\n",
+              "      <td>75.5</td>\n",
+              "      <td>019c00eb-e605-7112-81bd-90a9b86c26af</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>"
+            ],
+            "text/plain": [
+              "  customer  amount                              order_id\n",
+              "0    Alice   150.0  019c00eb-e605-7112-81bd-90a8e8e40943\n",
+              "1      Bob    75.5  019c00eb-e605-7112-81bd-90a9b86c26af"
+            ]
+          },
+          "execution_count": 9,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# View orders with their UUID column\n",
+        "orders.collect()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Explanation\n",
+        "\n",
+        "**Two ways to add UUIDs:**\n",
+        "\n",
+        "| Approach | Use case |\n",
+        "|----------|----------|\n",
+        "| `uuid7()` in schema | Auto-generated UUID at table creation |\n",
+        "| `add_computed_column(col=uuid7())` | Add UUID column to existing table |\n",
+        "\n",
+        "Both use `uuid7()` which generates UUIDv7 (time-based) identifiers:\n",
+        "\n",
+        "- 128-bit values\n",
+        "- Formatted as 32 hex digits with hyphens: `018e65c5-35e5-7c5d-8f37-f1c5b9c8a7b2`\n",
+        "- Time-ordered for better database performance\n",
+        "- Virtually guaranteed unique (collision probability is negligible)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## See also\n",
+        "\n",
+        "- [Tables and operations](https://docs.pixeltable.com/tutorials/tables-and-data-operations)\n",
+        "- [Computed columns](https://docs.pixeltable.com/tutorials/computed-columns)"
+      ]
     }
-   ],
-   "source": [
-    "# View orders with their UUID column\n",
-    "orders.collect()"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.9"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Explanation\n",
-    "\n",
-    "**Two ways to add UUIDs:**\n",
-    "\n",
-    "| Approach | Use case |\n",
-    "|----------|----------|\n",
-    "| `uuid4()` in schema | Auto-generated UUID at table creation |\n",
-    "| `add_computed_column(col=uuid4())` | Add UUID column to existing table |\n",
-    "\n",
-    "Both use `uuid4()` which generates UUIDv4 (random) identifiers:\n",
-    "\n",
-    "- 128-bit values\n",
-    "- Formatted as 32 hex digits with hyphens: `550e8400-e29b-41d4-a716-446655440000`\n",
-    "- Virtually guaranteed unique (collision probability is negligible)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## See also\n",
-    "\n",
-    "- [Tables and operations](https://docs.pixeltable.com/tutorials/tables-and-data-operations)\n",
-    "- [Computed columns](https://docs.pixeltable.com/tutorials/computed-columns)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "pixeltable",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.11"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/docs/release/howto/deployment/cheatsheet.mdx
+++ b/docs/release/howto/deployment/cheatsheet.mdx
@@ -277,19 +277,19 @@ t.add_computed_column(words=word_count(t.content))
   <Accordion title="User-Defined Aggregates (UDA)" icon="chart-line">
     ```python
     @pxt.uda
-    class StdDev(pxt.Aggregator):
+    class std(pxt.Aggregator):
         def __init__(self):
             self.sum = 0.0
             self.sum_sq = 0.0
             self.count = 0
-        def update(self, val: float):
+        def update(self, val: float | None):
             if val is not None:
                 self.sum += val
                 self.sum_sq += val * val
                 self.count += 1
-        def value(self) -> float:
+        def value(self) -> float | None:
             if self.count == 0:
-                return 0.0
+                return None
             mean = self.sum / self.count
             variance = (self.sum_sq / self.count) - (mean * mean)
             return variance ** 0.5

--- a/docs/release/howto/deployment/cheatsheet.mdx
+++ b/docs/release/howto/deployment/cheatsheet.mdx
@@ -277,16 +277,22 @@ t.add_computed_column(words=word_count(t.content))
   <Accordion title="User-Defined Aggregates (UDA)" icon="chart-line">
     ```python
     @pxt.uda
-    class RunningAvg(pxt.Aggregator):
+    class StdDev(pxt.Aggregator):
         def __init__(self):
             self.sum = 0.0
+            self.sum_sq = 0.0
             self.count = 0
         def update(self, val: float):
             if val is not None:
                 self.sum += val
+                self.sum_sq += val * val
                 self.count += 1
         def value(self) -> float:
-            return self.sum / self.count if self.count > 0 else 0.0
+            if self.count == 0:
+                return 0.0
+            mean = self.sum / self.count
+            variance = (self.sum_sq / self.count) - (mean * mean)
+            return variance ** 0.5
     ```
   </Accordion>
   

--- a/docs/release/howto/deployment/cheatsheet.mdx
+++ b/docs/release/howto/deployment/cheatsheet.mdx
@@ -161,10 +161,12 @@ import pixeltable as pxt
   <Tab title="Aggregations & Joins">
     ```python
     # Aggregate
+    import pixeltable.functions as pxtf
+    
     t.group_by(t.category).select(
         t.category,
-        total=count(t.id),
-        avg=avg(t.score)
+        total=pxtf.count(t.id),
+        average=pxtf.mean(t.score)
     ).collect()
 
     # Join
@@ -274,14 +276,15 @@ t.add_computed_column(words=word_count(t.content))
   
   <Accordion title="User-Defined Aggregates (UDA)" icon="chart-line">
     ```python
-    @pxt.uda(value_type=pxt.Float, update_type=pxt.Json)
-    class RunningAvg:
+    @pxt.uda
+    class RunningAvg(pxt.Aggregator):
         def __init__(self):
             self.sum = 0.0
             self.count = 0
         def update(self, val: float):
-            self.sum += val
-            self.count += 1
+            if val is not None:
+                self.sum += val
+                self.count += 1
         def value(self) -> float:
             return self.sum / self.count if self.count > 0 else 0.0
     ```
@@ -408,8 +411,7 @@ from pixeltable.iterators import (
 # Filtered view
 active = pxt.create_view(
     'project/active_users',
-    users,
-    filter=users.status == 'active'
+    users.where(users.status == 'active')
 )
 
 # View with iterator
@@ -679,7 +681,7 @@ t.add_computed_column(transformed=image_to_image(t.img, t.prompt, model_id='stab
     t.metadata['key']['nested']
 
     # UUID & Net
-    uuid4()
+    uuid7()
     presigned_url(t.s3_path, expiration=3600)
     ```
   </Tab>

--- a/docs/release/platform/type-system.mdx
+++ b/docs/release/platform/type-system.mdx
@@ -43,14 +43,14 @@ table = pxt.create_table('example/basic_types', {
 
 ### Auto-generated UUIDs
 
-Use `uuid4()` to create columns that auto-generate unique identifiers:
+Use `uuid7()` to create columns that auto-generate unique identifiers:
 
 ```python
-from pixeltable.functions.uuid import uuid4
+from pixeltable.functions.uuid import uuid7
 
 # UUID as primary key - auto-generated for each row
 products = pxt.create_table('example/products', {
-    'id': uuid4(),           # Auto-generates UUID
+    'id': uuid7(),           # Auto-generates UUID
     'name': pxt.String,
     'price': pxt.Float
 }, primary_key=['id'])
@@ -63,7 +63,7 @@ You can also add UUIDs to existing tables:
 
 ```python
 # Add UUID column to existing table
-orders.add_computed_column(order_id=uuid4())
+orders.add_computed_column(order_id=uuid7())
 ```
 
 <Tip>
@@ -227,22 +227,22 @@ movies = pxt.create_table('example/pydantic_movies', {
 
 ## Type conversion
 
-Use `astype()` to convert between compatible types:
+Use `astype()` to convert string file paths or URLs to media types:
 
 ```python
-# Cast float to integer
-table.select(int_score=table.score.astype(pxt.Int)).collect()
+# String file paths → Media types
+media = pxt.create_table('media_table', {'path': pxt.String})
+media.insert([{'path': '/path/to/image.jpg'}])
 
-# Cast integer to string
-table.select(str_count=table.count.astype(pxt.String)).collect()
-
-# Cast JSON to String (if the value is actually a string)
-table.select(text=table.json_col.astype(pxt.String)).collect()
+# Convert string path to Image
+media.select(img=media.path.astype(pxt.Image)).collect()
 ```
 
-<Warning>
-Type conversion assumes the underlying value is compatible. Converting a dict to a string will raise an exception.
-</Warning>
+**Primary use case:** Converting string columns containing file paths or URLs to media types (`Image`, `Video`, `Audio`, `Document`).
+
+<Tip>
+For other type conversions, use built-in functions from the [`string`](/sdk/latest/string), [`json`](/sdk/latest/json), or [`math`](/sdk/latest/math) modules. For example, use `string.len()` to get string length as an integer, or access JSON fields directly.
+</Tip>
 
 ## Column properties
 

--- a/docs/release/platform/type-system.mdx
+++ b/docs/release/platform/type-system.mdx
@@ -67,6 +67,10 @@ orders.add_computed_column(order_id=uuid7())
 ```
 
 <Tip>
+By default, `stored=True` for all computed columns—values compute once and persist. For UUIDs, this ensures stable identifiers. Setting `stored=False` would regenerate UUIDs on every query (almost never what you want).
+</Tip>
+
+<Tip>
 See the [UUID cookbook](/howto/cookbooks/core/workflow-uuid-identity) for more examples of working with unique identifiers.
 </Tip>
 


### PR DESCRIPTION
## Summary of Changes for uuid7() PR

### Primary Change: `uuid4()` → `uuid7()` Migration

Updated all documentation to use the new `uuid7()` UDF, which provides time-based UUIDs with better database index performance and sortable ordering.

**Files updated:**
- `workflow-uuid-identity.ipynb` - Core cookbook demonstrating UUID usage
- `type-system.mdx` - Type system documentation 
- `cheatsheet.mdx` - Quick reference guide

### Additional Fixes

While testing the updated documentation examples with the help of an AI code assistant, we found and fixed several code examples that would not work as written:

#### **`type-system.mdx`**
- **`astype()` documentation:** Updated examples to show string-to-media conversions (string paths → media types) instead of primitive type conversions, which don't work at runtime

#### **`cheatsheet.mdx`**
- **Aggregation functions:** Added `import pixeltable.functions as pxtf` and updated function calls (`pxtf.count()`, `pxtf.mean()`)
- **UDA syntax:** Updated `@pxt.uda` decorator to use correct signature with `pxt.Aggregator` inheritance
- **View creation:** Fixed to pass Query object (`users.where(...)`) instead of invalid `filter=` parameter

---

**Impact:** Primary uuid7() migration completed across all docs, plus 4 code example corrections.