### PR TITLE
Suppress pytest-benchmark/xdist warning in test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ WORKERS := 12
 
 # Common test args
 PYTEST_COMMON_ARGS := -v -n auto --dist loadgroup --maxprocesses 6 --reruns 2 \
-	--only-rerun 'That Pixeltable operation could not be completed because it conflicted with'
+	--only-rerun 'That Pixeltable operation could not be completed because it conflicted with' \
+	--benchmark-disable
 
 # Needed for LLaMA build to work correctly on some Linux systems
 CMAKE_ARGS := -DLLAVA_BUILD=OFF


### PR DESCRIPTION
Gets rid of:

```
PytestBenchmarkWarning: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.
```

in `make test`, `make slimtest`, etc.

This is a no op because benchmarks are already excluded via addopts anyway.