### PR TITLE
fix: add missing _runtime_ctx to embed_content multimodal overloads

### DIFF
--- a/pixeltable/functions/gemini.py
+++ b/pixeltable/functions/gemini.py
@@ -365,7 +365,12 @@ def _(model: str) -> str:
 
 @pxt.udf(batch_size=4)
 async def embed_content(
-    contents: Batch[str], *, model: str, config: dict[str, Any] | None = None, use_batch_api: bool = False
+    contents: Batch[str],
+    *,
+    model: str,
+    config: dict[str, Any] | None = None,
+    use_batch_api: bool = False,
+    _runtime_ctx: env.RuntimeCtx | None = None,
 ) -> Batch[pxt.Array[(None,), np.float32]]:
     """
     Generate embeddings for text, images, video, and other content. For more information on Gemini embeddings API, see:
@@ -405,28 +410,44 @@ async def embed_content(
 
 @embed_content.overload
 async def _(
-    contents: Batch[PIL.Image.Image], *, model: str, config: dict[str, Any] | None = None
+    contents: Batch[PIL.Image.Image],
+    *,
+    model: str,
+    config: dict[str, Any] | None = None,
+    _runtime_ctx: env.RuntimeCtx | None = None,
 ) -> Batch[pxt.Array[(None,), np.float32]]:
     return await _embed_content(contents, model, config, use_batch_api=False)
 
 
 @embed_content.overload
 async def _(
-    contents: Batch[pxt.Audio], *, model: str, config: dict[str, Any] | None = None
+    contents: Batch[pxt.Audio],
+    *,
+    model: str,
+    config: dict[str, Any] | None = None,
+    _runtime_ctx: env.RuntimeCtx | None = None,
 ) -> Batch[pxt.Array[(None,), np.float32]]:
     return await _embed_file_content(contents, model, config, use_batch_api=False)
 
 
 @embed_content.overload
 async def _(
-    contents: Batch[pxt.Video], *, model: str, config: dict[str, Any] | None = None
+    contents: Batch[pxt.Video],
+    *,
+    model: str,
+    config: dict[str, Any] | None = None,
+    _runtime_ctx: env.RuntimeCtx | None = None,
 ) -> Batch[pxt.Array[(None,), np.float32]]:
     return await _embed_file_content(contents, model, config, use_batch_api=False)
 
 
 @embed_content.overload
 async def _(
-    contents: Batch[pxt.Document], *, model: str, config: dict[str, Any] | None = None
+    contents: Batch[pxt.Document],
+    *,
+    model: str,
+    config: dict[str, Any] | None = None,
+    _runtime_ctx: env.RuntimeCtx | None = None,
 ) -> Batch[pxt.Array[(None,), np.float32]]:
     return await _embed_file_content(contents, model, config, use_batch_api=False)
 


### PR DESCRIPTION
**Stack trace:**
```
pixeltable.exceptions.Error: Exception in task:
  File "pixeltable/exec/expr_eval/schedulers.py", line 88, in _main_loop
    assert '_runtime_ctx' in item.request.fn_call.fn.signature.system_parameters
AssertionError
```
**How we identified the fix:** Compared `embed_content` signatures against `openai.embeddings` (which also uses `RateLimitsScheduler` via `rate-limits:openai:<model>` and declares `_runtime_ctx`) and confirmed that `twelvelabs.embed` / `voyageai.multimodal_embed` don't need it because they use `request-rate:` pools routed through `RequestRateScheduler`, which has no such assertion.