### PR TITLE
[PXT-1002] Catalog refactoring in begin_xact

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -354,11 +354,11 @@ class Catalog:
                             raise
                         except sql_exc.DBAPIError as e:
                             # Handle retriable errors
+                            has_exc = True
                             if isinstance(
                                 e.orig, (psycopg.errors.SerializationFailure, psycopg.errors.LockNotAvailable)
                             ) and (num_retries < _MAX_RETRIES or _MAX_RETRIES == -1):
                                 _logger.debug(f'Retriable error {type(e.orig)} on attempt {num_retries}')
-                                has_exc = True
                                 num_retries += 1
                                 time.sleep(random.uniform(0.1, 0.5))
                                 conn.rollback()  # attempt failed -- don't try to commit the transaction before retrying


### PR DESCRIPTION
1. extract a part of `begin_xact()` logic into a separate function
2. `_acquire_path_locks` and `_acquire_tbl_lock` return the locked table UUIDs, so no additional traversal is necessary later to collect locked table ids.