### PR TITLE
Switch away from gemini-2.0 models

### DIFF
--- a/docs/release/howto/deployment/cheatsheet.mdx
+++ b/docs/release/howto/deployment/cheatsheet.mdx
@@ -555,7 +555,7 @@ t.add_computed_column(tool_results=invoke_tools(tools, t.llm_response))
     ```python
     from pixeltable.functions.gemini import generate_content
     t.add_computed_column(
-        text=generate_content(contents=t.prompt, model='gemini-2.0-flash').text
+        text=generate_content(contents=t.prompt, model='gemini-2.5-flash').text
     )
     ```
     <Card title="Gemini Guide" href="/howto/providers/working-with-gemini" />

--- a/docs/release/howto/providers/working-with-gemini.ipynb
+++ b/docs/release/howto/providers/working-with-gemini.ipynb
@@ -162,7 +162,7 @@
     ")\n",
     "t.add_computed_column(\n",
     "    output=gemini.generate_content(\n",
-    "        t.input, model='gemini-2.0-flash', config=config\n",
+    "        t.input, model='gemini-2.5-flash', config=config\n",
     "    )\n",
     ")"
    ]

--- a/tests/functions/test_gemini.py
+++ b/tests/functions/test_gemini.py
@@ -72,7 +72,7 @@ class TestGemini:
 
         def make_table(tools: pxt.Tools, tool_choice: pxt.ToolChoice) -> pxt.Table:
             t = pxt.create_table('test_tbl', {'prompt': pxt.String}, if_exists='replace')
-            t.add_computed_column(response=gemini.generate_content(t.prompt, model='gemini-2.0-flash', tools=tools))
+            t.add_computed_column(response=gemini.generate_content(t.prompt, model='gemini-2.5-flash', tools=tools))
             t.add_computed_column(tool_calls=gemini.invoke_tools(tools, t.response))
             return t
 

--- a/tool/perftest_providers.py
+++ b/tool/perftest_providers.py
@@ -81,7 +81,7 @@ def create_provider_configs(max_tokens: int) -> dict[str, ProviderConfig]:
         'gemini': ProviderConfig(
             prompt_udf=create_simple_prompt,
             udf=pxtf.gemini.generate_content,
-            default_model='gemini-2.0-flash',
+            default_model='gemini-2.5-flash',
             kwargs={
                 'config': GenerateContentConfigDict(
                     candidate_count=3,
@@ -91,8 +91,6 @@ def create_provider_configs(max_tokens: int) -> dict[str, ProviderConfig]:
                     top_p=0.95,
                     top_k=40,
                     response_mime_type='text/plain',
-                    presence_penalty=0.6,
-                    frequency_penalty=0.6,
                 )
             },
         ),


### PR DESCRIPTION
The family of `gemini-2.0-flash` models is deprecated and will be shut down in March.