### PR TITLE
Fix convert_41.py

### DIFF
--- a/pixeltable/metadata/converters/convert_41.py
+++ b/pixeltable/metadata/converters/convert_41.py
@@ -6,7 +6,11 @@ from pixeltable.metadata import register_converter
 @register_converter(version=41)
 def _(engine: sql.engine.Engine) -> None:
     with engine.begin() as conn:
-        conn.execute(sql.text("ALTER TABLE dirs ADD COLUMN additional_md JSONB DEFAULT '{}'::JSONB"))
-        conn.execute(sql.text("ALTER TABLE tables ADD COLUMN additional_md JSONB DEFAULT '{}'::JSONB"))
-        conn.execute(sql.text("ALTER TABLE tableversions ADD COLUMN additional_md JSONB DEFAULT '{}'::JSONB"))
-        conn.execute(sql.text("ALTER TABLE tableschemaversions ADD COLUMN additional_md JSONB DEFAULT '{}'::JSONB"))
+        conn.execute(sql.text("ALTER TABLE dirs ADD COLUMN IF NOT EXISTS additional_md JSONB DEFAULT '{}'::JSONB"))
+        conn.execute(sql.text("ALTER TABLE tables ADD COLUMN IF NOT EXISTS additional_md JSONB DEFAULT '{}'::JSONB"))
+        conn.execute(
+            sql.text("ALTER TABLE tableversions ADD COLUMN IF NOT EXISTS additional_md JSONB DEFAULT '{}'::JSONB")
+        )
+        conn.execute(
+            sql.text("ALTER TABLE tableschemaversions ADD COLUMN IF NOT EXISTS additional_md JSONB DEFAULT '{}'::JSONB")
+        )


### PR DESCRIPTION
I don't know what exactly happened there, but there's no way this conversion is 100% reliable (edited)  

[9:42 AM]because we perform the conversion in one transaction, but advance the catalog version in another, it's possible that the process will crash between the two, and the alter table will be retried unnecessarily next time (edited)  

[9:42 AM]so it needs to be add column if not exists 