### PR TITLE
[PXT-1002] Retry loop in another location where pending table ops err…

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1395,8 +1395,11 @@ class Catalog:
 
         self._roll_forward()
 
-        with self.begin_xact(for_write=True, write_tbl_ids=[view_id]):
+        @retry_loop(read_tbl_ids=[view_id])
+        def _get_tbl() -> Table:
             return self.get_table_by_id(view_id)
+
+        return _get_tbl()
 
     def add_columns(self, tbl: TableVersionPath, cols: list[Column]) -> None:
         @retry_loop(for_write=True, write_tvps=[tbl], lock_mutable_tree=False)


### PR DESCRIPTION
…or is possible

Wraps `get_table_by_id` in `create_view` in a `@retry_loop`. Also makes it a read-only transaction -- I don't know why would it need to be read-write.

As seen in random ops error (on a branch, so the line numbers may be off):

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 437, in run
    RandomTableOps(worker_id, read_only, include_only_ops or [], exclude_ops or [], config).run()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 408, in run
    self.random_op()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 402, in random_op
    self.run_op(op)
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 395, in run_op
    raise fatal
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 374, in run_op
    for res in op():
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 333, in create_view
    pxt.create_view(vname, t.where(t.bc_int % p == 0), if_exists='replace_force')
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/globals.py", line 397, in create_view
    return get_runtime().catalog.create_view(
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/catalog/catalog.py", line 1442, in create_view
    return self.get_table_by_id(view_id)
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/catalog/catalog.py", line 1314, in get_table_by_id
    return self._load_tbl(tbl_id, ignore_pending_drop=ignore_if_dropped)
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/catalog/catalog.py", line 2184, in _load_tbl
    _ = self._load_tbl_version(key)
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/catalog/catalog.py", line 2677, in _load_tbl_version
    raise PendingTableOpsError(key.tbl_id)
pixeltable.catalog.catalog.PendingTableOpsError: 27a882e6-453d-4591-b1f7-48a34888fe0e
```