### PR TITLE
Drain pending async tasks after coroutine completion

### DIFF
--- a/pixeltable/runtime.py
+++ b/pixeltable/runtime.py
@@ -115,8 +115,10 @@ class Runtime:
             # this runs in the _run_coro_executor's thread, with its own Runtime instance
             loop = get_runtime().event_loop
             res = loop.run_until_complete(coro)
-            pending = asyncio.all_tasks(loop)
-            if pending:
+            while True:
+                pending = asyncio.all_tasks(loop)
+                if not pending:
+                    break
                 loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             return res
 

--- a/pixeltable/runtime.py
+++ b/pixeltable/runtime.py
@@ -113,9 +113,21 @@ class Runtime:
 
         def run(coro: Coroutine[Any, Any, _T]) -> _T:
             # this runs in the _run_coro_executor's thread, with its own Runtime instance
-            return get_runtime().event_loop.run_until_complete(coro)
+            loop = get_runtime().event_loop
+            res = loop.run_until_complete(coro)
+            # get_runtime().event_loop.run_until_complete(self._drain_event_loop())
+            pending = asyncio.all_tasks(loop)
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            return res
 
         return self._run_coro_executor.submit(run, coro).result()
+
+    async def _drain_event_loop(self) -> None:
+        """Run the event loop until all currently scheduled tasks are complete. Useful for testing."""
+        tasks = [t for t in asyncio.all_tasks(loop=self._event_loop) if t is not asyncio.current_task()]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     @contextmanager
     def begin_xact(self, *, for_write: bool = False) -> Iterator[sql.Connection]:

--- a/pixeltable/runtime.py
+++ b/pixeltable/runtime.py
@@ -115,19 +115,12 @@ class Runtime:
             # this runs in the _run_coro_executor's thread, with its own Runtime instance
             loop = get_runtime().event_loop
             res = loop.run_until_complete(coro)
-            # get_runtime().event_loop.run_until_complete(self._drain_event_loop())
             pending = asyncio.all_tasks(loop)
             if pending:
                 loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             return res
 
         return self._run_coro_executor.submit(run, coro).result()
-
-    async def _drain_event_loop(self) -> None:
-        """Run the event loop until all currently scheduled tasks are complete. Useful for testing."""
-        tasks = [t for t in asyncio.all_tasks(loop=self._event_loop) if t is not asyncio.current_task()]
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
 
     @contextmanager
     def begin_xact(self, *, for_write: bool = False) -> Iterator[sql.Connection]:


### PR DESCRIPTION
After `run_until_complete(coro)` returns, any tasks spawned by the coroutine that weren't explicitly awaited remain scheduled but unrun. This change drains those pending tasks before returning the result.