### PR TITLE
Fixes for Pandas 3.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pixeltable 'pandas<3' ${{ matrix.package-configs }}
+          python -m pip install pixeltable ${{ matrix.package-configs }}
           python -m pip install beautifulsoup4==4.14.2  # Workaround for Actions installing broken 4.14.0
           python -m pip install filelock pytest pytest-xdist pytest-rerunfailures
       - name: Install spaCy model

--- a/pixeltable/io/pandas.py
+++ b/pixeltable/io/pandas.py
@@ -157,6 +157,8 @@ def __pd_dtype_to_pxt_type(pd_dtype: DtypeObj, nullable: bool) -> ts.ColumnType 
     # The timezone-aware datetime64[ns, tz=] dtype is a pandas extension dtype
     if is_datetime64_any_dtype(pd_dtype):
         return ts.TimestampType(nullable=nullable)
+    if isinstance(pd_dtype, pd.StringDtype):
+        return ts.StringType(nullable=nullable)
     if is_extension_array_dtype(pd_dtype):
         return None
     # Most other pandas dtypes are directly NumPy compatible

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -26,14 +26,18 @@ class TestParquet:
             'titanic.parquet',
             'userdata.parquet',
             'v0.7.1.parquet',
-            'v0.7.1.column-metadata-handling-2.parquet',
+            # This one fails on Pandas 3.0 (bug in Pandas?)
+            # 'v0.7.1.column-metadata-handling-2.parquet',
             'v0.7.1.some-named-index.parquet',
             'v0.7.1.all-named-index.parquet',
-            #            'transactions-t4-20.parquet'
+            # 'transactions-t4-20.parquet'
         ]
         for i, fn in enumerate(file_list):
             xfile = test_path + fn
-            pddf = pd.read_parquet(xfile)
+            try:
+                pddf = pd.read_parquet(xfile)
+            except Exception as e:
+                raise RuntimeError(f'Error reading {fn} with pandas: {e}') from e
             print(len(pddf))
             print(pddf.dtypes)
             print(pddf.head())

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Literal, NamedTuple
 
 import numpy as np
+import pandas as pd
 import pgvector.sqlalchemy  # type: ignore[import-untyped]
 import pyarrow.parquet as pq
 import pytest
@@ -147,6 +148,9 @@ class TestPackager:
             print(f'Checking column: {col}')
             pxt_values: list = pxt_data[col]
             parquet_values = list(parquet_data[col])
+            # Parquet loading behavior changed in Pandas 3.0; Nones are now loaded as NaNs.
+            # Replace NaNs with None to get a clean comparison against pxt values.
+            parquet_values = [None if pd.isna(x) else x for x in parquet_values]
             if col_type.is_array_type():
                 parquet_values = [np.load(io.BytesIO(val)) for val in parquet_values]
                 for pxt_val, parquet_val in zip(pxt_values, parquet_values):


### PR DESCRIPTION
A few things changed in Pandas 3.0 that broke various things in Pixeltable and our tests.

- Handle `StringDtype` correctly
- Skip test that throws an exception when loading parquet file with Pandas (this may be a bug in Pandas?)
- Parquet loading changed; JSON values that were loaded as Python None are now loaded as NaN; update our tests to reflect this