### PR TITLE
Quality: Module resolution can mask real import errors

### DIFF
--- a/pixeltable/func/globals.py
+++ b/pixeltable/func/globals.py
@@ -10,9 +10,12 @@ def resolve_symbol(symbol_path: str) -> object | None:
     module: ModuleType | None = None
     i = len(path_elems) - 1
     while i > 0 and module is None:
+        module_path = '.'.join(path_elems[:i])
         try:
-            module = importlib.import_module('.'.join(path_elems[:i]))
-        except ModuleNotFoundError:
+            module = importlib.import_module(module_path)
+        except ModuleNotFoundError as e:
+            if e.name != module_path and not module_path.startswith(f'{e.name}.'):
+                raise
             i -= 1
     if i == 0:
         return None  # Not resolvable


### PR DESCRIPTION
## Summary

Quality: Module resolution can mask real import errors

## Problem

**Severity**: `Medium` | **File**: `pixeltable/func/globals.py:L11`

`resolve_symbol()` catches `ModuleNotFoundError` while probing module prefixes. This can accidentally swallow errors raised from within a module import (eg missing dependency inside the module), causing misleading "not resolvable" behavior.

## Solution

Only suppress `ModuleNotFoundError` when the missing module matches the probed prefix. If the exception references a different module, re-raise it so genuine dependency/import problems are surfaced.

## Changes

- `pixeltable/func/globals.py` (modified)