### PR TITLE
get rid of the corrupts_db marker -- we've fixed all issues, and it's…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,6 @@ pytest -m "remote_api" tests/functions/test_openai.py
 **Test markers:**
 - `@pytest.mark.expensive` - Long-running tests
 - `@pytest.mark.remote_api` - Tests calling external APIs
-- `@pytest.mark.corrupts_db` - Tests that modify database state destructively
 
 ### Creating a Pull Request
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,6 @@ pytest -m "remote_api" tests/functions/test_openai.py
 **Test markers:**
 - `@pytest.mark.expensive` - Long-running tests
 - `@pytest.mark.remote_api` - Tests calling external APIs
-- `@pytest.mark.corrupts_db` - Tests that modify database state destructively
 
 ### Required After Every Code Change
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,7 +260,6 @@ addopts = '-v -m "not remote_api and not expensive and not benchmark" --strict-m
 markers = [
     "expensive: marks tests as expensive to run",
     "remote_api: marks tests as calling a remote API (such as OpenAI)",
-    "corrupts_db: marks tests as corrupting the database and disables the database validation after the test",
     "benchmark: marks tests as benchmark tests (excluded from regular test runs)",
     "cockroachdb: tests to run against CockroachDB",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,10 +174,6 @@ def uses_db(init_env: None, request: pytest.FixtureRequest) -> Iterator[None]:
 
     yield
 
-    if 'corrupts_db' in request.keywords:
-        _logger.info('Skipping DB validation due to corrupts_db marker.')
-        return
-
     Env.get().user = None
     get_runtime().catalog.validate_store()
 


### PR DESCRIPTION
… no longer needed