### PR TITLE
Delete the invalidating table version log statement

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -397,7 +397,6 @@ class Catalog:
                 # invalidate cached current TableVersion instances
                 for tv in self._tbl_versions.values():
                     if tv.effective_version is None:
-                        _logger.debug(f'invalidating table version {tv} (0x{id(tv):x})')
                         tv.is_validated = False
 
                 if has_exc:


### PR DESCRIPTION
Its utility is not clear, and it's way too chatty. When random-ops runs, most of logged events are this one line.