### PR TITLE
fix model_dump() calls in udfs

### DIFF
--- a/pixeltable/functions/gemini.py
+++ b/pixeltable/functions/gemini.py
@@ -167,7 +167,7 @@ async def generate_content(
             await _poll_until_active(async_client=client.aio, uploaded=uploaded, video_paths=large_video_paths)
             contents = _replace_upload_placeholders(contents, uploaded)
         response = await client.aio.models.generate_content(model=model, contents=contents, config=config_)
-        return response.model_dump()
+        return response.model_dump(mode='json')
     finally:
         if uploaded:
             await asyncio.gather(*[client.aio.files.delete(name=f.name) for f in uploaded], return_exceptions=True)

--- a/pixeltable/functions/groq.py
+++ b/pixeltable/functions/groq.py
@@ -96,7 +96,7 @@ async def chat_completions(
         model=model,
         **model_kwargs,
     )
-    return result.model_dump()
+    return result.model_dump(mode='json')
 
 
 def invoke_tools(tools: pxt.func.Tools, response: exprs.Expr) -> exprs.InlineDict:

--- a/pixeltable/functions/openai.py
+++ b/pixeltable/functions/openai.py
@@ -763,7 +763,7 @@ async def image_generations(prompt: str, *, model: str, model_kwargs: dict[str, 
         prompt=prompt, model=model, response_format='b64_json', **model_kwargs
     )
 
-    result = result_model.model_dump()
+    result = result_model.model_dump(mode='json')
 
     # Decode images in response
     for i in range(len(result['data'])):

--- a/pixeltable/functions/openrouter.py
+++ b/pixeltable/functions/openrouter.py
@@ -133,7 +133,7 @@ async def chat_completions(
     result = await _openrouter_client().chat.completions.create(
         messages=messages, model=model, extra_body=extra_body if extra_body else None, **model_kwargs
     )
-    return result.model_dump()
+    return result.model_dump(mode='json')
 
 
 __all__ = local_public_names(__name__)


### PR DESCRIPTION
Returning the result of BaseModel.model_dump() from a (Json-valued) udf is problematic, because it might contain fields that aren't json-serializable.

This change forces a json-compatible return value.