### PR TITLE
Apply ruff formatting to code snippets in docstrings

### DIFF
--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -924,7 +924,9 @@ class Query:
             Use the above Query grouped by genre to count the number of
             books for each 'genre':
 
-            >>> query = book.group_by(t.genre).select(t.genre, count=count(t.genre)).show()
+            >>> query = (
+            ...     book.group_by(t.genre).select(t.genre, count=count(t.genre)).show()
+            ... )
 
             Use the above Query grouped by genre to the total price of
             books for each 'genre':
@@ -984,7 +986,11 @@ class Query:
 
             Select unique locations (street, city) in the state of `CA`
 
-            >>> results = addresses.select(addresses.street, addresses.city).where(addresses.state == 'CA').distinct()
+            >>> results = (
+            ...     addresses.select(addresses.street, addresses.city)
+            ...     .where(addresses.state == 'CA')
+            ...     .distinct()
+            ... )
         """
         exps, _ = self._normalize_select_list(self._from_clause.tbls, self.select_list)
         return self.group_by(*exps)

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -531,10 +531,7 @@ class Table(SchemaObject):
             Add multiple columns to the table `my_table`:
 
             >>> tbl = pxt.get_table('my_table')
-            ... schema = {
-            ...     'new_col_1': pxt.Int,
-            ...     'new_col_2': pxt.String,
-            ... }
+            ... schema = {'new_col_1': pxt.Int, 'new_col_2': pxt.String}
             ... tbl.add_columns(schema)
         """
         from pixeltable.catalog import Catalog
@@ -1043,7 +1040,9 @@ class Table(SchemaObject):
 
             Once the index is created, similarity lookups can be performed using the `similarity` pseudo-function:
 
-            >>> sim = tbl.img.similarity(image='/path/to/my-image.jpg')  # can also be a URL or a PIL image
+            >>> sim = tbl.img.similarity(
+            ...     image='/path/to/my-image.jpg'  # can also be a URL or a PIL image
+            ... )
             >>> tbl.select(tbl.img, sim).order_by(sim, asc=False).limit(5)
 
             If the embedding UDF is a multimodal embedding (supporting more than one data type), then lookups may be
@@ -1062,10 +1061,7 @@ class Table(SchemaObject):
             product as the distance metric, and with a specific name:
 
             >>> tbl.add_embedding_index(
-            ...     tbl.img,
-            ...     idx_name='ip_idx',
-            ...     embedding=embedding_fn,
-            ...     metric='ip'
+            ...     tbl.img, idx_name='ip_idx', embedding=embedding_fn, metric='ip'
             ... )
 
             Add an index using separately specified string and image embeddings:
@@ -1073,7 +1069,7 @@ class Table(SchemaObject):
             >>> tbl.add_embedding_index(
             ...     tbl.img,
             ...     string_embed=string_embedding_fn,
-            ...     image_embed=image_embedding_fn
+            ...     image_embed=image_embedding_fn,
             ... )
         """
         from pixeltable.catalog import Catalog
@@ -1410,6 +1406,7 @@ class Table(SchemaObject):
             ...     a: int
             ...     b: int
             ...
+            ...
             ... models = [MyModel(a=1, b=2), MyModel(a=3, b=4)]
             ... tbl.insert(models)
         """
@@ -1476,15 +1473,21 @@ class Table(SchemaObject):
             If either row does not exist, this raises an error:
 
             >>> tbl.batch_update(
-            ...     [{'id': 1, 'name': 'Alice', 'age': 30}, {'id': 2, 'name': 'Bob', 'age': 40}]
+            ...     [
+            ...         {'id': 1, 'name': 'Alice', 'age': 30},
+            ...         {'id': 2, 'name': 'Bob', 'age': 40},
+            ...     ]
             ... )
 
             Update the `name` and `age` columns for the row with `id` 1 (assuming `id` is the primary key) and insert
             the row with new `id` 3 (assuming this key does not exist):
 
             >>> tbl.batch_update(
-            ...     [{'id': 1, 'name': 'Alice', 'age': 30}, {'id': 3, 'name': 'Bob', 'age': 40}],
-            ...     if_not_exists='insert'
+            ...     [
+            ...         {'id': 1, 'name': 'Alice', 'age': 30},
+            ...         {'id': 3, 'name': 'Bob', 'age': 40},
+            ...     ],
+            ...     if_not_exists='insert',
             ... )
         """
         from pixeltable.catalog import Catalog

--- a/pixeltable/func/udf.py
+++ b/pixeltable/func/udf.py
@@ -50,7 +50,7 @@ def udf(*args, **kwargs):  # type: ignore[no-untyped-def]
     Examples:
         >>> @pxt.udf
         ... def my_function(x: int) -> int:
-        ...    return x + 1
+        ...     return x + 1
     """
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         # Decorator invoked without parentheses: @pxt.udf

