### PR TITLE
Hide progress tracker by default

### DIFF
--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -167,6 +167,7 @@ KNOWN_CONFIG_OPTIONS = {
         'time_zone': 'Default time zone for timestamps',
         'hide_warnings': 'Hide warnings from the console',
         'verbosity': 'Verbosity level for console output',
+        'show_progress': 'Show a progress tracker for long-running operations (default: false)',
         'api_key': 'API key for Pixeltable cloud',
         'input_media_dest': 'Default destination URI for input media data',
         'output_media_dest': 'Default destination URI for output (computed) media data',

--- a/pixeltable/exec/exec_context.py
+++ b/pixeltable/exec/exec_context.py
@@ -44,7 +44,9 @@ class ExecContext:
             self.show_progress = show_progress
         else:
             self.show_progress = (
-                Config.get().get_bool_value('show_progress') and Env.get().verbosity >= 1 and Env.get().is_interactive()
+                bool(Config.get().get_bool_value('show_progress'))
+                and Env.get().verbosity >= 1
+                and Env.get().is_interactive()
             )
 
         # disable progress reporting in Jupyter if ipywidgets is not installed

--- a/pixeltable/exec/exec_context.py
+++ b/pixeltable/exec/exec_context.py
@@ -6,6 +6,7 @@ import sqlalchemy as sql
 from rich.progress import Column, Progress, TextColumn
 
 from pixeltable import exprs
+from pixeltable.config import Config
 from pixeltable.env import Env
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.progress_reporter import ProgressReporter
@@ -42,7 +43,9 @@ class ExecContext:
         if show_progress is not None:
             self.show_progress = show_progress
         else:
-            self.show_progress = Env.get().verbosity >= 1 and Env.get().is_interactive()
+            self.show_progress = (
+                Config.get().get_bool_value('show_progress') and Env.get().verbosity >= 1 and Env.get().is_interactive()
+            )
 
         # disable progress reporting in Jupyter if ipywidgets is not installed
         if Env.get().is_notebook() and importlib.util.find_spec('ipywidgets') is None:


### PR DESCRIPTION
The progress tracker can be displayed by setting `PIXELTABLE_SHOW_PROGRESS=true`.