### PR TITLE
[PXT-1002] Fix a broken self-validation in Catalog

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -253,14 +253,12 @@ class Catalog:
                 if base.effective_version is None:
                     key = TableVersionKey(base.id, None, None)
                     base_tv = self._tbl_versions.get(key, None)
-                    if base_tv is not None and base_tv.is_validated:
-                        mutable_view_ids = ', '.join(str(tv.id) for tv in self._tbl_versions[key].mutable_views)
+                    if base_tv is not None and base_tv.is_validated and tbl_version.handle not in base_tv.mutable_views:
+                        mutable_view_ids = ', '.join(str(tv.id) for tv in base_tv.mutable_views)
                         mutable_view_names = ', '.join(
-                            tv._tbl_version.name
-                            for tv in self._tbl_versions[key].mutable_views
-                            if tv._tbl_version is not None
+                            tv._tbl_version.name for tv in base_tv.mutable_views if tv._tbl_version is not None
                         )
-                        assert tbl_version.handle in self._tbl_versions[key].mutable_views, (
+                        raise AssertionError(
                             f'{tbl_version.name} ({tbl_version.id}) missing in '
                             f'{mutable_view_ids} ({mutable_view_names})'
                         )


### PR DESCRIPTION
It is not required that the cache contains a base table for every mutable view.

Note: there's one other change of behavior here as I got rid of `continue`, so we should get to mutable views validation below more frequently.