### PR TITLE
Use a larger runner in merge queue for full tests on Python 3.10

### DIFF
--- a/tool/ci_tool.py
+++ b/tool/ci_tool.py
@@ -76,7 +76,13 @@ def generate_matrix(args: argparse.Namespace) -> None:
         MatrixConfig(
             'full', 'py', os, '3.10', pytest_options="-m ''" if os.startswith('ubuntu') else "-m 'not expensive'"
         )
-        for os in BASIC_PLATFORMS
+        for os in (
+            # Same as BASIC_PLATFORMS, but upgrade the Ubuntu VM for non-PR triggers.
+            # This is part of a gradual transition to using larger runners for merge queue.
+            'ubuntu-24.04' if trigger == 'pull_request' else 'ubuntu-24.04-medium',
+            'macos-15',
+            'windows-2022',
+        )
     )
 
     if force_all or trigger != 'pull_request':


### PR DESCRIPTION
I'm going to be gradually upgrading our runners in merge queue, starting with the most sensitive / failure-prone configurations. I'm phasing this to ensure we don't cause more harm than good, and to get a feel for which hardware configs are appropriate and how much they cost.

This PR upgrades `full / 3.10 / ubuntu` in merge queue.