--- a/pixeltable/functions/anthropic.py
+++ b/pixeltable/functions/anthropic.py
@@ -193,7 +193,9 @@ async def messages(
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
         >>> msgs = [{'role': 'user', 'content': tbl.prompt}]
-        ... tbl.add_computed_column(response=messages(msgs, model='claude-3-5-sonnet-20241022'))
+        ... tbl.add_computed_column(
+        ...     response=messages(msgs, model='claude-3-5-sonnet-20241022')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}

--- a/pixeltable/functions/audio.py
+++ b/pixeltable/functions/audio.py
@@ -149,7 +149,9 @@ def audio_splitter(
         >>> pxt.create_view(
         ...     'audio_chunks',
         ...     tbl,
-        ...     iterator=audio_splitter(tbl.audio, chunk_duration_sec=30.0, overlap_sec=5.0)
+        ...     iterator=audio_splitter(
+        ...         tbl.audio, chunk_duration_sec=30.0, overlap_sec=5.0
+        ...     ),
         ... )
     """
     kwargs: dict[str, Any] = {}

--- a/pixeltable/functions/bedrock.py
+++ b/pixeltable/functions/bedrock.py
@@ -85,7 +85,11 @@ async def converse(
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
         >>> msgs = [{'role': 'user', 'content': [{'text': tbl.prompt}]}]
-        ... tbl.add_computed_column(response=messages(msgs, model_id='anthropic.claude-3-haiku-20240307-v1:0'))
+        ... tbl.add_computed_column(
+        ...     response=messages(
+        ...         msgs, model_id='anthropic.claude-3-haiku-20240307-v1:0'
+        ...     )
+        ... )
     """
 
     kwargs: dict[str, Any] = {'messages': messages, 'modelId': model_id}
@@ -156,7 +160,9 @@ async def invoke_model(
         Add a computed column using Amazon Titan embedding model:
 
         >>> body = {'inputText': tbl.text, 'dimensions': 512, 'normalize': True}
-        >>> tbl.add_computed_column(response=invoke_model(body, model_id='amazon.titan-embed-text-v2:0'))
+        >>> tbl.add_computed_column(
+        ...     response=invoke_model(body, model_id='amazon.titan-embed-text-v2:0')
+        ... )
     """
     import json
 
@@ -204,7 +210,10 @@ async def embed(text: str, *, model_id: str, dimensions: int | None = None) -> p
 
         >>> tbl.add_embedding_index(
         ...     tbl.description,
-        ...     string_embed=embed.using(model_id='amazon.nova-2-multimodal-embeddings-v1:0', dimensions=1024)
+        ...     string_embed=embed.using(
+        ...         model_id='amazon.nova-2-multimodal-embeddings-v1:0',
+        ...         dimensions=1024,
+        ...     ),
         ... )
     """
     from botocore.exceptions import ClientError

--- a/pixeltable/functions/deepseek.py
+++ b/pixeltable/functions/deepseek.py
@@ -75,9 +75,11 @@ async def chat_completions(
 
         >>> messages = [
         ...     {'role': 'system', 'content': 'You are a helpful assistant.'},
-        ...     {'role': 'user', 'content': tbl.prompt}
+        ...     {'role': 'user', 'content': tbl.prompt},
         ... ]
-        >>> tbl.add_computed_column(response=chat_completions(messages, model='deepseek-chat'))
+        >>> tbl.add_computed_column(
+        ...     response=chat_completions(messages, model='deepseek-chat')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}

--- a/pixeltable/functions/document.py
+++ b/pixeltable/functions/document.py
@@ -51,14 +51,22 @@ def document_splitter(
 
         Create a view that splits all documents into chunks of up to 300 tokens:
 
-        >>> pxt.create_view('chunks', tbl, iterator=document_splitter(tbl.doc, separators='token_limit', limit=300))
+        >>> pxt.create_view(
+        ...     'chunks',
+        ...     tbl,
+        ...     iterator=document_splitter(
+        ...         tbl.doc, separators='token_limit', limit=300
+        ...     ),
+        ... )
 
         Create a view that splits all documents along sentence boundaries, including title and heading metadata:
 
         >>> pxt.create_view(
         ...     'sentence_chunks',
         ...     tbl,
-        ...     iterator=document_splitter(tbl.doc, separators='sentence', metadata='title,heading')
+        ...     iterator=document_splitter(
+        ...         tbl.doc, separators='sentence', metadata='title,heading'
+        ...     ),
         ... )
     """
 

--- a/pixeltable/functions/fabric.py
+++ b/pixeltable/functions/fabric.py
@@ -119,9 +119,11 @@ async def chat_completions(
         >>> from pixeltable.functions import fabric
         >>> messages = [
         ...     {'role': 'system', 'content': 'You are a helpful assistant.'},
-        ...     {'role': 'user', 'content': tbl.prompt}
+        ...     {'role': 'user', 'content': tbl.prompt},
         ... ]
-        >>> tbl.add_computed_column(response=fabric.chat_completions(messages, model='gpt-4.1'))
+        >>> tbl.add_computed_column(
+        ...     response=fabric.chat_completions(messages, model='gpt-4.1')
+        ... )
 
         Using a reasoning model (gpt-5):
 
@@ -129,7 +131,7 @@ async def chat_completions(
         ...     reasoning_response=fabric.chat_completions(
         ...         messages,
         ...         model='gpt-5',
-        ...         model_kwargs={'max_completion_tokens': 5000}
+        ...         model_kwargs={'max_completion_tokens': 5000},
         ...     )
         ... )
     """
@@ -233,7 +235,10 @@ async def embeddings(
 
         Add an embedding index to an existing column `text`:
 
-        >>> tbl.add_embedding_index('text', embedding=fabric.embeddings.using(model='text-embedding-ada-002'))
+        >>> tbl.add_embedding_index(
+        ...     'text',
+        ...     embedding=fabric.embeddings.using(model='text-embedding-ada-002'),
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}

--- a/pixeltable/functions/fal.py
+++ b/pixeltable/functions/fal.py
@@ -54,14 +54,20 @@ async def run(input: dict[str, Any], *, app: str) -> pxt.Json:
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
         >>> input = {'prompt': tbl.prompt}
-        ... tbl.add_computed_column(response=run(input, app='fal-ai/flux/schnell'))
+        >>> tbl.add_computed_column(response=run(input, app='fal-ai/flux/schnell'))
 
         Add a computed column that uses the model `fal-ai/fast-sdxl`
         to generate images from an existing Pixeltable column `tbl.prompt`:
 
-        >>> input = {'prompt': tbl.prompt, 'image_size': 'square', 'num_inference_steps': 25}
-        ... tbl.add_computed_column(response=run(input, app='fal-ai/fast-sdxl'))
-        ... tbl.add_computed_column(image=tbl.response['images'][0]['url'].astype(pxt.Image))
+        >>> input = {
+        ...     'prompt': tbl.prompt,
+        ...     'image_size': 'square',
+        ...     'num_inference_steps': 25,
+        ... }
+        >>> tbl.add_computed_column(response=run(input, app='fal-ai/fast-sdxl'))
+        >>> tbl.add_computed_column(
+        ...     image=tbl.response['images'][0]['url'].astype(pxt.Image)
+        ... )
     """
     Env.get().require_package('fal_client')
     client = _fal_client()

--- a/pixeltable/functions/fireworks.py
+++ b/pixeltable/functions/fireworks.py
@@ -60,7 +60,9 @@ async def chat_completions(
 
         >>> messages = [{'role': 'user', 'content': tbl.prompt}]
         ... tbl.add_computed_column(
-        ...     response=chat_completions(messages, model='accounts/fireworks/models/mixtral-8x22b-instruct')
+        ...     response=chat_completions(
+        ...         messages, model='accounts/fireworks/models/mixtral-8x22b-instruct'
+        ...     )
         ... )
     """
     if model_kwargs is None:

--- a/pixeltable/functions/gemini.py
+++ b/pixeltable/functions/gemini.py
@@ -98,7 +98,9 @@ async def generate_content(
         Add a computed column that applies the model `gemini-2.5-flash`
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
-        >>> tbl.add_computed_column(response=generate_content(tbl.prompt, model='gemini-2.5-flash'))
+        >>> tbl.add_computed_column(
+        ...     response=generate_content(tbl.prompt, model='gemini-2.5-flash')
+        ... )
 
         Add a computed column that applies the model `gemini-2.5-flash` for image understanding
     """
@@ -191,7 +193,9 @@ async def generate_images(
         Add a computed column that applies the model `imagen-4.0-generate-001`
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
-        >>> tbl.add_computed_column(response=generate_images(tbl.prompt, model='imagen-4.0-generate-001'))
+        >>> tbl.add_computed_column(
+        ...     response=generate_images(tbl.prompt, model='imagen-4.0-generate-001')
+        ... )
     """
     env.Env.get().require_package('google.genai')
     from google.genai.types import GenerateImagesConfig
@@ -247,7 +251,9 @@ async def generate_videos(
         Add a computed column that applies the model `veo-3.0-generate-001`
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
-        >>> tbl.add_computed_column(response=generate_videos(tbl.prompt, model='veo-3.0-generate-001'))
+        >>> tbl.add_computed_column(
+        ...     response=generate_videos(tbl.prompt, model='veo-3.0-generate-001')
+        ... )
     """
     env.Env.get().require_package('google.genai')
     from google.genai import types

--- a/pixeltable/functions/globals.py
+++ b/pixeltable/functions/globals.py
@@ -39,8 +39,7 @@ class sum(func.Aggregator, typing.Generic[T]):
         assigning the name `'category_total'` to the new column:
 
         >>> tbl.group_by(tbl.category).select(
-        ...     tbl.category,
-        ...     category_total=pxt.functions.sum(tbl.value)
+        ...     tbl.category, category_total=pxt.functions.sum(tbl.value)
         ... ).collect()
     """
 
@@ -91,8 +90,7 @@ class count(func.Aggregator, typing.Generic[T]):
         for each category, assigning the name `'category_count'` to the new column:
 
         >>> tbl.group_by(tbl.category).select(
-        ...     tbl.category,
-        ...     category_count=pxt.functions.count(tbl.value)
+        ...     tbl.category, category_count=pxt.functions.count(tbl.value)
         ... ).collect()
     """
 
@@ -135,8 +133,7 @@ class min(func.Aggregator, typing.Generic[T]):
         assigning the name `'category_min'` to the new column:
 
         >>> tbl.group_by(tbl.category).select(
-        ...     tbl.category,
-        ...     category_min=pxt.functions.min(tbl.value)
+        ...     tbl.category, category_min=pxt.functions.min(tbl.value)
         ... ).collect()
     """
 
@@ -188,8 +185,7 @@ class max(func.Aggregator, typing.Generic[T]):
         assigning the name `'category_max'` to the new column:
 
         >>> tbl.group_by(tbl.category).select(
-        ...     tbl.category,
-        ...     category_max=pxt.functions.max(tbl.value)
+        ...     tbl.category, category_max=pxt.functions.max(tbl.value)
         ... ).collect()
     """
 
@@ -236,8 +232,7 @@ class mean(func.Aggregator, typing.Generic[T]):
         assigning the name `'category_mean'` to the new column:
 
         >>> tbl.group_by(tbl.category).select(
-        ...     tbl.category,
-        ...     category_mean=pxt.functions.mean(tbl.value)
+        ...     tbl.category, category_mean=pxt.functions.mean(tbl.value)
         ... ).collect()
     """
 

--- a/pixeltable/functions/groq.py
+++ b/pixeltable/functions/groq.py
@@ -66,7 +66,9 @@ async def chat_completions(
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
         >>> messages = [{'role': 'user', 'content': tbl.prompt}]
-        ... tbl.add_computed_column(response=chat_completions(messages, model='llama-3.1-8b-instant'))
+        ... tbl.add_computed_column(
+        ...     response=chat_completions(messages, model='llama-3.1-8b-instant')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}

--- a/pixeltable/functions/huggingface.py
+++ b/pixeltable/functions/huggingface.py
@@ -52,7 +52,11 @@ def sentence_transformer(
         Add a computed column that applies the model `all-mpnet-base-2` to an existing Pixeltable column `tbl.sentence`
         of the table `tbl`:
 
-        >>> tbl.add_computed_column(result=sentence_transformer(tbl.sentence, model_id='all-mpnet-base-v2'))
+        >>> tbl.add_computed_column(
+        ...     result=sentence_transformer(
+        ...         tbl.sentence, model_id='all-mpnet-base-v2'
+        ...     )
+        ... )
     """
     env.Env.get().require_package('sentence_transformers')
     device = resolve_torch_device('auto')
@@ -98,9 +102,11 @@ def cross_encoder(sentences1: Batch[str], sentences2: Batch[str], *, model_id: s
         Add a computed column that applies the model `ms-marco-MiniLM-L-4-v2` to the sentences in
         columns `tbl.sentence1` and `tbl.sentence2`:
 
-        >>> tbl.add_computed_column(result=sentence_transformer(
-        ...     tbl.sentence1, tbl.sentence2, model_id='ms-marco-MiniLM-L-4-v2'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     result=sentence_transformer(
+        ...         tbl.sentence1, tbl.sentence2, model_id='ms-marco-MiniLM-L-4-v2'
+        ...     )
+        ... )
     """
     env.Env.get().require_package('sentence_transformers')
     device = resolve_torch_device('auto')
@@ -219,11 +225,17 @@ def detr_for_object_detection(
 
             ```python
             {
-                'scores': [0.99, 0.999],  # list of confidence scores for each detected object
-                'labels': [25, 25],  # list of COCO class labels for each detected object
-                'label_text': ['giraffe', 'giraffe'],  # corresponding text names of class labels
-                'boxes': [[51.942, 356.174, 181.481, 413.975], [383.225, 58.66, 605.64, 361.346]]
-                    # list of bounding boxes for each detected object, as [x1, y1, x2, y2]
+                # list of confidence scores for each detected object
+                'scores': [0.99, 0.999],
+                # list of COCO class labels for each detected object
+                'labels': [25, 25],
+                # corresponding text names of class labels
+                'label_text': ['giraffe', 'giraffe'],
+                # list of bounding boxes for each detected object, as [x1, y1, x2, y2]
+                'boxes': [
+                    [51.942, 356.174, 181.481, 413.975],
+                    [383.225, 58.66, 605.64, 361.346],
+                ],
             }
             ```
 
@@ -231,11 +243,11 @@ def detr_for_object_detection(
         Add a computed column that applies the model `facebook/detr-resnet-50` to an existing
         Pixeltable column `image` of the table `tbl`:
 
-        >>> tbl.add_computed_column(detections=detr_for_object_detection(
-        ...     tbl.image,
-        ...     model_id='facebook/detr-resnet-50',
-        ...     threshold=0.8
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     detections=detr_for_object_detection(
+        ...         tbl.image, model_id='facebook/detr-resnet-50', threshold=0.8
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -293,10 +305,10 @@ def detr_for_segmentation(image: Batch[PIL.Image.Image], *, model_id: str, thres
                         'label_id': 0,  # class label index
                         'label_text': 'person',  # human-readable class name
                         'score': 0.98,  # confidence score
-                        'was_fused': False  # whether segment was fused from multiple instances
+                        'was_fused': False,  # whether segment was fused from multiple instances
                     },
-                    ...
-                ]
+                    ...,
+                ],
             }
             ```
 
@@ -304,11 +316,13 @@ def detr_for_segmentation(image: Batch[PIL.Image.Image], *, model_id: str, thres
         Add a computed column that applies the model `facebook/detr-resnet-50-panoptic` to an existing
         Pixeltable column `image` of the table `tbl`:
 
-        >>> tbl.add_computed_column(segmentation=detr_for_segmentation(
-        ...     tbl.image,
-        ...     model_id='facebook/detr-resnet-50-panoptic',
-        ...     threshold=0.5
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     segmentation=detr_for_segmentation(
+        ...         tbl.image,
+        ...         model_id='facebook/detr-resnet-50-panoptic',
+        ...         threshold=0.5,
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     env.Env.get().require_package('timm')
@@ -384,11 +398,11 @@ def vit_for_image_classification(
         Add a computed column that applies the model `google/vit-base-patch16-224` to an existing
         Pixeltable column `image` of the table `tbl`, returning the 10 most likely classes for each image:
 
-        >>> tbl.add_computed_column(image_class=vit_for_image_classification(
-        ...     tbl.image,
-        ...     model_id='google/vit-base-patch16-224',
-        ...     top_k=10
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     image_class=vit_for_image_classification(
+        ...         tbl.image, model_id='google/vit-base-patch16-224', top_k=10
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -443,19 +457,22 @@ def speech2text_for_conditional_generation(audio: pxt.Audio, *, model_id: str, l
         Add a computed column that applies the model `facebook/s2t-small-librispeech-asr` to an existing
         Pixeltable column `audio` of the table `tbl`:
 
-        >>> tbl.add_computed_column(transcription=speech2text_for_conditional_generation(
-        ...     tbl.audio,
-        ...     model_id='facebook/s2t-small-librispeech-asr'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     transcription=speech2text_for_conditional_generation(
+        ...         tbl.audio, model_id='facebook/s2t-small-librispeech-asr'
+        ...     )
+        ... )
 
         Add a computed column that applies the model `facebook/s2t-medium-mustc-multilingual-st` to an existing
         Pixeltable column `audio` of the table `tbl`, translating the audio to French:
 
-        >>> tbl.add_computed_column(translation=speech2text_for_conditional_generation(
-        ...     tbl.audio,
-        ...     model_id='facebook/s2t-medium-mustc-multilingual-st',
-        ...     language='fr'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     translation=speech2text_for_conditional_generation(
+        ...         tbl.audio,
+        ...         model_id='facebook/s2t-medium-mustc-multilingual-st',
+        ...         language='fr',
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     env.Env.get().require_package('torchaudio')
@@ -520,7 +537,9 @@ def detr_to_coco(image: PIL.Image.Image, detr_info: dict[str, Any]) -> dict[str,
         Add a computed column that converts the output `tbl.detections` to COCO format, where `tbl.image`
         is the image for which detections were computed:
 
-        >>> tbl.add_computed_column(detections_coco=detr_to_coco(tbl.image, tbl.detections))
+        >>> tbl.add_computed_column(
+        ...     detections_coco=detr_to_coco(tbl.image, tbl.detections)
+        ... )
     """
     bboxes, labels = detr_info['boxes'], detr_info['labels']
     annotations = [
@@ -554,11 +573,13 @@ def text_generation(text: str, *, model_id: str, model_kwargs: dict[str, Any] | 
     Examples:
         Add a computed column that generates text completions using the `Qwen/Qwen3-0.6B` model:
 
-        >>> tbl.add_computed_column(completion=text_generation(
-        ...     tbl.prompt,
-        ...     model_id='Qwen/Qwen3-0.6B',
-        ...     model_kwargs={'temperature': 0.5, 'max_length': 150}
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     completion=text_generation(
+        ...         tbl.prompt,
+        ...         model_id='Qwen/Qwen3-0.6B',
+        ...         model_kwargs={'temperature': 0.5, 'max_length': 150},
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -605,10 +626,12 @@ def text_classification(text: Batch[str], *, model_id: str, top_k: int = 5) -> B
     Examples:
         Add a computed column for sentiment analysis:
 
-        >>> tbl.add_computed_column(sentiment=text_classification(
-        ...     tbl.review_text,
-        ...     model_id='cardiffnlp/twitter-roberta-base-sentiment-latest'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     sentiment=text_classification(
+        ...         tbl.review_text,
+        ...         model_id='cardiffnlp/twitter-roberta-base-sentiment-latest',
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -668,11 +691,13 @@ def image_captioning(
         Add a computed column `caption` to an existing table `tbl` that generates captions using the
         `Salesforce/blip-image-captioning-base` model:
 
-        >>> tbl.add_computed_column(caption=image_captioning(
-        ...     tbl.image,
-        ...     model_id='Salesforce/blip-image-captioning-base',
-        ...     model_kwargs={'max_length': 30}
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     caption=image_captioning(
+        ...         tbl.image,
+        ...         model_id='Salesforce/blip-image-captioning-base',
+        ...         model_kwargs={'max_length': 30},
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -715,11 +740,13 @@ def summarization(text: Batch[str], *, model_id: str, model_kwargs: dict[str, An
     Examples:
         Add a computed column that summarizes documents:
 
-        >>> tbl.add_computed_column(summary=text_summarization(
-        ...     tbl.document_text,
-        ...     model_id='facebook/bart-large-cnn',
-        ...     max_length=100
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     summary=text_summarization(
+        ...         tbl.document_text,
+        ...         model_id='facebook/bart-large-cnn',
+        ...         max_length=100,
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -763,10 +790,12 @@ def token_classification(
     Examples:
         Add a computed column that extracts named entities:
 
-        >>> tbl.add_computed_column(entities=token_classification(
-        ...     tbl.text,
-        ...     model_id='dbmdz/bert-large-cased-finetuned-conll03-english'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     entities=token_classification(
+        ...         tbl.text,
+        ...         model_id='dbmdz/bert-large-cased-finetuned-conll03-english',
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -902,11 +931,13 @@ def question_answering(context: str, question: str, *, model_id: str) -> dict[st
     Examples:
         Add a computed column that answers questions based on document context:
 
-        >>> tbl.add_computed_column(answer=question_answering(
-        ...     tbl.document_text,
-        ...     tbl.question,
-        ...     model_id='deepset/roberta-base-squad2'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     answer=question_answering(
+        ...         tbl.document_text,
+        ...         tbl.question,
+        ...         model_id='deepset/roberta-base-squad2',
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -974,12 +1005,14 @@ def translation(
     Examples:
         Add a computed column that translates text:
 
-        >>> tbl.add_computed_column(french_text=translation(
-        ...     tbl.english_text,
-        ...     model_id='Helsinki-NLP/opus-mt-en-fr',
-        ...     src_lang='en',
-        ...     target_lang='fr'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     french_text=translation(
+        ...         tbl.english_text,
+        ...         model_id='Helsinki-NLP/opus-mt-en-fr',
+        ...         src_lang='en',
+        ...         target_lang='fr',
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     device = resolve_torch_device('auto')
@@ -1053,13 +1086,15 @@ def text_to_image(
     Examples:
         Add a computed column that generates images from text prompts:
 
-        >>> tbl.add_computed_column(generated_image=text_to_image(
-        ...     tbl.prompt,
-        ...     model_id='stable-diffusion-v1.5/stable-diffusion-v1-5',
-        ...     height=512,
-        ...     width=512,
-        ...     model_kwargs={'num_inference_steps': 25},
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     generated_image=text_to_image(
+        ...         tbl.prompt,
+        ...         model_id='stable-diffusion-v1.5/stable-diffusion-v1-5',
+        ...         height=512,
+        ...         width=512,
+        ...         model_kwargs={'num_inference_steps': 25},
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     env.Env.get().require_package('diffusers')
@@ -1127,11 +1162,11 @@ def text_to_speech(text: str, *, model_id: str, speaker_id: int | None = None, v
     Examples:
         Add a computed column that converts text to speech:
 
-        >>> tbl.add_computed_column(audio=text_to_speech(
-        ...     tbl.text_content,
-        ...     model_id='microsoft/speecht5_tts',
-        ...     speaker_id=0
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     audio=text_to_speech(
+        ...         tbl.text_content, model_id='microsoft/speecht5_tts', speaker_id=0
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     env.Env.get().require_package('datasets')
@@ -1247,20 +1282,24 @@ def image_to_image(
     Examples:
         Add a computed column that transforms images based on prompts:
 
-        >>> tbl.add_computed_column(transformed=image_to_image(
-        ...     tbl.source_image,
-        ...     tbl.transformation_prompt,
-        ...     model_id='stable-diffusion-v1-5/stable-diffusion-v1-5'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     transformed=image_to_image(
+        ...         tbl.source_image,
+        ...         tbl.transformation_prompt,
+        ...         model_id='stable-diffusion-v1-5/stable-diffusion-v1-5',
+        ...     )
+        ... )
 
         With custom transformation strength:
 
-        >>> tbl.add_computed_column(transformed=image_to_image(
-        ...     tbl.source_image,
-        ...     tbl.transformation_prompt,
-        ...     model_id='stable-diffusion-v1-5/stable-diffusion-v1-5',
-        ...     model_kwargs={'strength': 0.75, 'num_inference_steps': 50}
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     transformed=image_to_image(
+        ...         tbl.source_image,
+        ...         tbl.transformation_prompt,
+        ...         model_id='stable-diffusion-v1-5/stable-diffusion-v1-5',
+        ...         model_kwargs={'strength': 0.75, 'num_inference_steps': 50},
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     env.Env.get().require_package('diffusers')
@@ -1342,18 +1381,20 @@ def automatic_speech_recognition(
     Examples:
         Add a computed column that transcribes audio files:
 
-        >>> tbl.add_computed_column(transcription=automatic_speech_recognition(
-        ...     tbl.audio_file,
-        ...     model_id='openai/whisper-tiny.en'  # Recommended
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     transcription=automatic_speech_recognition(
+        ...         tbl.audio_file,
+        ...         model_id='openai/whisper-tiny.en',  # Recommended
+        ...     )
+        ... )
 
         Transcribe with language specification:
 
-        >>> tbl.add_computed_column(transcription=automatic_speech_recognition(
-        ...     tbl.audio_file,
-        ...     model_id='facebook/mms-1b-all',
-        ...     language='en'
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     transcription=automatic_speech_recognition(
+        ...         tbl.audio_file, model_id='facebook/mms-1b-all', language='en'
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     env.Env.get().require_package('torchaudio')
@@ -1486,12 +1527,14 @@ def image_to_video(
     Examples:
         Add a computed column that creates videos from images:
 
-        >>> tbl.add_computed_column(video=image_to_video(
-        ...     tbl.input_image,
-        ...     model_id='stabilityai/stable-video-diffusion-img2vid-xt',
-        ...     num_frames=25,
-        ...     fps=7
-        ... ))
+        >>> tbl.add_computed_column(
+        ...     video=image_to_video(
+        ...         tbl.input_image,
+        ...         model_id='stabilityai/stable-video-diffusion-img2vid-xt',
+        ...         num_frames=25,
+        ...         fps=7,
+        ...     )
+        ... )
     """
     env.Env.get().require_package('transformers')
     env.Env.get().require_package('diffusers')

--- a/pixeltable/functions/image.py
+++ b/pixeltable/functions/image.py
@@ -471,7 +471,9 @@ def tile_iterator(
         >>> pxt.create_view(
         ...     'image_tiles',
         ...     tbl,
-        ...     iterator=image_tile_iterator(tbl.img, tile_size=(256, 256), overlap=(32, 32))
+        ...     iterator=image_tile_iterator(
+        ...         tbl.img, tile_size=(256, 256), overlap=(32, 32)
+        ...     ),
         ... )
     """
     kwargs: dict[str, Any] = {}

--- a/pixeltable/functions/jina.py
+++ b/pixeltable/functions/jina.py
@@ -140,12 +140,16 @@ async def embeddings(
         Add a computed column that applies jina-embeddings-v3 to an existing column:
 
         >>> tbl.add_computed_column(
-        ...     embed=jina.embeddings(tbl.text, model='jina-embeddings-v3', task='retrieval.passage')
+        ...     embed=jina.embeddings(
+        ...         tbl.text, model='jina-embeddings-v3', task='retrieval.passage'
+        ...     )
         ... )
 
         Add an embedding index:
 
-        >>> tbl.add_embedding_index('text', string_embed=jina.embeddings.using(model='jina-embeddings-v3'))
+        >>> tbl.add_embedding_index(
+        ...     'text', string_embed=jina.embeddings.using(model='jina-embeddings-v3')
+        ... )
     """
     cl = _client()
 
@@ -216,7 +220,7 @@ async def rerank(
         ...         tbl.query,
         ...         tbl.candidate_docs,
         ...         model='jina-reranker-v2-base-multilingual',
-        ...         top_n=5
+        ...         top_n=5,
         ...     )
         ... )
     """

--- a/pixeltable/functions/mistralai.py
+++ b/pixeltable/functions/mistralai.py
@@ -62,7 +62,9 @@ async def chat_completions(
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
         >>> messages = [{'role': 'user', 'content': tbl.prompt}]
-        ... tbl.add_computed_column(response=completions(messages, model='mistral-latest-small'))
+        ... tbl.add_computed_column(
+        ...     response=completions(messages, model='mistral-latest-small')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -107,7 +109,9 @@ async def fim_completions(prompt: str, *, model: str, model_kwargs: dict[str, An
         Add a computed column that applies the model `codestral-latest`
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
-        >>> tbl.add_computed_column(response=completions(tbl.prompt, model='codestral-latest'))
+        >>> tbl.add_computed_column(
+        ...     response=completions(tbl.prompt, model='codestral-latest')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}

--- a/pixeltable/functions/net.py
+++ b/pixeltable/functions/net.py
@@ -39,7 +39,7 @@ def presigned_url(uri: str, expiration_seconds: int) -> str:
 
         >>> tbl.select(
         ...     original_url=tbl.video.fileurl,
-        ...     presigned_url=pxtf.net.presigned_url(tbl.video.fileurl, 3600)
+        ...     presigned_url=pxtf.net.presigned_url(tbl.video.fileurl, 3600),
         ... ).collect()
     """
     if not uri:

--- a/pixeltable/functions/openai.py
+++ b/pixeltable/functions/openai.py
@@ -265,7 +265,9 @@ async def speech(input: str, *, model: str, voice: str, model_kwargs: dict[str, 
         Add a computed column that applies the model `tts-1` to an existing Pixeltable column `tbl.text`
         of the table `tbl`:
 
-        >>> tbl.add_computed_column(audio=speech(tbl.text, model='tts-1', voice='nova'))
+        >>> tbl.add_computed_column(
+        ...     audio=speech(tbl.text, model='tts-1', voice='nova')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -306,7 +308,11 @@ async def transcriptions(audio: pxt.Audio, *, model: str, model_kwargs: dict[str
         Add a computed column that applies the model `whisper-1` to an existing Pixeltable column `tbl.audio`
         of the table `tbl`:
 
-        >>> tbl.add_computed_column(transcription=transcriptions(tbl.audio, model='whisper-1', language='en'))
+        >>> tbl.add_computed_column(
+        ...     transcription=transcriptions(
+        ...         tbl.audio, model='whisper-1', language='en'
+        ...     )
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -345,7 +351,9 @@ async def translations(audio: pxt.Audio, *, model: str, model_kwargs: dict[str, 
         Add a computed column that applies the model `whisper-1` to an existing Pixeltable column `tbl.audio`
         of the table `tbl`:
 
-        >>> tbl.add_computed_column(translation=translations(tbl.audio, model='whisper-1', language='en'))
+        >>> tbl.add_computed_column(
+        ...     translation=translations(tbl.audio, model='whisper-1', language='en')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -448,9 +456,11 @@ async def chat_completions(
 
         >>> messages = [
         ...     {'role': 'system', 'content': 'You are a helpful assistant.'},
-        ...     {'role': 'user', 'content': tbl.prompt}
+        ...     {'role': 'user', 'content': tbl.prompt},
         ... ]
-        >>> tbl.add_computed_column(response=chat_completions(messages, model='gpt-4o-mini'))
+        >>> tbl.add_computed_column(
+        ...     response=chat_completions(messages, model='gpt-4o-mini')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -559,7 +569,11 @@ async def vision(
         Add a computed column that applies the model `gpt-4o-mini` to an existing Pixeltable column `tbl.image`
         of the table `tbl`:
 
-        >>> tbl.add_computed_column(response=vision("What's in this image?", tbl.image, model='gpt-4o-mini'))
+        >>> tbl.add_computed_column(
+        ...     response=vision(
+        ...         "What's in this image?", tbl.image, model='gpt-4o-mini'
+        ...     )
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -651,11 +665,15 @@ async def embeddings(
         Add a computed column that applies the model `text-embedding-3-small` to an existing
         Pixeltable column `tbl.text` of the table `tbl`:
 
-        >>> tbl.add_computed_column(embed=embeddings(tbl.text, model='text-embedding-3-small'))
+        >>> tbl.add_computed_column(
+        ...     embed=embeddings(tbl.text, model='text-embedding-3-small')
+        ... )
 
         Add an embedding index to an existing column `text`, using the model `text-embedding-3-small`:
 
-        >>> tbl.add_embedding_index(embedding=embeddings.using(model='text-embedding-3-small'))
+        >>> tbl.add_embedding_index(
+        ...     embedding=embeddings.using(model='text-embedding-3-small')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -723,7 +741,9 @@ async def image_generations(
         Add a computed column that applies the model `dall-e-2` to an existing
         Pixeltable column `tbl.text` of the table `tbl`:
 
-        >>> tbl.add_computed_column(gen_image=image_generations(tbl.text, model='dall-e-2'))
+        >>> tbl.add_computed_column(
+        ...     gen_image=image_generations(tbl.text, model='dall-e-2')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -788,7 +808,9 @@ async def moderations(input: str, *, model: str = 'omni-moderation-latest') -> d
         Add a computed column that applies the model `text-moderation-stable` to an existing
         Pixeltable column `tbl.input` of the table `tbl`:
 
-        >>> tbl.add_computed_column(moderations=moderations(tbl.text, model='text-moderation-stable'))
+        >>> tbl.add_computed_column(
+        ...     moderations=moderations(tbl.text, model='text-moderation-stable')
+        ... )
     """
     result = await _openai_client().moderations.create(input=input, model=model)
     return result.dict()

--- a/pixeltable/functions/openrouter.py
+++ b/pixeltable/functions/openrouter.py
@@ -79,8 +79,7 @@ async def chat_completions(
         >>> messages = [{'role': 'user', 'content': tbl.prompt}]
         ... tbl.add_computed_column(
         ...     response=chat_completions(
-        ...         messages,
-        ...         model='anthropic/claude-3.5-sonnet'
+        ...         messages, model='anthropic/claude-3.5-sonnet'
         ...     )
         ... )
 
@@ -90,7 +89,7 @@ async def chat_completions(
         ...     response=chat_completions(
         ...         messages,
         ...         model='anthropic/claude-3.5-sonnet',
-        ...         provider={'require_parameters': True, 'order': ['Anthropic']}
+        ...         provider={'require_parameters': True, 'order': ['Anthropic']},
         ...     )
         ... )
 
@@ -100,7 +99,7 @@ async def chat_completions(
         ...     response=chat_completions(
         ...         messages,
         ...         model='openai/gpt-4',
-        ...         transforms=['middle-out']  # Optimize for long contexts
+        ...         transforms=['middle-out'],  # Optimize for long contexts
         ...     )
         ... )
     """

--- a/pixeltable/functions/replicate.py
+++ b/pixeltable/functions/replicate.py
@@ -52,14 +52,21 @@ async def run(input: dict[str, Any], *, ref: str) -> pxt.Json:
         Add a computed column that applies the model `meta/meta-llama-3-8b-instruct`
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
-        >>> input = {'system_prompt': 'You are a helpful assistant.', 'prompt': tbl.prompt}
-        ... tbl.add_computed_column(response=run(input, ref='meta/meta-llama-3-8b-instruct'))
+        >>> input = {
+        ...     'system_prompt': 'You are a helpful assistant.',
+        ...     'prompt': tbl.prompt,
+        ... }
+        ... tbl.add_computed_column(
+        ...     response=run(input, ref='meta/meta-llama-3-8b-instruct')
+        ... )
 
         Add a computed column that uses the model `black-forest-labs/flux-schnell`
         to generate images from an existing Pixeltable column `tbl.prompt`:
 
         >>> input = {'prompt': tbl.prompt, 'go_fast': True, 'megapixels': '1'}
-        ... tbl.add_computed_column(response=run(input, ref='black-forest-labs/flux-schnell'))
+        ... tbl.add_computed_column(
+        ...     response=run(input, ref='black-forest-labs/flux-schnell')
+        ... )
         ... tbl.add_computed_column(image=tbl.response.output[0].astype(pxt.Image))
     """
     Env.get().require_package('replicate')

--- a/pixeltable/functions/reve.py
+++ b/pixeltable/functions/reve.py
@@ -148,9 +148,7 @@ async def create(prompt: str, *, aspect_ratio: str | None = None, version: str |
     Examples:
         Add a computed column with generated square images to a table with text prompts:
 
-        >>> t.add_computed_column(
-        ...     img=reve.create(t.prompt, aspect_ratio='1:1')
-        ... )
+        >>> t.add_computed_column(img=reve.create(t.prompt, aspect_ratio='1:1'))
     """
     payload = {'prompt': prompt}
     if aspect_ratio is not None:
@@ -184,7 +182,7 @@ async def edit(image: PIL.Image.Image, edit_instruction: str, *, version: str | 
         >>> t.add_computed_column(
         ...     catalog_img=reve.edit(
         ...         t.product_img,
-        ...         'Remove background and distractions from the product picture, improve lighting.'
+        ...         'Remove background and distractions from the product picture, improve lighting.',
         ...     )
         ... )
     """

--- a/pixeltable/functions/runwayml.py
+++ b/pixeltable/functions/runwayml.py
@@ -85,7 +85,9 @@ async def text_to_image(
         Add a computed column that generates images from prompts:
 
         >>> tbl.add_computed_column(
-        ...     response=text_to_image(tbl.prompt, [tbl.ref_image], model='gen4_image', ratio='16:9')
+        ...     response=text_to_image(
+        ...         tbl.prompt, [tbl.ref_image], model='gen4_image', ratio='16:9'
+        ...     )
         ... )
         >>> tbl.add_computed_column(image=tbl.response['output'][0].astype(pxt.Image))
     """
@@ -147,7 +149,11 @@ async def text_to_video(
     Examples:
         Add a computed column that generates videos from prompts:
 
-        >>> tbl.add_computed_column(response=text_to_video(tbl.prompt, model='veo3.1', ratio='16:9', duration=4))
+        >>> tbl.add_computed_column(
+        ...     response=text_to_video(
+        ...         tbl.prompt, model='veo3.1', ratio='16:9', duration=4
+        ...     )
+        ... )
         >>> tbl.add_computed_column(video=tbl.response['output'].astype(pxt.Video))
     """
     Env.get().require_package('runwayml')
@@ -207,7 +213,13 @@ async def image_to_video(
         Add a computed column that generates videos from images:
 
         >>> tbl.add_computed_column(
-        ...     response=image_to_video(tbl.image, model='gen4', ratio='16:9', prompt_text='Slow motion', duration=5)
+        ...     response=image_to_video(
+        ...         tbl.image,
+        ...         model='gen4',
+        ...         ratio='16:9',
+        ...         prompt_text='Slow motion',
+        ...         duration=5,
+        ...     )
         ... )
         >>> tbl.add_computed_column(video=tbl.response['output'].astype(pxt.Video))
     """
@@ -269,7 +281,9 @@ async def video_to_video(
         Add a computed column that transforms videos:
 
         >>> tbl.add_computed_column(
-        ...     response=video_to_video(tbl.video_url, 'Anime style', model='gen4_aleph', ratio='16:9')
+        ...     response=video_to_video(
+        ...         tbl.video_url, 'Anime style', model='gen4_aleph', ratio='16:9'
+        ...     )
         ... )
         >>> tbl.add_computed_column(video=tbl.response['output'].astype(pxt.Video))
     """

--- a/pixeltable/functions/string.py
+++ b/pixeltable/functions/string.py
@@ -838,7 +838,7 @@ def string_splitter(
         >>> pxt.create_view(
         ...     'sentence_chunks',
         ...     tbl,
-        ...     iterator=string_splitter(tbl.text, separators='sentence')
+        ...     iterator=string_splitter(tbl.text, separators='sentence'),
         ... )
     """
     return pxt.iterators.string.StringSplitter._create(text=text, separators=separators)

--- a/pixeltable/functions/together.py
+++ b/pixeltable/functions/together.py
@@ -78,7 +78,9 @@ async def completions(prompt: str, *, model: str, model_kwargs: dict[str, Any] |
         Add a computed column that applies the model `mistralai/Mixtral-8x7B-v0.1` to an existing Pixeltable column
         `tbl.prompt` of the table `tbl`:
 
-        >>> tbl.add_computed_column(response=completions(tbl.prompt, model='mistralai/Mixtral-8x7B-v0.1'))
+        >>> tbl.add_computed_column(
+        ...     response=completions(tbl.prompt, model='mistralai/Mixtral-8x7B-v0.1')
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -119,7 +121,11 @@ async def chat_completions(
         `tbl.prompt` of the table `tbl`:
 
         >>> messages = [{'role': 'user', 'content': tbl.prompt}]
-        ... tbl.add_computed_column(response=chat_completions(messages, model='mistralai/Mixtral-8x7B-v0.1'))
+        ... tbl.add_computed_column(
+        ...     response=chat_completions(
+        ...         messages, model='mistralai/Mixtral-8x7B-v0.1'
+        ...     )
+        ... )
     """
     if model_kwargs is None:
         model_kwargs = {}
@@ -167,7 +173,11 @@ async def embeddings(input: Batch[str], *, model: str) -> Batch[pxt.Array[(None,
         Add a computed column that applies the model `togethercomputer/m2-bert-80M-8k-retrieval`
         to an existing Pixeltable column `tbl.text` of the table `tbl`:
 
-        >>> tbl.add_computed_column(response=embeddings(tbl.text, model='togethercomputer/m2-bert-80M-8k-retrieval'))
+        >>> tbl.add_computed_column(
+        ...     response=embeddings(
+        ...         tbl.text, model='togethercomputer/m2-bert-80M-8k-retrieval'
+        ...     )
+        ... )
     """
     result = await _together_client().embeddings.create(input=input, model=model)
     return [np.array(data.embedding, dtype=np.float64) for data in result.data]
@@ -212,7 +222,9 @@ async def image_generations(prompt: str, *, model: str, model_kwargs: dict[str, 
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
         >>> tbl.add_computed_column(
-        ...     response=image_generations(tbl.prompt, model='stabilityai/stable-diffusion-xl-base-1.0')
+        ...     response=image_generations(
+        ...         tbl.prompt, model='stabilityai/stable-diffusion-xl-base-1.0'
+        ...     )
         ... )
     """
     if model_kwargs is None:

--- a/pixeltable/functions/video.py
+++ b/pixeltable/functions/video.py
@@ -403,7 +403,7 @@ def segment_video(
         ...     segment_paths=tbl.video.segment_video(
         ...         duration=10,
         ...         video_encoder='libx264',
-        ...         video_encoder_args={'crf': 23, 'preset': 'slow'}
+        ...         video_encoder_args={'crf': 23, 'preset': 'slow'},
         ...     )
         ... ).collect()
 
@@ -411,9 +411,7 @@ def segment_video(
 
         >>> duration = tbl.video.get_duration()
         >>> tbl.select(
-        ...     segment_paths=tbl.video.segment_video(
-        ...         segment_times=[duration / 2]
-        ...     )
+        ...     segment_paths=tbl.video.segment_video(segment_times=[duration / 2])
         ... ).collect()
     """
     Env.get().require_binary('ffmpeg')
@@ -645,9 +643,7 @@ def with_audio(
 
         >>> tbl.select(
         ...     tbl.video.with_audio(
-        ...         tbl.music_track,
-        ...         video_start_time=5.0,
-        ...         audio_start_time=5.0
+        ...         tbl.music_track, video_start_time=5.0, audio_start_time=5.0
         ...     )
         ... ).collect()
 
@@ -659,7 +655,7 @@ def with_audio(
         ...         video_start_time=30.0,
         ...         video_duration=10.0,
         ...         audio_start_time=15.0,
-        ...         audio_duration=10.0
+        ...         audio_duration=10.0,
         ...     )
         ... ).collect()
     """
@@ -790,7 +786,7 @@ def overlay_text(
         ...         box_border=[6, 14],
         ...         horizontal_margin=10,
         ...         vertical_align='bottom',
-        ...         vertical_margin=70
+        ...         vertical_margin=70,
         ...     )
         ... ).collect()
 
@@ -804,7 +800,7 @@ def overlay_text(
         ...         box=True,
         ...         box_color='black',
         ...         box_opacity=0.6,
-        ...         box_border=[20, 10]
+        ...         box_border=[20, 10],
         ...     )
         ... ).collect()
     """
@@ -991,15 +987,14 @@ def scene_detect_adaptive(
 
         Detect more scenes by lowering the threshold:
 
-        >>> tbl.select(tbl.video.scene_detect_adaptive(adaptive_threshold=1.5)).collect()
+        >>> tbl.select(
+        ...     tbl.video.scene_detect_adaptive(adaptive_threshold=1.5)
+        ... ).collect()
 
         Use luminance-only detection with a longer minimum scene length:
 
         >>> tbl.select(
-        ...     tbl.video.scene_detect_adaptive(
-        ...         luma_only=True,
-        ...         min_scene_len=30
-        ...     )
+        ...     tbl.video.scene_detect_adaptive(luma_only=True, min_scene_len=30)
         ... ).collect()
 
         Add scene cuts as a computed column:
@@ -1101,9 +1096,7 @@ def scene_detect_content(
 
         >>> tbl.select(
         ...     tbl.video.scene_detect_content(
-        ...         delta_edges=1.0,
-        ...         delta_hue=0.5,
-        ...         delta_sat=0.5
+        ...         delta_edges=1.0, delta_hue=0.5, delta_sat=0.5
         ...     )
         ... ).collect()
 
@@ -1201,9 +1194,7 @@ def scene_detect_threshold(
         Add final scene boundary:
 
         >>> tbl.select(
-        ...     tbl.video.scene_detect_threshold(
-        ...         add_final_scene=True
-        ...     )
+        ...     tbl.video.scene_detect_threshold(add_final_scene=True)
         ... ).collect()
 
         Add fade transitions as a computed column:
@@ -1283,11 +1274,7 @@ def scene_detect_histogram(
 
         Use with a longer minimum scene length:
 
-        >>> tbl.select(
-        ...     tbl.video.scene_detect_histogram(
-        ...         min_scene_len=30
-        ...     )
-        ... ).collect()
+        >>> tbl.select(tbl.video.scene_detect_histogram(min_scene_len=30)).collect()
 
         Add scene cuts as a computed column:
 
@@ -1368,18 +1355,11 @@ def scene_detect_hash(
 
         Use for fast processing with lower frame rate:
 
-        >>> tbl.select(
-        ...     tbl.video.scene_detect_hash(
-        ...         fps=1.0,
-        ...         threshold=0.4
-        ...     )
-        ... ).collect()
+        >>> tbl.select(tbl.video.scene_detect_hash(fps=1.0, threshold=0.4)).collect()
 
         Add scene cuts as a computed column:
 
-        >>> tbl.add_computed_column(
-        ...     scene_cuts=tbl.video.scene_detect_hash()
-        ... )
+        >>> tbl.add_computed_column(scene_cuts=tbl.video.scene_detect_hash())
     """
     Env.get().require_package('scenedetect')
     from scenedetect.detectors import HashDetector
@@ -1505,15 +1485,23 @@ def frame_iterator(
 
         Create a view that extracts only keyframes from all videos:
 
-        >>> pxt.create_view('keyframes', tbl, iterator=frame_iterator(tbl.video, keyframes_only=True))
+        >>> pxt.create_view(
+        ...     'keyframes',
+        ...     tbl,
+        ...     iterator=frame_iterator(tbl.video, keyframes_only=True),
+        ... )
 
         Create a view that extracts frames from all videos at a rate of 1 frame per second:
 
-        >>> pxt.create_view('one_fps_frames', tbl, iterator=frame_iterator(tbl.video, fps=1.0))
+        >>> pxt.create_view(
+        ...     'one_fps_frames', tbl, iterator=frame_iterator(tbl.video, fps=1.0)
+        ... )
 
         Create a view that extracts exactly 10 frames from each video:
 
-        >>> pxt.create_view('ten_frames', tbl, iterator=frame_iterator(tbl.video, num_frames=10))
+        >>> pxt.create_view(
+        ...     'ten_frames', tbl, iterator=frame_iterator(tbl.video, num_frames=10)
+        ... )
     """
     kwargs: dict[str, Any] = {}
     if fps is not None:
@@ -1564,17 +1552,29 @@ def video_splitter(
 
         Create a view that splits each video into 10-second segments:
 
-        >>> pxt.create_view('ten_second_segments', tbl, iterator=video_splitter(tbl.video, duration=10.0))
+        >>> pxt.create_view(
+        ...     'ten_second_segments',
+        ...     tbl,
+        ...     iterator=video_splitter(tbl.video, duration=10.0),
+        ... )
 
         Create a view that splits each video into segments at specified fixed times:
 
         >>> split_times = [5.0, 15.0, 30.0]
-        >>> pxt.create_view('custom_segments', tbl, iterator=video_splitter(tbl.video, segment_times=split_times))
+        >>> pxt.create_view(
+        ...     'custom_segments',
+        ...     tbl,
+        ...     iterator=video_splitter(tbl.video, segment_times=split_times),
+        ... )
 
         Create a view that splits each video into segments at times specified by a column `split_times` of type
         `pxt.Json`, containing a list of timestamps in seconds:
 
-        >>> pxt.create_view('custom_segments', tbl, iterator=video_splitter(tbl.video, segment_times=tbl.split_times))
+        >>> pxt.create_view(
+        ...     'custom_segments',
+        ...     tbl,
+        ...     iterator=video_splitter(tbl.video, segment_times=tbl.split_times),
+        ... )
     """
     kwargs: dict[str, Any] = {}
     if duration is not None:

--- a/pixeltable/functions/vision.py
+++ b/pixeltable/functions/vision.py
@@ -7,7 +7,9 @@ import pixeltable as pxt
 from pixeltable.functions import vision as pxtv
 
 t = pxt.get_table(...)
-t.select(pxtv.draw_bounding_boxes(t.img, boxes=t.boxes, label=t.labels)).collect()
+t.select(
+    pxtv.draw_bounding_boxes(t.img, boxes=t.boxes, label=t.labels)
+).collect()
 ```
 """
 
@@ -188,11 +190,14 @@ def eval_detections(
         {
             'min_iou': float,  # The value of `min_iou` used for the detections
             'class': int,  # The label class
-            'tp': list[int],  # List of 1's and 0's indicating true positives for each
-                              # predicted bounding box of this class
-            'fp': list[int],  # List of 1's and 0's indicating false positives for each
-                              # predicted bounding box of this class; `fp[n] == 1 - tp[n]`
-            'scores': list[float],  # List of predicted scores for each bounding box of this class
+            # List of 1's and 0's indicating true positives for each
+            # predicted bounding box of this class
+            'tp': list[int],
+            # List of 1's and 0's indicating false positives for each
+            # predicted bounding box of this class; `fp[n] == 1 - tp[n]`
+            'fp': list[int],
+            # List of predicted scores for each bounding box of this class
+            'scores': list[float],
             'num_gts': int,  # Number of ground truth bounding boxes of this class
         }
         ```

--- a/pixeltable/functions/voyageai.py
+++ b/pixeltable/functions/voyageai.py
@@ -91,11 +91,15 @@ async def embeddings(
         Add a computed column that applies the model `voyage-3.5` to an existing
         Pixeltable column `tbl.text` of the table `tbl`:
 
-        >>> tbl.add_computed_column(embed=embeddings(tbl.text, model='voyage-3.5', input_type='document'))
+        >>> tbl.add_computed_column(
+        ...     embed=embeddings(tbl.text, model='voyage-3.5', input_type='document')
+        ... )
 
         Add an embedding index to an existing column `text`, using the model `voyage-3.5`:
 
-        >>> tbl.add_embedding_index('text', string_embed=embeddings.using(model='voyage-3.5'))
+        >>> tbl.add_embedding_index(
+        ...     'text', string_embed=embeddings.using(model='voyage-3.5')
+        ... )
     """
     cl = _voyageai_client()
 
@@ -174,13 +178,20 @@ async def rerank(
         >>>
         >>> @pxt.query
         ... def get_candidates(query_text: str):
-        ...     sim = docs.text.similarity(query_text, embed=embeddings.using(model='voyage-3.5'))
+        ...     sim = docs.text.similarity(
+        ...         query_text, embed=embeddings.using(model='voyage-3.5')
+        ...     )
         ...     return docs.order_by(sim, asc=False).limit(20).select(docs.text)
         >>>
         >>> queries = pxt.create_table('queries', {'query': pxt.String})
         >>> queries.add_computed_column(candidates=get_candidates(queries.query))
         >>> queries.add_computed_column(
-        ...     reranked=rerank(queries.query, queries.candidates.text, model='rerank-2.5', top_k=5)
+        ...     reranked=rerank(
+        ...         queries.query,
+        ...         queries.candidates.text,
+        ...         model='rerank-2.5',
+        ...         top_k=5,
+        ...     )
         ... )
     """
     cl = _voyageai_client()
@@ -237,11 +248,16 @@ async def multimodal_embed(
 
         Add an embedding index for column `description`:
 
-        >>> tbl.add_embedding_index('description', string_embed=multimodal_embed.using(model='voyage-multimodal-3'))
+        >>> tbl.add_embedding_index(
+        ...     'description',
+        ...     string_embed=multimodal_embed.using(model='voyage-multimodal-3'),
+        ... )
 
         Embed an image column `img`:
 
-        >>> tbl.add_computed_column(embed=multimodal_embed(tbl.img, input_type='document'))
+        >>> tbl.add_computed_column(
+        ...     embed=multimodal_embed(tbl.img, input_type='document')
+        ... )
     """
     cl = _voyageai_client()
 

--- a/pixeltable/functions/yolox.py
+++ b/pixeltable/functions/yolox.py
@@ -38,7 +38,9 @@ def yolox(images: Batch[PIL.Image.Image], *, model_id: str, threshold: float = 0
         Add a computed column that applies the model `yolox_m` to an existing
         Pixeltable column `tbl.image` of the table `tbl`:
 
-        >>> tbl.add_computed_column(detections=yolox(tbl.image, model_id='yolox_m', threshold=0.8))
+        >>> tbl.add_computed_column(
+        ...     detections=yolox(tbl.image, model_id='yolox_m', threshold=0.8)
+        ... )
     """
     Env.get().require_package('yolox')
     import torch
@@ -67,7 +69,9 @@ def yolo_to_coco(detections: dict) -> list:
         Add a computed column that converts the output `tbl.detections` to COCO format, where `tbl.image`
         is the image for which detections were computed:
 
-        >>> tbl.add_computed_column(detections=yolox(tbl.image, model_id='yolox_m', threshold=0.8))
+        >>> tbl.add_computed_column(
+        ...     detections=yolox(tbl.image, model_id='yolox_m', threshold=0.8)
+        ... )
         ... tbl.add_computed_column(detections_coco=yolo_to_coco(tbl.detections))
     """
     bboxes, labels = detections['bboxes'], detections['labels']

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -127,21 +127,33 @@ def create_table(
     Examples:
         Create a table with an int and a string column:
 
-        >>> tbl = pxt.create_table('my_table', schema={'col1': pxt.Int, 'col2': pxt.String})
+        >>> tbl = pxt.create_table(
+        ...     'my_table', schema={'col1': pxt.Int, 'col2': pxt.String}
+        ... )
 
         Create a table from a select statement over an existing table `orig_table` (this will create a new table
         containing the exact contents of the query):
 
         >>> tbl1 = pxt.get_table('orig_table')
-        ... tbl2 = pxt.create_table('new_table', tbl1.where(tbl1.col1 < 10).select(tbl1.col2))
+        ... tbl2 = pxt.create_table(
+        ...     'new_table', tbl1.where(tbl1.col1 < 10).select(tbl1.col2)
+        ... )
 
         Create a table if it does not already exist, otherwise get the existing table:
 
-        >>> tbl = pxt.create_table('my_table', schema={'col1': pxt.Int, 'col2': pxt.String}, if_exists='ignore')
+        >>> tbl = pxt.create_table(
+        ...     'my_table',
+        ...     schema={'col1': pxt.Int, 'col2': pxt.String},
+        ...     if_exists='ignore',
+        ... )
 
         Create a table with an int and a float column, and replace any existing table:
 
-        >>> tbl = pxt.create_table('my_table', schema={'col1': pxt.Int, 'col2': pxt.Float}, if_exists='replace')
+        >>> tbl = pxt.create_table(
+        ...     'my_table',
+        ...     schema={'col1': pxt.Int, 'col2': pxt.Float},
+        ...     if_exists='replace',
+        ... )
 
         Create a table from a CSV file:
 
@@ -152,7 +164,7 @@ def create_table(
         >>> tbl = pxt.create_table(
         ...     'my_table',
         ...     schema={'id': pxt.functions.uuid.uuid4(), 'data': pxt.String},
-        ...     primary_key=['id']
+        ...     primary_key=['id'],
         ... )
     """
     from pixeltable.io.table_data_conduit import UnkTableDataConduit
@@ -302,13 +314,17 @@ def create_view(
         and if it not already exist. Otherwise, get the existing view named `my_view`:
 
         >>> tbl = pxt.get_table('my_table')
-        ... view = pxt.create_view('my_view', tbl.where(tbl.col1 > 10), if_exists='ignore')
+        ... view = pxt.create_view(
+        ...     'my_view', tbl.where(tbl.col1 > 10), if_exists='ignore'
+        ... )
 
         Create a view `my_view` of an existing table `my_table`, filtering on rows where `col1` is greater than 100,
         and replace any existing view named `my_view`:
 
         >>> tbl = pxt.get_table('my_table')
-        ... view = pxt.create_view('my_view', tbl.where(tbl.col1 > 100), if_exists='replace_force')
+        ... view = pxt.create_view(
+        ...     'my_view', tbl.where(tbl.col1 > 100), if_exists='replace_force'
+        ... )
     """
     if is_snapshot and create_default_idxs is True:
         raise excs.Error('Cannot create default indexes on a snapshot')
@@ -436,13 +452,18 @@ def create_snapshot(
 
         >>> view = pxt.get_table('my_view')
         ... snapshot = pxt.create_snapshot(
-        ...     'my_snapshot', view, additional_columns={'col3': pxt.Int}, if_exists='ignore'
+        ...     'my_snapshot',
+        ...     view,
+        ...     additional_columns={'col3': pxt.Int},
+        ...     if_exists='ignore',
         ... )
 
         Create a snapshot `my_snapshot` on a table `my_table`, and replace any existing snapshot named `my_snapshot`:
 
         >>> tbl = pxt.get_table('my_table')
-        ... snapshot = pxt.create_snapshot('my_snapshot', tbl, if_exists='replace_force')
+        ... snapshot = pxt.create_snapshot(
+        ...     'my_snapshot', tbl, if_exists='replace_force'
+        ... )
     """
     return create_view(
         path_str,
@@ -1000,7 +1021,10 @@ def tools(*args: func.Function | func.tools.Tool) -> func.tools.Tools:
 
         >>> tools = pxt.tools(
         ...     stock_price,
-        ...     pxt.tool(weather_quote, description='Returns information about the weather in a particular location.'),
+        ...     pxt.tool(
+        ...         weather_quote,
+        ...         description='Returns information about the weather in a particular location.',
+        ...     ),
         ...     pxt.tool(traffic_quote, name='traffic_conditions'),
         ... )
     """

--- a/pixeltable/io/globals.py
+++ b/pixeltable/io/globals.py
@@ -121,7 +121,7 @@ def create_label_studio_project(
         ...     tbl,
         ...     config,
         ...     media_import_method='url',
-        ...     s3_configuration={'bucket': 'my-bucket', 'region_name': 'us-east-2'}
+        ...     s3_configuration={'bucket': 'my-bucket', 'region_name': 'us-east-2'},
         ... )
     """
     Env.get().require_package('label_studio_sdk')
@@ -192,7 +192,8 @@ def export_images_as_fo_dataset(
             {
                 'label': 'giraffe',
                 'confidence': 0.99,
-                'bounding_box': [0.081, 0.836, 0.202, 0.136]  # [x, y, w, h], fractional coordinates
+                # [x, y, w, h], fractional coordinates
+                'bounding_box': [0.081, 0.836, 0.202, 0.136],
             }
             ```
 
@@ -206,9 +207,7 @@ def export_images_as_fo_dataset(
         labels from `tbl.classifications`:
 
         >>> export_images_as_fo_dataset(
-        ...     tbl,
-        ...     tbl.image,
-        ...     classifications=tbl.classifications
+        ...     tbl, tbl.image, classifications=tbl.classifications
         ... )
 
         See the [Working with Voxel51 in Pixeltable](https://docs.pixeltable.com/examples/vision/voxel51) tutorial

--- a/pixeltable/io/label_studio.py
+++ b/pixeltable/io/label_studio.py
@@ -106,7 +106,7 @@ class LabelStudioProject(Project):
         Always contains a single entry:
 
         ```
-        {"annotations": ts.JsonType(nullable=True)}
+        {'annotations': ts.JsonType(nullable=True)}
         ```
         """
         return {ANNOTATIONS_COLUMN: ts.JsonType(nullable=True)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,8 @@ known-first-party = ["pixeltable"]
 split-on-trailing-comma = false
 
 [tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 74
 line-ending = "lf"
 quote-style = "single"
 skip-magic-trailing-comma = true


### PR DESCRIPTION
`ruff` has a setting to format code snippets in docstrings. I tried it out, and the changes are mostly good ones, so I think we should just deploy it. This will ensure the code examples in our SDK docs are properly formatted to a max line length of 74, matching our other documentation outputs (notebook code cells and SDK signatures).

Going forward there will be nothing to do; the existing `make format` and `make formatcheck` commands will incorporate docstring formatting.