### PR TITLE
export_sql parameter for FastAPIRouter insert/update routes

### DIFF
--- a/docs/public_api.opml
+++ b/docs/public_api.opml
@@ -475,6 +475,7 @@
             <outline text="method|pixeltable.serving.FastAPIRouter.add_delete_route" />
             <outline text="method|pixeltable.serving.FastAPIRouter.add_query_route" />
           </outline>
+          <outline text="class|pixeltable.serving.SqlExport" />
         </outline>
       </outline>
 

--- a/docs/release/howto/deployment/serving.mdx
+++ b/docs/release/howto/deployment/serving.mdx
@@ -142,10 +142,13 @@ service file.
 ## Exporting rows to an external database
 
 Insert and update routes can export each successful request as a row in an
-external SQL database. Pass an `export_sql=SqlExport(...)` argument to
-`add_insert_route`, `add_update_route`, or the decorator forms. Each request
-performs the Pixeltable insert/update first; only if it succeeds does the row
-get written to the external table.
+external SQL database. Configure it via the Python API, the TOML service file,
+or the CLI; all three forms route through the same `SqlExport` specification.
+Each request performs the Pixeltable insert/update first; only if it succeeds
+does the row get written to the external table.
+
+**Python API.** Pass an `export_sql=SqlExport(...)` argument to
+`add_insert_route`, `add_update_route`, or the decorator forms.
 
 ```python
 from pixeltable.serving import FastAPIRouter, SqlExport
@@ -161,6 +164,34 @@ router.add_insert_route(
         target_table='generations',
     ),
 )
+```
+
+**TOML.** Add a nested `[routes.export_sql]` table under any insert or update
+route. The same fields apply.
+
+```toml
+[[routes]]
+type = "insert"
+table = "my_dir.my_table"
+path = "/generate"
+inputs = ["prompt"]
+outputs = ["prompt", "result"]
+
+[routes.export_sql]
+db_connect = "postgresql+psycopg://user:pw@host/analytics"
+target_table = "generations"
+# target_schema = "public"  # optional
+# method = "insert"         # default; alternatives: "update", "merge" (not yet supported)
+```
+
+**CLI.** Single-endpoint mode supports the same fields via `--export-sql-*`
+flags on `pxt serve insert` and `pxt serve update`.
+
+```bash
+pxt serve insert --table my_dir.my_table --path /generate \
+  --inputs prompt --outputs prompt result \
+  --export-sql-db-connect 'postgresql+psycopg://user:pw@host/analytics' \
+  --export-sql-target-table generations
 ```
 
 The row written to the target is the response body: the same columns as
@@ -196,10 +227,13 @@ compatible with `background=True` (the SQL write runs in the worker thread).
 See [`SqlExport`](https://docs.pixeltable.com/sdk/latest/pixeltable/serving/SqlExport)
 for the full target specification.
 
-<Note>
-The `export_sql=` parameter is Python-API only; there is currently no
-equivalent in the TOML service file.
-</Note>
+<Warning>
+Connection strings with embedded passwords land in plaintext on disk (TOML)
+or in process listings (CLI). Don't commit `service.toml`; consider a
+connection string that pulls credentials from the environment or a
+`.pgpass`-style file. Env-var substitution within the TOML is not yet
+supported.
+</Warning>
 
 ## TOML Service File Reference
 
@@ -269,6 +303,7 @@ outputs = ["prompt", "result"]
 | `uploadfile_inputs` | list of strings | no | -- | Columns to accept as file uploads (multipart) |
 | `outputs` | list of strings | no | all columns | Columns to include in the response |
 | `return_fileresponse` | bool | no | `false` | Return the single media-typed output as a raw file download |
+| `export_sql` | nested table | no | -- | Export each request as a row into an external SQL database. See [Exporting rows to an external database](#exporting-rows-to-an-external-database). |
 
 **File uploads:** when `uploadfile_inputs` is set, the request uses `multipart/form-data`
 instead of JSON. All other inputs become form fields.
@@ -312,6 +347,7 @@ outputs = ["id", "prompt", "result"]
 | `inputs` | list of strings | no | all non-PK, non-computed, non-media columns | Columns to update (PK columns are always in the request body but cannot appear here) |
 | `outputs` | list of strings | no | all columns | Columns to include in the response |
 | `return_fileresponse` | bool | no | `false` | Return the single media-typed output as a raw file download |
+| `export_sql` | nested table | no | -- | Export each request as a row into an external SQL database. See [Exporting rows to an external database](#exporting-rows-to-an-external-database). |
 
 The request body carries the primary key values (to identify the row) plus the
 values to update, as JSON fields:

--- a/docs/release/howto/deployment/serving.mdx
+++ b/docs/release/howto/deployment/serving.mdx
@@ -161,7 +161,7 @@ router.add_insert_route(
     outputs=['prompt', 'result'],
     export_sql=SqlExport(
         db_connect='postgresql+psycopg://user:pw@host/analytics',
-        target_table='generations',
+        table='generations',
     ),
 )
 ```
@@ -179,8 +179,8 @@ outputs = ["prompt", "result"]
 
 [routes.export_sql]
 db_connect = "postgresql+psycopg://user:pw@host/analytics"
-target_table = "generations"
-# target_schema = "public"  # optional
+table = "generations"
+# db_schema = "public"  # optional
 # method = "insert"         # default; alternatives: "update", "merge" (not yet supported)
 ```
 
@@ -191,7 +191,7 @@ flags on `pxt serve insert` and `pxt serve update`.
 pxt serve insert --table my_dir.my_table --path /generate \
   --inputs prompt --outputs prompt result \
   --export-sql-db-connect 'postgresql+psycopg://user:pw@host/analytics' \
-  --export-sql-target-table generations
+  --export-sql-table generations
 ```
 
 The row written to the target is the response body: the same columns as

--- a/docs/release/howto/deployment/serving.mdx
+++ b/docs/release/howto/deployment/serving.mdx
@@ -139,6 +139,68 @@ background-job result.
 The decorator forms are Python-only -- there is no equivalent in the TOML
 service file.
 
+## Exporting rows to an external database
+
+Insert and update routes can export each successful request as a row in an
+external SQL database. Pass an `export_sql=SqlExport(...)` argument to
+`add_insert_route`, `add_update_route`, or the decorator forms. Each request
+performs the Pixeltable insert/update first; only if it succeeds does the row
+get written to the external table.
+
+```python
+from pixeltable.serving import FastAPIRouter, SqlExport
+
+router = FastAPIRouter()
+router.add_insert_route(
+    t,
+    path='/generate',
+    inputs=['prompt'],
+    outputs=['prompt', 'result'],
+    export_sql=SqlExport(
+        db_connect='postgresql+psycopg://user:pw@host/analytics',
+        target_table='generations',
+    ),
+)
+```
+
+The row written to the target is the response body: the same columns as
+`outputs`, with media-typed columns rendered as URL strings (so the
+corresponding target columns must be string-typed). Schema compatibility is
+validated once at registration; the target table must already exist or
+registration fails. The engine and connection pool are cached per
+`db_connect`, so multiple routes pointing at the same database share one pool.
+
+`SqlExport.method` controls how each row is written:
+
+- `'insert'` (default): append the row via `INSERT ... VALUES`. The target
+  acts as an audit log -- replaying the same request produces a duplicate.
+- `'update'`: update the row by primary-key match. The target is treated as a
+  current-state view keyed on its primary key. The response columns must
+  include all primary-key columns of the target plus at least one non-PK
+  column to set; the target table itself must declare a primary key. This is a
+  strict update, not an upsert -- if no row matches, the request fails with
+  HTTP 500.
+- `'merge'` (upsert): not yet supported.
+
+When paired with `add_insert_route` and `method='update'`, a Pixeltable insert
+triggers a target-side update. This is intentional: it supports the pattern
+where the Pixeltable table is append-only (e.g. an event log) but the target
+is a deduplicated, current-state view.
+
+If the external write fails after the Pixeltable insert/update has already
+committed, the request returns HTTP 500; no rollback is performed.
+
+`export_sql=` is mutually exclusive with `return_fileresponse=True` and is
+compatible with `background=True` (the SQL write runs in the worker thread).
+
+See [`SqlExport`](https://docs.pixeltable.com/sdk/latest/pixeltable/serving/SqlExport)
+for the full target specification.
+
+<Note>
+The `export_sql=` parameter is Python-API only; there is currently no
+equivalent in the TOML service file.
+</Note>
+
 ## TOML Service File Reference
 
 ### `[service]` (optional)

--- a/pixeltable/cli.py
+++ b/pixeltable/cli.py
@@ -15,6 +15,7 @@ from pixeltable import exceptions as excs
 
 if TYPE_CHECKING:
     from pixeltable.serving._config import AppConfig, RouteConfig
+    from pixeltable.serving.globals import SqlExport
 
 
 class _Parser(argparse.ArgumentParser):
@@ -102,6 +103,34 @@ def _add_output_args(p: argparse.ArgumentParser) -> None:
     p.add_argument('--json', action='store_true', dest='json', help='Emit machine-readable JSON output')
 
 
+def _add_export_sql_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        '--export-sql-db-connect',
+        dest='export_sql_db_connect',
+        default=None,
+        help='SQLAlchemy connection string for an external SQL target (enables export_sql)',
+    )
+    p.add_argument(
+        '--export-sql-target-table',
+        dest='export_sql_target_table',
+        default=None,
+        help='Target table name (required when --export-sql-db-connect is set)',
+    )
+    p.add_argument(
+        '--export-sql-target-schema',
+        dest='export_sql_target_schema',
+        default=None,
+        help='Optional database schema qualifier for the target table',
+    )
+    p.add_argument(
+        '--export-sql-method',
+        dest='export_sql_method',
+        choices=('insert', 'update', 'merge'),
+        default='insert',
+        help="How to write each row into the target table (default: 'insert')",
+    )
+
+
 def _add_serve_subparsers(serve_parser: argparse.ArgumentParser) -> None:
     serve_sub = serve_parser.add_subparsers(dest='mode', required=True)
 
@@ -141,6 +170,7 @@ def _add_serve_subparsers(serve_parser: argparse.ArgumentParser) -> None:
         help='Stream the output as a file response',
     )
     insert_parser.add_argument('--background', action='store_true', help='Run the insert in the background')
+    _add_export_sql_args(insert_parser)
     _add_service_args(insert_parser)
     _add_output_args(insert_parser)
 
@@ -167,6 +197,7 @@ def _add_serve_subparsers(serve_parser: argparse.ArgumentParser) -> None:
         help='Stream the output as a file response',
     )
     update_parser.add_argument('--background', action='store_true', help='Run the update in the background')
+    _add_export_sql_args(update_parser)
     _add_service_args(update_parser)
     _add_output_args(update_parser)
 
@@ -229,7 +260,7 @@ def _serve(args: argparse.Namespace) -> None:
         config = load_app_config(args.config)
     else:
         try:
-            route = _build_route_from_args(args)
+            route = _create_route_from_args(args)
             config = AppConfig(service=ServiceConfig(), routes=[route])
         except pydantic.ValidationError as e:
             raise excs.RequestError(excs.ErrorCode.INVALID_ARGUMENT, str(e)) from e
@@ -269,7 +300,29 @@ def _print_dry_run(config: 'AppConfig', json_output: bool) -> None:
             print(f'  [{d["type"]}] {d["path"]}')
 
 
-def _build_route_from_args(args: argparse.Namespace) -> 'RouteConfig':
+def _create_sql_export(args: argparse.Namespace) -> 'SqlExport | None':
+    from pixeltable.serving.globals import SqlExport
+
+    db_connect = args.export_sql_db_connect
+    target_table = args.export_sql_target_table
+    target_schema = args.export_sql_target_schema
+    if db_connect is None:
+        if target_table is not None or target_schema is not None:
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_ARGUMENT,
+                '--export-sql-target-table / --export-sql-target-schema requires --export-sql-db-connect',
+            )
+        return None
+    if target_table is None:
+        raise excs.RequestError(
+            excs.ErrorCode.INVALID_ARGUMENT, '--export-sql-db-connect requires --export-sql-target-table'
+        )
+    return SqlExport(
+        db_connect=db_connect, target_table=target_table, target_schema=target_schema, method=args.export_sql_method
+    )
+
+
+def _create_route_from_args(args: argparse.Namespace) -> 'RouteConfig':
     from pixeltable.serving._config import DeleteRouteConfig, InsertRouteConfig, QueryRouteConfig, UpdateRouteConfig
 
     if args.mode == 'insert':
@@ -281,6 +334,7 @@ def _build_route_from_args(args: argparse.Namespace) -> 'RouteConfig':
             uploadfile_inputs=args.uploadfile_inputs,
             outputs=args.outputs,
             return_fileresponse=args.return_fileresponse,
+            export_sql=_create_sql_export(args),
             background=args.background,
         )
     if args.mode == 'update':
@@ -291,6 +345,7 @@ def _build_route_from_args(args: argparse.Namespace) -> 'RouteConfig':
             inputs=args.inputs,
             outputs=args.outputs,
             return_fileresponse=args.return_fileresponse,
+            export_sql=_create_sql_export(args),
             background=args.background,
         )
     if args.mode == 'delete':

--- a/pixeltable/cli.py
+++ b/pixeltable/cli.py
@@ -14,8 +14,8 @@ import pixeltable as pxt
 from pixeltable import exceptions as excs
 
 if TYPE_CHECKING:
+    from pixeltable.serving import SqlExport
     from pixeltable.serving._config import AppConfig, RouteConfig
-    from pixeltable.serving.globals import SqlExport
 
 
 class _Parser(argparse.ArgumentParser):
@@ -111,14 +111,14 @@ def _add_export_sql_args(p: argparse.ArgumentParser) -> None:
         help='SQLAlchemy connection string for an external SQL target (enables export_sql)',
     )
     p.add_argument(
-        '--export-sql-target-table',
-        dest='export_sql_target_table',
+        '--export-sql-table',
+        dest='export_sql_table',
         default=None,
         help='Target table name (required when --export-sql-db-connect is set)',
     )
     p.add_argument(
-        '--export-sql-target-schema',
-        dest='export_sql_target_schema',
+        '--export-sql-db-schema',
+        dest='export_sql_db_schema',
         default=None,
         help='Optional database schema qualifier for the target table',
     )
@@ -304,22 +304,18 @@ def _create_sql_export(args: argparse.Namespace) -> 'SqlExport | None':
     from pixeltable.serving.globals import SqlExport
 
     db_connect = args.export_sql_db_connect
-    target_table = args.export_sql_target_table
-    target_schema = args.export_sql_target_schema
+    table = args.export_sql_table
+    db_schema = args.export_sql_db_schema
     if db_connect is None:
-        if target_table is not None or target_schema is not None:
+        if table is not None or db_schema is not None:
             raise excs.RequestError(
                 excs.ErrorCode.INVALID_ARGUMENT,
-                '--export-sql-target-table / --export-sql-target-schema requires --export-sql-db-connect',
+                '--export-sql-table / --export-sql-db-schema requires --export-sql-db-connect',
             )
         return None
-    if target_table is None:
-        raise excs.RequestError(
-            excs.ErrorCode.INVALID_ARGUMENT, '--export-sql-db-connect requires --export-sql-target-table'
-        )
-    return SqlExport(
-        db_connect=db_connect, target_table=target_table, target_schema=target_schema, method=args.export_sql_method
-    )
+    if table is None:
+        raise excs.RequestError(excs.ErrorCode.INVALID_ARGUMENT, '--export-sql-db-connect requires --export-sql-table')
+    return SqlExport(db_connect=db_connect, table=table, db_schema=db_schema, method=args.export_sql_method)
 
 
 def _create_route_from_args(args: argparse.Namespace) -> 'RouteConfig':

--- a/pixeltable/io/sql.py
+++ b/pixeltable/io/sql.py
@@ -53,7 +53,7 @@ def export_sql(
         source_schema=query.schema,
         if_exists=if_exists,
         if_not_exists=if_not_exists,
-        error_prefix='',
+        error_prefix='export_sql()',
     )
 
     batch_size = 16 * 1024

--- a/pixeltable/io/sql.py
+++ b/pixeltable/io/sql.py
@@ -1,76 +1,10 @@
-"""
-To add support for a new target database:
-- check if the generic type mapping of _get_sa_type() needs to be overridden
-- if so, add a new function _get_{dialect}_type()
-- add an entry to GET_DIALECT_TYPE
-"""
-
-import datetime
-import uuid
-from typing import Any, Callable, Literal
+from typing import Literal
 
 import sqlalchemy as sql
 
 import pixeltable as pxt
 import pixeltable.exceptions as excs
-import pixeltable.type_system as ts
-from pixeltable.env import Env
-
-
-def _sa_type(col_type: ts.ColumnType) -> sql.types.TypeEngine:
-    """
-    Default mapping of ColumnType to SQLAlchemy type.
-
-    This matches the following dialects:
-    - sqlite
-    - mysql
-    """
-    if col_type.is_int_type():
-        return sql.Integer()
-    elif col_type.is_string_type():
-        return sql.String()
-    elif col_type.is_float_type():
-        return sql.Float()
-    elif col_type.is_bool_type():
-        return sql.Boolean()
-    elif col_type.is_timestamp_type():
-        return sql.TIMESTAMP()
-    elif col_type.is_date_type():
-        return sql.Date()
-    elif col_type.is_uuid_type():
-        return sql.UUID()
-    elif col_type.is_binary_type():
-        return sql.LargeBinary()
-    elif col_type.is_json_type():
-        return sql.JSON()
-    raise pxt.RequestError(pxt.ErrorCode.UNSUPPORTED_OPERATION, f'Cannot export column of type {col_type}')
-
-
-def _postgresql_type(col_type: ts.ColumnType) -> sql.types.TypeEngine:
-    """Type mapping for dialect 'postgresql'"""
-    if col_type.is_json_type():
-        return sql.dialects.postgresql.JSONB()
-    return _sa_type(col_type)
-
-
-def _snowflake_type(col_type: ts.ColumnType) -> sql.types.TypeEngine:
-    """Type mapping for dialect 'snowflake'"""
-    if col_type.is_json_type():
-        Env.get().require_package(
-            'snowflake.sqlalchemy',
-            not_installed_msg='Exporting json data to Snowflake requires the snowflake-sqlalchemy package',
-        )
-        from snowflake.sqlalchemy import VARIANT  # type: ignore[import-untyped]
-
-        return VARIANT()
-    else:
-        return _sa_type(col_type)
-
-
-DIALECT_TYPE: dict[str, Callable[[ts.ColumnType], sql.types.TypeEngine]] = {
-    'postgresql': _postgresql_type,
-    'snowflake': _snowflake_type,
-}
+from pixeltable.utils import sql as sql_utils
 
 
 def export_sql(
@@ -80,6 +14,7 @@ def export_sql(
     db_connect_str: str | None,
     target_schema_name: str | None = None,
     if_exists: Literal['error', 'replace', 'insert'] = 'error',
+    if_not_exists: Literal['error', 'create'] = 'create',
 ) -> None:
     """
     Exports a query result or table to an RDBMS table.
@@ -94,6 +29,10 @@ def export_sql(
             - 'error': raise an error
             - 'replace': drop the existing table and create a new one
             - 'insert': insert new rows into the existing table
+        if_not_exists : What to do if the target table does not exist.
+
+            - 'error': raise an error
+            - 'create': create the table from the source schema
     """
     # TODO:
     # - overrides for output schema
@@ -107,31 +46,15 @@ def export_sql(
         query = table_or_query
 
     engine = sql.create_engine(db_connect_str)
-
-    metadata = sql.MetaData()
-    target: sql.Table | None = None
-    if _table_exists(engine, target_table_name, target_schema_name):
-        if if_exists == 'error':
-            raise pxt.AlreadyExistsError(
-                pxt.ErrorCode.PATH_ALREADY_EXISTS, f'Table {target_table_name!r} already exists in:\n{db_connect_str}'
-            )
-        target = sql.Table(target_table_name, metadata, schema=target_schema_name, autoload_with=engine)
-        if if_exists == 'replace':
-            # drop existing table first
-            target.drop(engine)
-            target = None
-        else:
-            _check_schema_compatible(target, query.schema, engine)
-
-    if target is None:
-        # create table
-        dialect = engine.dialect.name
-        get_type = DIALECT_TYPE.get(dialect, _sa_type)
-        target_schema = {col_name: get_type(col_type) for col_name, col_type in query.schema.items()}
-        columns = [sql.Column(col_name, col_type) for col_name, col_type in target_schema.items()]
-        metadata = sql.MetaData()
-        target = sql.Table(target_table_name, metadata, *columns, schema=target_schema_name)
-        target.create(engine, checkfirst=True)
+    target = sql_utils.resolve_table(
+        engine=engine,
+        table_name=target_table_name,
+        schema_name=target_schema_name,
+        source_schema=query.schema,
+        if_exists=if_exists,
+        if_not_exists=if_not_exists,
+        error_prefix='',
+    )
 
     batch_size = 16 * 1024
     try:
@@ -151,45 +74,3 @@ def export_sql(
 
     except excs.ExprEvalError as e:
         query._raise_expr_eval_err(e)
-
-
-def _table_exists(engine: sql.Engine, table_name: str, schema_name: str | None = None) -> bool:
-    """Check if a table exists in the database."""
-    inspector = sql.inspect(engine)
-    return table_name in inspector.get_table_names(schema=schema_name)
-
-
-_SAMPLE_LITERALS: dict[ts.ColumnType.Type, Any] = {
-    ts.ColumnType.Type.STRING: 'test',
-    ts.ColumnType.Type.INT: 1,
-    ts.ColumnType.Type.FLOAT: 1.0,
-    ts.ColumnType.Type.BOOL: True,
-    # don't reference Env.default_time_zone here, Env may not be initialized yet
-    ts.ColumnType.Type.TIMESTAMP: datetime.datetime.now(tz=datetime.timezone.utc),
-    ts.ColumnType.Type.DATE: datetime.date.today(),
-    ts.ColumnType.Type.UUID: uuid.uuid4(),
-    ts.ColumnType.Type.BINARY: b'test',
-    ts.ColumnType.Type.JSON: {'a': 1, 'b': [2, 3], 'c': {'d': 4}},
-}
-
-
-def _check_schema_compatible(tbl: sql.Table, source_schema: dict[str, ts.ColumnType], engine: sql.Engine) -> None:
-    for col_name, source_type in source_schema.items():
-        if col_name not in tbl.c:
-            raise pxt.NotFoundError(pxt.ErrorCode.COLUMN_NOT_FOUND, f'Column {col_name!r} not in table {tbl.name!r}')
-
-        target_type = tbl.c[col_name].type
-        # CAST(<literal> AS target_type)
-        cast_expr = sql.cast(_SAMPLE_LITERALS[source_type._type], target_type).label(col_name)
-        # 1 = 0: we only want to check whether the casts are legal, not run anything
-        query = sql.select(cast_expr).where(sql.literal(1) == sql.literal(0))
-
-        with engine.connect() as conn:
-            try:
-                conn.execute(query)
-            except Exception:
-                raise pxt.RequestError(
-                    pxt.ErrorCode.TYPE_MISMATCH,
-                    f'Table {tbl.name!r}: column {col_name!r} of type {target_type} is not compatible with '
-                    f'the source type ({source_type})',
-                ) from None

--- a/pixeltable/io/sql.py
+++ b/pixeltable/io/sql.py
@@ -11,7 +11,7 @@ def export_sql(
     table_or_query: pxt.Table | pxt.Query,
     target_table_name: str,
     *,
-    db_connect_str: str | None,
+    db_connect_str: str,
     target_schema_name: str | None = None,
     if_exists: Literal['error', 'replace', 'insert'] = 'error',
     if_not_exists: Literal['error', 'create'] = 'create',

--- a/pixeltable/serving/__init__.py
+++ b/pixeltable/serving/__init__.py
@@ -5,7 +5,8 @@ Adapters for web serving frameworks.
 from typing import Any
 
 try:
-    from ._fastapi import FastAPIRouter, SqlExport
+    from ._fastapi import FastAPIRouter
+    from .globals import SqlExport
 except ImportError:
     # fastapi is an optional dependency; provide a stub that raises a helpful error on use
     class FastAPIRouter:  # type: ignore[no-redef]

--- a/pixeltable/serving/__init__.py
+++ b/pixeltable/serving/__init__.py
@@ -5,7 +5,7 @@ Adapters for web serving frameworks.
 from typing import Any
 
 try:
-    from ._fastapi import FastAPIRouter
+    from ._fastapi import FastAPIRouter, SqlExport
 except ImportError:
     # fastapi is an optional dependency; provide a stub that raises a helpful error on use
     class FastAPIRouter:  # type: ignore[no-redef]
@@ -14,5 +14,11 @@ except ImportError:
                 "pixeltable.serving.FastAPIRouter requires fastapi; install it with `pip install 'fastapi[standard]'`"
             )
 
+    class SqlExport:  # type: ignore[no-redef]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise ImportError(
+                "pixeltable.serving.SqlExport requires fastapi; install it with `pip install 'fastapi[standard]'`"
+            )
 
-__all__ = ['FastAPIRouter']
+
+__all__ = ['FastAPIRouter', 'SqlExport']

--- a/pixeltable/serving/_config.py
+++ b/pixeltable/serving/_config.py
@@ -13,6 +13,7 @@ import pixeltable as pxt
 import pixeltable.func as func
 from pixeltable import exceptions as excs
 from pixeltable.env import Env
+from pixeltable.serving.globals import SqlExport
 
 if TYPE_CHECKING:
     import fastapi
@@ -59,6 +60,7 @@ class InsertRouteConfig(RouteConfigBase):
     uploadfile_inputs: list[str] | None = None
     outputs: list[str] | None = None
     return_fileresponse: bool = False
+    export_sql: SqlExport | None = None
 
 
 class UpdateRouteConfig(RouteConfigBase):
@@ -67,6 +69,7 @@ class UpdateRouteConfig(RouteConfigBase):
     inputs: list[str] | None = None
     outputs: list[str] | None = None
     return_fileresponse: bool = False
+    export_sql: SqlExport | None = None
 
 
 class DeleteRouteConfig(RouteConfigBase):
@@ -173,6 +176,7 @@ def create_app_from_config(config: AppConfig) -> 'fastapi.FastAPI':
                 uploadfile_inputs=route.uploadfile_inputs,
                 outputs=route.outputs,
                 return_fileresponse=route.return_fileresponse,
+                export_sql=route.export_sql,
                 background=route.background,
             )
         elif isinstance(route, UpdateRouteConfig):
@@ -183,6 +187,7 @@ def create_app_from_config(config: AppConfig) -> 'fastapi.FastAPI':
                 inputs=route.inputs,
                 outputs=route.outputs,
                 return_fileresponse=route.return_fileresponse,
+                export_sql=route.export_sql,
                 background=route.background,
             )
         elif isinstance(route, DeleteRouteConfig):

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -1119,7 +1119,7 @@ class FastAPIRouter(fastapi.APIRouter):
             return None
         sql_output_schema: dict[str, ts.ColumnType] = {}
         for fname, finfo in response_model.model_fields.items():
-            ct = ts.ColumnType.from_python_type(finfo.annotation)
+            ct = ts.ColumnType.from_python_type(finfo.annotation, infer_pydantic_json=True)
             if ct is None:
                 raise excs.RequestError(
                     excs.ErrorCode.INVALID_TYPE,

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -28,9 +28,9 @@ import pixeltable.exprs as exprs
 import pixeltable.func as func
 import pixeltable.type_system as ts
 import pixeltable.utils.image as image_utils
-import pixeltable.utils.sql as sql_utils
 from pixeltable.config import Config
 from pixeltable.env import Env
+from pixeltable.serving.globals import SqlExport, SqlExporter
 from pixeltable.utils.local_store import LocalStore, TempStore
 
 _logger = logging.getLogger('pixeltable')
@@ -58,62 +58,6 @@ class JobStatusResponse(pydantic.BaseModel):
     # the per-route response_model produced by add_insert_route(); typed as Any since it varies by route
     # only set for status == 'done'
     result: Optional[Any] = None
-
-
-class SqlExport(pydantic.BaseModel):
-    """Specification of an export target with the `export_sql` parameter"""
-
-    db_connect: str
-    target_table: str
-    target_schema: str | None
-    method: Literal['insert', 'merge']
-
-
-class SqlExporter:
-    """Per-route SQL export state.
-
-    Validates the spec and resolves the target table at construction time (called once per route at
-    registration); used per request via write_row().
-    """
-
-    engine: sql.Engine
-    table: sql.Table
-
-    def __init__(
-        self, spec: SqlExport, *, engine: sql.Engine, output_schema: dict[str, ts.ColumnType], error_prefix: str
-    ) -> None:
-        if spec.method == 'merge':
-            raise excs.RequestError(
-                excs.ErrorCode.UNSUPPORTED_OPERATION, f"{error_prefix}: 'merge' is not yet supported"
-            )
-        # response-body form: media columns are URL strings on the wire
-        src_schema = {
-            name: ts.StringType(nullable=ct.nullable) if ct.is_media_type() else ct
-            for name, ct in output_schema.items()
-        }
-        self.engine = engine
-        self.table = sql_utils.resolve_table(
-            engine=engine,
-            table_name=spec.target_table,
-            schema_name=spec.target_schema,
-            source_schema=src_schema,
-            if_exists='insert',
-            if_not_exists='error',
-            error_prefix=error_prefix,
-        )
-
-    def write_row(self, row: pydantic.BaseModel) -> None:
-        """Insert one response-body row.
-
-        Raises HTTPException(500) on SQL failure; the pxt insert has already committed by
-        the time this runs.
-        """
-        try:
-            with self.engine.connect() as conn:
-                conn.execute(self.table.insert(), [row.model_dump(mode='python')])
-                conn.commit()
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f'export_sql write failed: {e}') from e
 
 
 # Name used to register the /media/{path:path} route. Insert routes use this name with
@@ -378,6 +322,7 @@ class FastAPIRouter(fastapi.APIRouter):
         inputs: list[str] | None = None,
         uploadfile_inputs: list[str] | None = None,
         outputs: list[str] | None = None,
+        export_sql: SqlExport | None = None,
         background: bool = False,
     ) -> Callable[[Callable[..., pydantic.BaseModel]], Callable[..., pydantic.BaseModel]]:
         """
@@ -402,6 +347,31 @@ class FastAPIRouter(fastapi.APIRouter):
                 become [`Form`](https://fastapi.tiangolo.com/tutorial/request-forms/) fields.
             outputs: Columns from the inserted row to pass to the decorated function as keyword
                 arguments. Defaults to all columns.
+            export_sql: If set, insert the decorated function's return value into an external RDBMS
+                table after the Pixeltable insert succeeds. The row written to the target is the
+                pydantic response model returned by the user function (its fields, not the source
+                columns) -- the target table schema must match those fields, with media-typed
+                fields modeled as strings (URL form). The `SqlExport` specification contains:
+
+                - `db_connect`: SQLAlchemy connection string for the target database (e.g.
+                  `'postgresql+psycopg://user:pw@host/db'`).
+                - `target_table`: name of the target table. It must already exist and its schema
+                  must be compatible with the response model's fields.
+                - `target_schema`: optional database schema qualifier for the target table.
+                - `method`: how to write the row into the target table.
+
+                    - `'insert'`: append the row via `INSERT ... VALUES`. Duplicates are possible
+                      if the same request is replayed.
+                    - `'merge'`: merge (upsert) the row using the target table's primary key (or
+                      unique constraint). Requires that the target table has such a key defined
+                      on fields present in the response model. **Currently not supported.**
+
+                If the external write fails, the request fails with an HTTP 500 after the
+                Pixeltable insert has already succeeded; no rollback is performed.
+
+                Compatible with `background=True` (the SQL write runs in the worker thread).
+                Schema compatibility is validated once at registration time; the target table
+                must already exist or registration fails.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the insert plus post-processing in a background thread. Poll `job_url` for the
                 result; the decorated function's return value is delivered as the job result.
@@ -425,6 +395,23 @@ class FastAPIRouter(fastapi.APIRouter):
               -d '{"prompt": "a sunset over the ocean"}'
             # {"caption": "orange sky above calm water", "score": 0.932}
             ```
+
+            Mirror the post-processed response into an external RDBMS table:
+
+            ```python
+            @router.insert_route(
+                t, path='/generate', inputs=['prompt'], outputs=['caption', 'score'],
+                export_sql=SqlExport(
+                    db_connect='postgresql+psycopg://user:pw@host/analytics',
+                    target_table='captions',
+                ),
+            )
+            def format_response(*, caption: str, score: float) -> GenerateResponse:
+                return GenerateResponse(caption=caption.strip(), score=round(score, 3))
+            ```
+
+            Each successful POST inserts a row into the Pixeltable table and then appends a row
+            with columns `caption`, `score` (the response model fields) to `captions`.
         """
         _, input_col_names, output_col_names, cols_by_name = self._validate_dml_args(
             t,
@@ -474,6 +461,7 @@ class FastAPIRouter(fastapi.APIRouter):
         inputs: list[str] | None = None,
         outputs: list[str] | None = None,
         return_fileresponse: bool = False,
+        export_sql: SqlExport | None = None,
         background: bool = False,
     ) -> None:
         """
@@ -503,6 +491,16 @@ class FastAPIRouter(fastapi.APIRouter):
             return_fileresponse: If True, return the single media-typed output column as a
                 [`FileResponse`](https://fastapi.tiangolo.com/advanced/custom-response/#fileresponse).
                 Requires exactly one media-typed output column.
+            export_sql: If set, insert the updated row into an external RDBMS table after the
+                Pixeltable update succeeds. The row written is the response body (same columns as
+                `outputs`, with media columns as URL strings). See
+                [`add_insert_route`][pixeltable.serving.FastAPIRouter.add_insert_route] for the
+                full description of the `SqlExport` specification, the `'merge'` restriction, and
+                the failure semantics. Mutually exclusive with `return_fileresponse`. Compatible
+                with `background=True`. Schema compatibility is validated once at registration
+                time; the target table must already exist or registration fails. Note: every
+                update appends a new row to the target table; the target is treated as an audit
+                log, not a mirror.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the update in a background thread. Poll `job_url` for the result. Mutually
                 exclusive with `return_fileresponse`.
@@ -519,6 +517,18 @@ class FastAPIRouter(fastapi.APIRouter):
               -H 'Content-Type: application/json' \
               -d '{"id": 1, "prompt": "a sunset over the ocean"}'
             # {"prompt": "a sunset over the ocean", "result": "..."}
+            ```
+
+            Append every update to an external audit table:
+
+            ```python
+            router.add_update_route(
+                t, path='/update', inputs=['prompt'], outputs=['id', 'prompt', 'result'],
+                export_sql=SqlExport(
+                    db_connect='postgresql+psycopg://user:pw@host/analytics',
+                    target_table='update_log',
+                ),
+            )
             ```
 
             Background processing:
@@ -581,6 +591,7 @@ class FastAPIRouter(fastapi.APIRouter):
         path: str,
         inputs: list[str] | None = None,
         outputs: list[str] | None = None,
+        export_sql: SqlExport | None = None,
         background: bool = False,
     ) -> Callable[[Callable[..., pydantic.BaseModel]], Callable[..., pydantic.BaseModel]]:
         """
@@ -611,6 +622,17 @@ class FastAPIRouter(fastapi.APIRouter):
                 non-media columns.
             outputs: Columns from the updated row to pass to the decorated function as keyword
                 arguments. Defaults to all columns.
+            export_sql: If set, insert the decorated function's return value into an external RDBMS
+                table after the Pixeltable update succeeds. The row written to the target is the
+                pydantic response model returned by the user function (its fields, not the source
+                columns) -- the target table schema must match those fields, with media-typed
+                fields modeled as strings (URL form). See
+                [`add_insert_route`][pixeltable.serving.FastAPIRouter.add_insert_route] for the
+                full description of the `SqlExport` specification, the `'merge'` restriction, and
+                the failure semantics. Compatible with `background=True`. Schema compatibility is
+                validated once at registration time; the target table must already exist or
+                registration fails. Note: every update appends a new row to the target table; the
+                target is treated as an audit log, not a mirror.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run the
                 update plus post-processing in a background thread. Poll `job_url` for the result;
                 the decorated function's return value is delivered as the job result.
@@ -634,6 +656,20 @@ class FastAPIRouter(fastapi.APIRouter):
               -H 'Content-Type: application/json' \\
               -d '{"id": 42, "text": "new content"}'
             # {"id": 42, "summary": "new content", "score": 0.871}
+            ```
+
+            Append every post-processed update into an external audit table:
+
+            ```python
+            @router.update_route(
+                t, path='/update', inputs=['text'], outputs=['id', 'text', 'score'],
+                export_sql=SqlExport(
+                    db_connect='postgresql+psycopg://user:pw@host/analytics',
+                    target_table='item_log',
+                ),
+            )
+            def format_response(*, id: int, text: str, score: float) -> ItemResponse:
+                return ItemResponse(id=id, summary=text[:100], score=round(score, 3))
             ```
 
             Background processing:

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -268,20 +268,12 @@ class FastAPIRouter(fastapi.APIRouter):
         uploadfile_inputs = uploadfile_inputs or []
         output_cols = [cols_by_name[name] for name in output_col_names]
 
-        if export_sql is not None and return_fileresponse:
-            raise excs.RequestError(
-                excs.ErrorCode.INVALID_ARGUMENT,
-                'add_insert_route(): export_sql and return_fileresponse are mutually exclusive',
-            )
-
-        sql_exporter: SqlExporter | None = None
-        if export_sql is not None:
-            sql_exporter = SqlExporter(
-                export_sql,
-                engine=self._get_sql_engine(export_sql.db_connect),
-                output_schema={name: cols_by_name[name].col_type for name in output_col_names},
-                error_prefix='add_insert_route()',
-            )
+        sql_exporter = self._make_schema_sql_exporter(
+            export_sql,
+            return_fileresponse=return_fileresponse,
+            schema={name: cols_by_name[name].col_type for name in output_col_names},
+            error_prefix='add_insert_route()',
+        )
 
         # response model derived from output columns, named after the path
         path_str = ''.join(el.capitalize() for el in path.split('/') if len(el) > 0)
@@ -419,24 +411,9 @@ class FastAPIRouter(fastapi.APIRouter):
                 error_prefix='insert_route()',
             )
 
-            sql_exporter: SqlExporter | None = None
-            if export_sql is not None:
-                sql_output_schema: dict[str, ts.ColumnType] = {}
-                for field_name, field_info in response_model.model_fields.items():
-                    ct = ts.ColumnType.from_python_type(field_info.annotation)
-                    if ct is None:
-                        raise excs.RequestError(
-                            excs.ErrorCode.INVALID_TYPE,
-                            f'insert_route(): cannot interpret response field {field_name!r} annotation '
-                            f'{field_info.annotation!r} as a Pixeltable type for export_sql',
-                        )
-                    sql_output_schema[field_name] = ct
-                sql_exporter = SqlExporter(
-                    export_sql,
-                    engine=self._get_sql_engine(export_sql.db_connect),
-                    output_schema=sql_output_schema,
-                    error_prefix='insert_route()',
-                )
+            sql_exporter = self._make_model_sql_exporter(
+                export_sql, response_model=response_model, error_prefix='insert_route()'
+            )
 
             def row_processor(row: dict[str, Any], url_for_media: Callable[[str], str]) -> pydantic.BaseModel:
                 kwargs = {name: self._convert_media_val(row[name], url_for_media) for name in output_col_names}
@@ -579,6 +556,13 @@ class FastAPIRouter(fastapi.APIRouter):
         )
         output_cols = [cols_by_name[name] for name in output_col_names]
 
+        sql_exporter = self._make_schema_sql_exporter(
+            export_sql,
+            return_fileresponse=return_fileresponse,
+            schema={name: cols_by_name[name].col_type for name in output_col_names},
+            error_prefix='add_update_route()',
+        )
+
         path_str = ''.join(el.capitalize() for el in path.split('/') if len(el) > 0)
         update_response_model = self._create_model(f'{path_str}Response', output_cols=output_cols)
 
@@ -586,7 +570,11 @@ class FastAPIRouter(fastapi.APIRouter):
             output = self._create_output(
                 [row], output_col_names, update_response_model, return_fileresponse, url_for_media
             )
-            return output[0] if isinstance(output, list) else output
+            result = output[0] if isinstance(output, list) else output
+            if sql_exporter is not None:
+                assert isinstance(result, pydantic.BaseModel)
+                sql_exporter.export_row(result)
+            return result
 
         self._add_dml_route(
             t,
@@ -736,9 +724,16 @@ class FastAPIRouter(fastapi.APIRouter):
                 error_prefix='update_route()',
             )
 
+            sql_exporter = self._make_model_sql_exporter(
+                export_sql, response_model=response_model, error_prefix='update_route()'
+            )
+
             def row_processor(row: dict[str, Any], url_for_media: Callable[[str], str]) -> pydantic.BaseModel:
                 kwargs = {name: self._convert_media_val(row[name], url_for_media) for name in output_col_names}
-                return user_fn(**kwargs)
+                result = user_fn(**kwargs)
+                if sql_exporter is not None:
+                    sql_exporter.export_row(result)
+                return result
 
             self._add_dml_route(
                 t,
@@ -1095,6 +1090,50 @@ class FastAPIRouter(fastapi.APIRouter):
             api_kwargs['response_class'] = FileResponse
         self.add_api_route(path, endpoint, **api_kwargs)
 
+    def _make_schema_sql_exporter(
+        self,
+        export_sql: SqlExport | None,
+        *,
+        return_fileresponse: bool,
+        schema: dict[str, ts.ColumnType],
+        error_prefix: str,
+    ) -> SqlExporter | None:
+        if export_sql is None:
+            return None
+        if return_fileresponse:
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_ARGUMENT,
+                f'{error_prefix}: export_sql and return_fileresponse are mutually exclusive',
+            )
+        return SqlExporter(
+            export_sql,
+            engine=self._get_sql_engine(export_sql.db_connect),
+            output_schema=schema,
+            error_prefix=error_prefix,
+        )
+
+    def _make_model_sql_exporter(
+        self, export_sql: SqlExport | None, *, response_model: type[pydantic.BaseModel], error_prefix: str
+    ) -> SqlExporter | None:
+        if export_sql is None:
+            return None
+        sql_output_schema: dict[str, ts.ColumnType] = {}
+        for fname, finfo in response_model.model_fields.items():
+            ct = ts.ColumnType.from_python_type(finfo.annotation)
+            if ct is None:
+                raise excs.RequestError(
+                    excs.ErrorCode.INVALID_TYPE,
+                    f'{error_prefix}: cannot interpret response field {fname!r} annotation '
+                    f'{finfo.annotation!r} as a Pixeltable type for export_sql',
+                )
+            sql_output_schema[fname] = ct
+        return SqlExporter(
+            export_sql,
+            engine=self._get_sql_engine(export_sql.db_connect),
+            output_schema=sql_output_schema,
+            error_prefix=error_prefix,
+        )
+
     def _add_dml_route(
         self,
         t: pxt.Table,
@@ -1110,12 +1149,12 @@ class FastAPIRouter(fastapi.APIRouter):
         row_processor_model: type[pydantic.BaseModel] | None,
         is_update: bool,
     ) -> None:
-        """Shared wiring for insert/update routes.
+        """Create endpoint for insert/update.
 
         The endpoint signature is the PK columns (for row identification, update only) followed by
-        the input columns. `row_processor` is called with the single inserted/updated row dict and
-        `url_for_media`. For insert routes, `pk_col_names` must be []; for update routes,
-        `uploadfile_inputs` must be [].
+        the input columns. row_processor is called with the single inserted/updated row dict and
+        url_for_media. For insert routes, pk_col_names must be []; for update routes,
+        uploadfile_inputs must be [].
         """
         md = t.get_metadata()
         tbl_path, tbl_id, schema_version = md['path'], md['id'], md['schema_version']

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -230,8 +230,8 @@ class FastAPIRouter(fastapi.APIRouter):
                 outputs=['prompt', 'result'],
                 export_sql=SqlExport(
                     db_connect='postgresql+psycopg://user:pw@host/analytics',
-                    table='generations',
-                    schema='public',
+                    target_table='generations',
+                    target_schema='public',
                 ),
             )
             ```

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -122,7 +122,8 @@ class FastAPIRouter(fastapi.APIRouter):
         self.add_event_handler('shutdown', self._shutdown)
 
     def _shutdown(self) -> None:
-        self._executor.shutdown(wait=False, cancel_futures=True)
+        # wait until in-flight requests are done and won't access _engine_cache
+        self._executor.shutdown(wait=True, cancel_futures=True)
         for eng in self._engine_cache.values():
             eng.dispose()
         self._engine_cache.clear()

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -57,14 +57,23 @@ class JobStatusResponse(pydantic.BaseModel):
     result: Optional[Any] = None
 
 
-# Name used to register the `/media/{path:path}` route. Insert routes use this name with
-# `request.url_for(_MEDIA_ROUTE_NAME, path=...)` to build absolute media URLs at request time.
+class SqlExport(pydantic.BaseModel):
+    """Specification of an export target with the `export_sql` parameter"""
+
+    db_connect: str
+    target_table: str
+    target_schema: str | None
+    method: Literal['insert', 'merge']
+
+
+# Name used to register the /media/{path:path} route. Insert routes use this name with
+# request.url_for(_MEDIA_ROUTE_NAME, path=...) to build absolute media URLs at request time.
 _MEDIA_ROUTE_NAME = 'pxt_serve_media'
 _JOB_STATUS_ROUTE_NAME = 'pxt_serve_job_status'
 
 
 # ColumnType.Type -> JSON-Schema contentMediaType
-# `.../*`: tell OpenAPI tooling to render the URL as a media link without committing to a specific subtype
+# .../*: tell OpenAPI tooling to render the URL as a media link without committing to a specific subtype
 _MEDIA_CONTENT_TYPES: dict[ts.ColumnType.Type, str] = {
     ts.ColumnType.Type.IMAGE: 'image/*',
     ts.ColumnType.Type.VIDEO: 'video/*',
@@ -128,6 +137,7 @@ class FastAPIRouter(fastapi.APIRouter):
         uploadfile_inputs: list[str] | None = None,
         outputs: list[str] | None = None,
         return_fileresponse: bool = False,
+        export_sql: SqlExport | None = None,
         background: bool = False,
     ) -> None:
         """
@@ -151,6 +161,25 @@ class FastAPIRouter(fastapi.APIRouter):
             return_fileresponse: If True, return the single media-typed output column as a
                 [`FileResponse`](https://fastapi.tiangolo.com/advanced/custom-response/#fileresponse).
                 Requires exactly one media-typed output column.
+            export_sql: If set, insert/merge the newly inserted row to an external RDBMS table after the
+                insert succeeds. The `SqlExport` specification contains:
+
+                - `db_connect`: SQLAlchemy connection string for the target database (e.g.
+                  `'postgresql+psycopg://user:pw@host/db'`).
+                - `target_table`: name of the target table. It must already exist and its schema must be
+                  compatible with the columns included in the response body (same columns as
+                  `outputs`, with compatible types).
+                - `target_schema`: optional database schema qualifier for the target table.
+                - `method`: how to write the row into the target table.
+
+                    - `'insert'`: append the row via `INSERT ... VALUES`. Duplicates are possible
+                      if the same request is replayed.
+                    - `'merge'`: merge (upsert) the row using the target table's primary key (or unique
+                      constraint). Requires that the target table has such a key defined on
+                      columns present in the response body. **Currently not supported.**
+
+                If the external write fails, the request fails with an HTTP 500 after the
+                Pixeltable insert has already succeeded; no rollback is performed.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the insert in a background thread. Poll `job_url` for the result. Mutually
                 exclusive with `return_fileresponse`.
@@ -184,6 +213,25 @@ class FastAPIRouter(fastapi.APIRouter):
               --output resized.jpg
             # saves the resized image to resized.jpg
             ```
+
+            Mirror each inserted row into an external RDBMS table:
+
+            ```python
+            router.add_insert_route(
+                t,
+                path='/generate',
+                inputs=['prompt'],
+                outputs=['prompt', 'result'],
+                export_sql=SqlExport(
+                    db_connect='postgresql+psycopg://user:pw@host/analytics',
+                    table='generations',
+                    schema='public',
+                ),
+            )
+            ```
+
+            Each successful POST inserts a row into the Pixeltable table and then appends the
+            same row (columns: `prompt`, `result`) to `public.generations` in the target database.
 
             Background processing:
 
@@ -794,7 +842,7 @@ class FastAPIRouter(fastapi.APIRouter):
             if one_row:
                 output_model = query_result_model
             else:
-                # Multi-row: wrap per-row models in a response with a `rows` field.
+                # Multi-row: wrap per-row models in a response with a rows field.
                 output_model = pydantic.create_model(
                     f'{path_str}Response',
                     rows=(list[query_result_model], pydantic.Field(description='Query result rows')),  # type: ignore[valid-type]

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -179,9 +179,19 @@ class FastAPIRouter(fastapi.APIRouter):
                 - `method`: how to write the row into the target table.
 
                     - `'insert'`: insert the row via `INSERT ... VALUES`.
+                    - `'update'`: update the row in the target table by primary-key match
+                      (`UPDATE ... SET ... WHERE pk=...`). The response columns must include all
+                      primary-key columns of the target plus at least one non-PK column to set.
+                      This is a strict update, **not** an upsert: if the WHERE clause matches zero
+                      rows, the request fails with HTTP 500. Useful when the source table is
+                      append-only but the target is a deduplicated current-state view.
                     - `'merge'`: merge (upsert) the row using the target table's primary key (or unique
                       constraint). Requires that the target table has such a key defined on
                       columns present in the response body. **Currently not supported.**
+
+                Note: when `add_insert_route` is paired with `method='update'`, a Pixeltable insert
+                triggers a target-side update -- this is intentional, supporting the
+                append-only-source / current-state-mirror pattern.
 
                 If the external write fails, the request fails with an HTTP 500 after the
                 Pixeltable insert has already succeeded; no rollback is performed.
@@ -297,7 +307,7 @@ class FastAPIRouter(fastapi.APIRouter):
             result = output[0] if isinstance(output, list) else output
             if sql_exporter is not None:
                 assert isinstance(result, pydantic.BaseModel)
-                sql_exporter.write_row(result)
+                sql_exporter.export_row(result)
             return result
 
         self._add_dml_route(
@@ -362,6 +372,11 @@ class FastAPIRouter(fastapi.APIRouter):
 
                     - `'insert'`: append the row via `INSERT ... VALUES`. Duplicates are possible
                       if the same request is replayed.
+                    - `'update'`: update the row in the target table by primary-key match
+                      (`UPDATE ... SET ... WHERE pk=...`). The response model fields must include
+                      all primary-key columns of the target plus at least one non-PK field to
+                      set. This is a strict update, **not** an upsert: if the WHERE clause
+                      matches zero rows, the request fails with HTTP 500.
                     - `'merge'`: merge (upsert) the row using the target table's primary key (or
                       unique constraint). Requires that the target table has such a key defined
                       on fields present in the response model. **Currently not supported.**
@@ -455,7 +470,7 @@ class FastAPIRouter(fastapi.APIRouter):
                 kwargs = {name: self._convert_media_val(row[name], url_for_media) for name in output_col_names}
                 result = user_fn(**kwargs)
                 if sql_exporter is not None:
-                    sql_exporter.write_row(result)
+                    sql_exporter.export_row(result)
                 return result
 
             self._add_dml_route(
@@ -517,12 +532,12 @@ class FastAPIRouter(fastapi.APIRouter):
                 Pixeltable update succeeds. The row written is the response body (same columns as
                 `outputs`, with media columns as URL strings). See
                 [`add_insert_route`][pixeltable.serving.FastAPIRouter.add_insert_route] for the
-                full description of the `SqlExport` specification, the `'merge'` restriction, and
-                the failure semantics. Mutually exclusive with `return_fileresponse`. Compatible
-                with `background=True`. Schema compatibility is validated once at registration
-                time; the target table must already exist or registration fails. Note: every
-                update appends a new row to the target table; the target is treated as an audit
-                log, not a mirror.
+                full description of the `SqlExport` specification (including `method='update'`
+                and the `'merge'` restriction) and the failure semantics. Mutually exclusive with
+                `return_fileresponse`. Compatible with `background=True`. Schema compatibility is
+                validated once at registration time; the target table must already exist or
+                registration fails. Note: every update appends a new row to the target table; the
+                target is treated as an audit log, not a mirror.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the update in a background thread. Poll `job_url` for the result. Mutually
                 exclusive with `return_fileresponse`.
@@ -650,11 +665,12 @@ class FastAPIRouter(fastapi.APIRouter):
                 columns) -- the target table schema must match those fields, with media-typed
                 fields modeled as strings (URL form). See
                 [`add_insert_route`][pixeltable.serving.FastAPIRouter.add_insert_route] for the
-                full description of the `SqlExport` specification, the `'merge'` restriction, and
-                the failure semantics. Compatible with `background=True`. Schema compatibility is
-                validated once at registration time; the target table must already exist or
-                registration fails. Note: every update appends a new row to the target table; the
-                target is treated as an audit log, not a mirror.
+                full description of the `SqlExport` specification (including `method='update'`
+                and the `'merge'` restriction) and the failure semantics. Compatible with
+                `background=True`. Schema compatibility is validated once at registration time;
+                the target table must already exist or registration fails. Note: every update
+                appends a new row to the target table; the target is treated as an audit log,
+                not a mirror.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run the
                 update plus post-processing in a background thread. Poll `job_url` for the result;
                 the decorated function's return value is delivered as the job result.

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -167,38 +167,25 @@ class FastAPIRouter(fastapi.APIRouter):
             return_fileresponse: If True, return the single media-typed output column as a
                 [`FileResponse`](https://fastapi.tiangolo.com/advanced/custom-response/#fileresponse).
                 Requires exactly one media-typed output column.
-            export_sql: If set, insert/merge the newly inserted row to an external RDBMS table after the
-                insert succeeds. The `SqlExport` specification contains:
+            export_sql: If set, export each inserted row into an external RDBMS table after the
+                Pixeltable insert succeeds. See [`SqlExport`][pixeltable.serving.SqlExport] for
+                the target specification and supported `method` values.
 
-                - `db_connect`: SQLAlchemy connection string for the target database (e.g.
-                  `'postgresql+psycopg://user:pw@host/db'`).
-                - `target_table`: name of the target table. It must already exist and its schema must be
-                  compatible with the columns included in the response body (same columns as
-                  `outputs`, with compatible types).
-                - `target_schema`: optional database schema qualifier for the target table.
-                - `method`: how to write the row into the target table.
+                The row written is the response body: same columns as `outputs`, with media-typed
+                columns rendered as URL strings (so the corresponding target columns must be
+                string-typed).
 
-                    - `'insert'`: insert the row via `INSERT ... VALUES`.
-                    - `'update'`: update the row in the target table by primary-key match
-                      (`UPDATE ... SET ... WHERE pk=...`). The response columns must include all
-                      primary-key columns of the target plus at least one non-PK column to set.
-                      This is a strict update, **not** an upsert: if the WHERE clause matches zero
-                      rows, the request fails with HTTP 500. Useful when the source table is
-                      append-only but the target is a deduplicated current-state view.
-                    - `'merge'`: merge (upsert) the row using the target table's primary key (or unique
-                      constraint). Requires that the target table has such a key defined on
-                      columns present in the response body. **Currently not supported.**
-
-                Note: when `add_insert_route` is paired with `method='update'`, a Pixeltable insert
-                triggers a target-side update -- this is intentional, supporting the
-                append-only-source / current-state-mirror pattern.
-
-                If the external write fails, the request fails with an HTTP 500 after the
-                Pixeltable insert has already succeeded; no rollback is performed.
-
+                Schema compatibility against the response columns is validated once at
+                registration time; the target table must already exist or registration fails.
                 Mutually exclusive with `return_fileresponse`. Compatible with `background=True`
-                (the SQL write runs in the worker thread). Schema compatibility is validated once
-                at registration time; the target table must already exist or registration fails.
+                (the SQL write runs in the worker thread).
+
+                Note: when paired with `method='update'`, a Pixeltable insert triggers a
+                target-side update -- this is intentional, supporting the append-only-source /
+                current-state-view pattern.
+
+                If the external write fails after the Pixeltable insert has already succeeded,
+                the request fails with HTTP 500; no rollback is performed.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the insert in a background thread. Poll `job_url` for the result. Mutually
                 exclusive with `return_fileresponse`.
@@ -233,7 +220,7 @@ class FastAPIRouter(fastapi.APIRouter):
             # saves the resized image to resized.jpg
             ```
 
-            Mirror each inserted row into an external RDBMS table:
+            Export each inserted row into an external RDBMS table:
 
             ```python
             router.add_insert_route(
@@ -357,36 +344,21 @@ class FastAPIRouter(fastapi.APIRouter):
                 become [`Form`](https://fastapi.tiangolo.com/tutorial/request-forms/) fields.
             outputs: Columns from the inserted row to pass to the decorated function as keyword
                 arguments. Defaults to all columns.
-            export_sql: If set, insert the decorated function's return value into an external RDBMS
-                table after the Pixeltable insert succeeds. The row written to the target is the
-                pydantic response model returned by the user function (its fields, not the source
-                columns) -- the target table schema must match those fields, with media-typed
-                fields modeled as strings (URL form). The `SqlExport` specification contains:
+            export_sql: If set, export the decorated function's return value into an external
+                RDBMS table after the Pixeltable insert succeeds. See
+                [`SqlExport`][pixeltable.serving.SqlExport] for the target specification and
+                supported `method` values.
 
-                - `db_connect`: SQLAlchemy connection string for the target database (e.g.
-                  `'postgresql+psycopg://user:pw@host/db'`).
-                - `target_table`: name of the target table. It must already exist and its schema
-                  must be compatible with the response model's fields.
-                - `target_schema`: optional database schema qualifier for the target table.
-                - `method`: how to write the row into the target table.
+                The row written is the user function's pydantic return value (its fields, not the
+                source columns), so the target table schema must match those fields. Media-typed
+                fields are modeled as strings (URL form).
 
-                    - `'insert'`: append the row via `INSERT ... VALUES`. Duplicates are possible
-                      if the same request is replayed.
-                    - `'update'`: update the row in the target table by primary-key match
-                      (`UPDATE ... SET ... WHERE pk=...`). The response model fields must include
-                      all primary-key columns of the target plus at least one non-PK field to
-                      set. This is a strict update, **not** an upsert: if the WHERE clause
-                      matches zero rows, the request fails with HTTP 500.
-                    - `'merge'`: merge (upsert) the row using the target table's primary key (or
-                      unique constraint). Requires that the target table has such a key defined
-                      on fields present in the response model. **Currently not supported.**
-
-                If the external write fails, the request fails with an HTTP 500 after the
-                Pixeltable insert has already succeeded; no rollback is performed.
-
-                Compatible with `background=True` (the SQL write runs in the worker thread).
                 Schema compatibility is validated once at registration time; the target table
-                must already exist or registration fails.
+                must already exist or registration fails. Compatible with `background=True` (the
+                SQL write runs in the worker thread).
+
+                If the external write fails after the Pixeltable insert has already succeeded,
+                the request fails with HTTP 500; no rollback is performed.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the insert plus post-processing in a background thread. Poll `job_url` for the
                 result; the decorated function's return value is delivered as the job result.
@@ -411,7 +383,7 @@ class FastAPIRouter(fastapi.APIRouter):
             # {"caption": "orange sky above calm water", "score": 0.932}
             ```
 
-            Mirror the post-processed response into an external RDBMS table:
+            Export the post-processed response into an external RDBMS table:
 
             ```python
             @router.insert_route(
@@ -528,16 +500,25 @@ class FastAPIRouter(fastapi.APIRouter):
             return_fileresponse: If True, return the single media-typed output column as a
                 [`FileResponse`](https://fastapi.tiangolo.com/advanced/custom-response/#fileresponse).
                 Requires exactly one media-typed output column.
-            export_sql: If set, insert the updated row into an external RDBMS table after the
-                Pixeltable update succeeds. The row written is the response body (same columns as
-                `outputs`, with media columns as URL strings). See
-                [`add_insert_route`][pixeltable.serving.FastAPIRouter.add_insert_route] for the
-                full description of the `SqlExport` specification (including `method='update'`
-                and the `'merge'` restriction) and the failure semantics. Mutually exclusive with
-                `return_fileresponse`. Compatible with `background=True`. Schema compatibility is
-                validated once at registration time; the target table must already exist or
-                registration fails. Note: every update appends a new row to the target table; the
-                target is treated as an audit log, not a mirror.
+            export_sql: If set, export each updated row into an external RDBMS table after the
+                Pixeltable update succeeds. See [`SqlExport`][pixeltable.serving.SqlExport] for
+                the target specification and supported `method` values.
+
+                The row written is the response body: same columns as `outputs`, with media-typed
+                columns rendered as URL strings (so the corresponding target columns must be
+                string-typed).
+
+                Schema compatibility is validated once at registration time; the target table
+                must already exist or registration fails. Mutually exclusive with
+                `return_fileresponse`. Compatible with `background=True`.
+
+                Note: with `method='insert'` (the default), every update appends a new row to the
+                target table -- the target acts as an audit log, not a current-state view. Use
+                `method='update'` to keep the target as a current-state view keyed on the
+                target's primary key.
+
+                If the external write fails after the Pixeltable update has already succeeded,
+                the request fails with HTTP 500; no rollback is performed.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the update in a background thread. Poll `job_url` for the result. Mutually
                 exclusive with `return_fileresponse`.
@@ -659,18 +640,25 @@ class FastAPIRouter(fastapi.APIRouter):
                 non-media columns.
             outputs: Columns from the updated row to pass to the decorated function as keyword
                 arguments. Defaults to all columns.
-            export_sql: If set, insert the decorated function's return value into an external RDBMS
-                table after the Pixeltable update succeeds. The row written to the target is the
-                pydantic response model returned by the user function (its fields, not the source
-                columns) -- the target table schema must match those fields, with media-typed
-                fields modeled as strings (URL form). See
-                [`add_insert_route`][pixeltable.serving.FastAPIRouter.add_insert_route] for the
-                full description of the `SqlExport` specification (including `method='update'`
-                and the `'merge'` restriction) and the failure semantics. Compatible with
-                `background=True`. Schema compatibility is validated once at registration time;
-                the target table must already exist or registration fails. Note: every update
-                appends a new row to the target table; the target is treated as an audit log,
-                not a mirror.
+            export_sql: If set, export the decorated function's return value into an external
+                RDBMS table after the Pixeltable update succeeds. See
+                [`SqlExport`][pixeltable.serving.SqlExport] for the target specification and
+                supported `method` values.
+
+                The row written is the user function's pydantic return value (its fields, not the
+                source columns), so the target table schema must match those fields. Media-typed
+                fields are modeled as strings (URL form).
+
+                Schema compatibility is validated once at registration time; the target table
+                must already exist or registration fails. Compatible with `background=True`.
+
+                Note: with `method='insert'` (the default), every update appends a new row to the
+                target table -- the target acts as an audit log, not a current-state view. Use
+                `method='update'` to keep the target as a current-state view keyed on the
+                target's primary key.
+
+                If the external write fails after the Pixeltable update has already succeeded,
+                the request fails with HTTP 500; no rollback is performed.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run the
                 update plus post-processing in a background thread. Poll `job_url` for the result;
                 the decorated function's return value is delivered as the job result.

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -432,9 +432,31 @@ class FastAPIRouter(fastapi.APIRouter):
                 error_prefix='insert_route()',
             )
 
+            sql_exporter: SqlExporter | None = None
+            if export_sql is not None:
+                sql_output_schema: dict[str, ts.ColumnType] = {}
+                for field_name, field_info in response_model.model_fields.items():
+                    ct = ts.ColumnType.from_python_type(field_info.annotation)
+                    if ct is None:
+                        raise excs.RequestError(
+                            excs.ErrorCode.INVALID_TYPE,
+                            f'insert_route(): cannot interpret response field {field_name!r} annotation '
+                            f'{field_info.annotation!r} as a Pixeltable type for export_sql',
+                        )
+                    sql_output_schema[field_name] = ct
+                sql_exporter = SqlExporter(
+                    export_sql,
+                    engine=self._get_sql_engine(export_sql.db_connect),
+                    output_schema=sql_output_schema,
+                    error_prefix='insert_route()',
+                )
+
             def row_processor(row: dict[str, Any], url_for_media: Callable[[str], str]) -> pydantic.BaseModel:
                 kwargs = {name: self._convert_media_val(row[name], url_for_media) for name in output_col_names}
-                return user_fn(**kwargs)
+                result = user_fn(**kwargs)
+                if sql_exporter is not None:
+                    sql_exporter.write_row(result)
+                return result
 
             self._add_dml_route(
                 t,

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -231,8 +231,8 @@ class FastAPIRouter(fastapi.APIRouter):
                 outputs=['prompt', 'result'],
                 export_sql=SqlExport(
                     db_connect='postgresql+psycopg://user:pw@host/analytics',
-                    target_table='generations',
-                    target_schema='public',
+                    table='generations',
+                    db_schema='public',
                 ),
             )
             ```
@@ -383,7 +383,7 @@ class FastAPIRouter(fastapi.APIRouter):
                 t, path='/generate', inputs=['prompt'], outputs=['caption', 'score'],
                 export_sql=SqlExport(
                     db_connect='postgresql+psycopg://user:pw@host/analytics',
-                    target_table='captions',
+                    table='captions',
                 ),
             )
             def format_response(*, caption: str, score: float) -> GenerateResponse:
@@ -522,7 +522,7 @@ class FastAPIRouter(fastapi.APIRouter):
                 t, path='/update', inputs=['prompt'], outputs=['id', 'prompt', 'result'],
                 export_sql=SqlExport(
                     db_connect='postgresql+psycopg://user:pw@host/analytics',
-                    target_table='update_log',
+                    table='update_log',
                 ),
             )
             ```
@@ -680,7 +680,7 @@ class FastAPIRouter(fastapi.APIRouter):
                 t, path='/update', inputs=['text'], outputs=['id', 'text', 'score'],
                 export_sql=SqlExport(
                     db_connect='postgresql+psycopg://user:pw@host/analytics',
-                    target_table='item_log',
+                    table='item_log',
                 ),
             )
             def format_response(*, id: int, text: str, score: float) -> ItemResponse:

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -16,16 +16,19 @@ from typing import Annotated, Any, Callable, Literal, Optional, TypeVar, get_typ
 import fastapi
 import PIL.Image
 import pydantic
+import sqlalchemy as sql
 from fastapi import Body, File, Form, HTTPException, Query as QueryParam, Request, UploadFile
 from fastapi.responses import FileResponse
 from pydantic.fields import FieldInfo
 
 import pixeltable as pxt
 import pixeltable.catalog as catalog
+import pixeltable.exceptions as excs
 import pixeltable.exprs as exprs
 import pixeltable.func as func
 import pixeltable.type_system as ts
 import pixeltable.utils.image as image_utils
+import pixeltable.utils.sql as sql_utils
 from pixeltable.config import Config
 from pixeltable.env import Env
 from pixeltable.utils.local_store import LocalStore, TempStore
@@ -64,6 +67,53 @@ class SqlExport(pydantic.BaseModel):
     target_table: str
     target_schema: str | None
     method: Literal['insert', 'merge']
+
+
+class SqlExporter:
+    """Per-route SQL export state.
+
+    Validates the spec and resolves the target table at construction time (called once per route at
+    registration); used per request via write_row().
+    """
+
+    engine: sql.Engine
+    table: sql.Table
+
+    def __init__(
+        self, spec: SqlExport, *, engine: sql.Engine, output_schema: dict[str, ts.ColumnType], error_prefix: str
+    ) -> None:
+        if spec.method == 'merge':
+            raise excs.RequestError(
+                excs.ErrorCode.UNSUPPORTED_OPERATION, f"{error_prefix}: 'merge' is not yet supported"
+            )
+        # response-body form: media columns are URL strings on the wire
+        src_schema = {
+            name: ts.StringType(nullable=ct.nullable) if ct.is_media_type() else ct
+            for name, ct in output_schema.items()
+        }
+        self.engine = engine
+        self.table = sql_utils.resolve_table(
+            engine=engine,
+            table_name=spec.target_table,
+            schema_name=spec.target_schema,
+            source_schema=src_schema,
+            if_exists='insert',
+            if_not_exists='error',
+            error_prefix=error_prefix,
+        )
+
+    def write_row(self, row: pydantic.BaseModel) -> None:
+        """Insert one response-body row.
+
+        Raises HTTPException(500) on SQL failure; the pxt insert has already committed by
+        the time this runs.
+        """
+        try:
+            with self.engine.connect() as conn:
+                conn.execute(self.table.insert(), [row.model_dump(mode='python')])
+                conn.commit()
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f'export_sql write failed: {e}') from e
 
 
 # Name used to register the /media/{path:path} route. Insert routes use this name with
@@ -111,6 +161,7 @@ class FastAPIRouter(fastapi.APIRouter):
     _jobs_lock: threading.Lock
     _home_dir: Path
     _allowed_media_dirs: list[Path]
+    _engine_cache: dict[str, sql.Engine]  # keyed by SqlExport.db_connect; shared across routes
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -119,6 +170,7 @@ class FastAPIRouter(fastapi.APIRouter):
         self._jobs_lock = threading.Lock()
         self._home_dir = Config.get().home.resolve()
         self._allowed_media_dirs = [Env.get().media_dir.resolve(), Env.get().tmp_dir.resolve()]
+        self._engine_cache = {}
         self._register_media_route()
         self._register_jobs_route()
         # Shut down the worker pool when the parent app's lifespan ends. include_router()
@@ -127,6 +179,16 @@ class FastAPIRouter(fastapi.APIRouter):
 
     def _shutdown(self) -> None:
         self._executor.shutdown(wait=False, cancel_futures=True)
+        for eng in self._engine_cache.values():
+            eng.dispose()
+        self._engine_cache.clear()
+
+    def _get_sql_engine(self, db_connect: str) -> sql.Engine:
+        eng = self._engine_cache.get(db_connect)
+        if eng is None:
+            eng = sql.create_engine(db_connect)
+            self._engine_cache[db_connect] = eng
+        return eng
 
     def add_insert_route(
         self,
@@ -172,14 +234,17 @@ class FastAPIRouter(fastapi.APIRouter):
                 - `target_schema`: optional database schema qualifier for the target table.
                 - `method`: how to write the row into the target table.
 
-                    - `'insert'`: append the row via `INSERT ... VALUES`. Duplicates are possible
-                      if the same request is replayed.
+                    - `'insert'`: insert the row via `INSERT ... VALUES`.
                     - `'merge'`: merge (upsert) the row using the target table's primary key (or unique
                       constraint). Requires that the target table has such a key defined on
                       columns present in the response body. **Currently not supported.**
 
                 If the external write fails, the request fails with an HTTP 500 after the
                 Pixeltable insert has already succeeded; no rollback is performed.
+
+                Mutually exclusive with `return_fileresponse`. Compatible with `background=True`
+                (the SQL write runs in the worker thread). Schema compatibility is validated once
+                at registration time; the target table must already exist or registration fails.
             background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
                 the insert in a background thread. Poll `job_url` for the result. Mutually
                 exclusive with `return_fileresponse`.
@@ -230,7 +295,7 @@ class FastAPIRouter(fastapi.APIRouter):
             )
             ```
 
-            Each successful POST inserts a row into the Pixeltable table and then appends the
+            Each successful POST inserts a row into the Pixeltable table and then inserts the
             same row (columns: `prompt`, `result`) to `public.generations` in the target database.
 
             Background processing:
@@ -262,6 +327,21 @@ class FastAPIRouter(fastapi.APIRouter):
         uploadfile_inputs = uploadfile_inputs or []
         output_cols = [cols_by_name[name] for name in output_col_names]
 
+        if export_sql is not None and return_fileresponse:
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_ARGUMENT,
+                'add_insert_route(): export_sql and return_fileresponse are mutually exclusive',
+            )
+
+        sql_exporter: SqlExporter | None = None
+        if export_sql is not None:
+            sql_exporter = SqlExporter(
+                export_sql,
+                engine=self._get_sql_engine(export_sql.db_connect),
+                output_schema={name: cols_by_name[name].col_type for name in output_col_names},
+                error_prefix='add_insert_route()',
+            )
+
         # response model derived from output columns, named after the path
         path_str = ''.join(el.capitalize() for el in path.split('/') if len(el) > 0)
         insert_response_model = self._create_model(f'{path_str}Response', output_cols=output_cols)
@@ -270,7 +350,11 @@ class FastAPIRouter(fastapi.APIRouter):
             output = self._create_output(
                 [row], output_col_names, insert_response_model, return_fileresponse, url_for_media
             )
-            return output[0] if isinstance(output, list) else output
+            result = output[0] if isinstance(output, list) else output
+            if sql_exporter is not None:
+                assert isinstance(result, pydantic.BaseModel)
+                sql_exporter.write_row(result)
+            return result
 
         self._add_dml_route(
             t,

--- a/pixeltable/serving/globals.py
+++ b/pixeltable/serving/globals.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Literal
 
 import pydantic
 import sqlalchemy as sql
-from fastapi import HTTPException
 
 import pixeltable.exceptions as excs
 import pixeltable.type_system as ts
 import pixeltable.utils.sql as sql_utils
+
+_logger = logging.getLogger('pixeltable')
 
 
 class SqlExport(pydantic.BaseModel):
@@ -128,6 +130,8 @@ class SqlExporter:
         Raises HTTPException(500) on SQL failure.
         For method='update', also raises HTTPException(500) if the WHERE clause matched zero rows
         """
+        from fastapi import HTTPException
+
         params = row.model_dump(mode='python')
         if self.method == 'update':
             # add prefixed copies of PK values for the WHERE bindparams
@@ -143,4 +147,7 @@ class SqlExporter:
         except HTTPException:
             raise
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f'export_sql write failed: {e}') from e
+            # log full diagnostics server-side; client gets a generic message so we don't leak SQL
+            # text, parameter values, or driver internals carried by DBAPI/SQLAlchemy exceptions
+            _logger.exception('export_sql write to %s failed', self.table.name)
+            raise HTTPException(status_code=500, detail='export_sql write failed') from e

--- a/pixeltable/serving/globals.py
+++ b/pixeltable/serving/globals.py
@@ -37,6 +37,8 @@ class SqlExport(pydantic.BaseModel):
               **Currently not supported.**
     """
 
+    model_config = pydantic.ConfigDict(extra='forbid')
+
     db_connect: str
     target_table: str
     target_schema: str | None = None
@@ -53,9 +55,11 @@ class SqlExporter:
     engine: sql.Engine
     table: sql.Table
     method: Literal['insert', 'update']
+
     # cached SQLAlchemy construct: the engine's compiled-SQL cache hits on every reuse, so per-request
     # cost is bind + send, no recompile.
     _stmt: sql.sql.expression.Executable
+
     # primary-key column names for method='update'; used to translate row dict to WHERE bindparams
     _pk_names: list[str]
 

--- a/pixeltable/serving/globals.py
+++ b/pixeltable/serving/globals.py
@@ -22,9 +22,10 @@ class SqlExport(pydantic.BaseModel):
     Attributes:
         db_connect: SQLAlchemy connection string for the target database (e.g.
             `'postgresql+psycopg://user:pw@host/db'`, `'sqlite:///path/to.db'`).
-        target_table: Name of the target table. It must already exist; resolution fails
+        table: Name of the target table. It must already exist; resolution fails
             if the table is missing.
-        target_schema: Optional database schema qualifier for the target table.
+        db_schema: Optional database schema qualifier (e.g. `'analytics'`); leave `None` to
+            use the connection's default schema.
         method: How to write each row into the target table.
 
             - `'insert'`: append the row via `INSERT ... VALUES`.
@@ -42,8 +43,8 @@ class SqlExport(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra='forbid')
 
     db_connect: str
-    target_table: str
-    target_schema: str | None = None
+    table: str
+    db_schema: str | None = None
     method: Literal['insert', 'update', 'merge'] = 'insert'
 
 
@@ -80,8 +81,8 @@ class SqlExporter:
         self.engine = engine
         self.table = sql_utils.resolve_table(
             engine=engine,
-            table_name=spec.target_table,
-            schema_name=spec.target_schema,
+            table_name=spec.table,
+            schema_name=spec.db_schema,
             source_schema=src_schema,
             if_exists='insert',
             if_not_exists='error',
@@ -135,7 +136,7 @@ class SqlExporter:
         params = row.model_dump(mode='python')
         if self.method == 'update':
             # add prefixed copies of PK values for the WHERE bindparams
-            params = {**params, **{f'b_{n}': params[n] for n in self._pk_names}}
+            params |= {f'b_{n}': params[n] for n in self._pk_names}
         try:
             with self.engine.connect() as conn:
                 result = conn.execute(self._stmt, [params])

--- a/pixeltable/serving/globals.py
+++ b/pixeltable/serving/globals.py
@@ -1,0 +1,142 @@
+"""Shared serving-layer types: SqlExport spec + per-route SqlExporter."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pydantic
+import sqlalchemy as sql
+from fastapi import HTTPException
+
+import pixeltable.exceptions as excs
+import pixeltable.type_system as ts
+import pixeltable.utils.sql as sql_utils
+
+
+class SqlExport(pydantic.BaseModel):
+    """
+    Specification of an external RDBMS target for SQL export.
+
+    Attributes:
+        db_connect: SQLAlchemy connection string for the target database (e.g.
+            `'postgresql+psycopg://user:pw@host/db'`, `'sqlite:///path/to.db'`).
+        target_table: Name of the target table. It must already exist; resolution fails
+            if the table is missing.
+        target_schema: Optional database schema qualifier for the target table.
+        method: How to write each row into the target table.
+
+            - `'insert'`: append the row via `INSERT ... VALUES`.
+            - `'update'`: update the row by primary-key match
+              (`UPDATE ... SET ... WHERE pk=...`). Requires that the target table has a
+              primary key whose metadata is exposed by the dialect. The exported columns
+              must include all primary-key columns of the target plus at least one non-PK
+              column to set. This is a strict update, **not** an upsert: if the WHERE
+              clause matches zero rows, the export fails. Useful when the source is
+              append-only but the target is a deduplicated current-state view.
+            - `'merge'`: upsert via the target table's primary key.
+              **Currently not supported.**
+    """
+
+    db_connect: str
+    target_table: str
+    target_schema: str | None = None
+    method: Literal['insert', 'update', 'merge'] = 'insert'
+
+
+class SqlExporter:
+    """Per-route SQL export state.
+
+    Validates the spec and resolves the target table at construction time (called once per route at
+    registration); used per request via export_row().
+    """
+
+    engine: sql.Engine
+    table: sql.Table
+    method: Literal['insert', 'update']
+    # cached SQLAlchemy construct: the engine's compiled-SQL cache hits on every reuse, so per-request
+    # cost is bind + send, no recompile.
+    _stmt: sql.sql.expression.Executable
+    # primary-key column names for method='update'; used to translate row dict to WHERE bindparams
+    _pk_names: list[str]
+
+    def __init__(
+        self, spec: SqlExport, *, engine: sql.Engine, output_schema: dict[str, ts.ColumnType], error_prefix: str
+    ) -> None:
+        if spec.method == 'merge':
+            raise excs.RequestError(
+                excs.ErrorCode.UNSUPPORTED_OPERATION, f"{error_prefix}: 'merge' is not yet supported"
+            )
+        # response-body form: media columns are URL strings on the wire
+        src_schema = {
+            col_name: ts.StringType(nullable=col_type.nullable) if col_type.is_media_type() else col_type
+            for col_name, col_type in output_schema.items()
+        }
+        self.engine = engine
+        self.table = sql_utils.resolve_table(
+            engine=engine,
+            table_name=spec.target_table,
+            schema_name=spec.target_schema,
+            source_schema=src_schema,
+            if_exists='insert',
+            if_not_exists='error',
+            error_prefix=error_prefix,
+        )
+        # 'merge' rejected above; remaining values are 'insert' | 'update'
+        self.method = spec.method
+
+        if spec.method == 'update':
+            # require a primary key on the target; the response columns must include every PK column
+            # so we can build the WHERE clause, plus at least one non-PK column to set
+            pk_names = [col.name for col in self.table.primary_key.columns]
+            if not pk_names:
+                raise excs.RequestError(
+                    excs.ErrorCode.INVALID_ARGUMENT,
+                    f'{error_prefix}: target table {self.table.name!r} has no primary key; '
+                    f"required for method='update' (note: requires the target dialect's metadata "
+                    f'to expose the primary key)',
+                )
+            missing_pk = [n for n in pk_names if n not in output_schema]
+            if missing_pk:
+                raise excs.RequestError(
+                    excs.ErrorCode.MISSING_REQUIRED,
+                    f"{error_prefix}: response columns must include the target table's primary-key "
+                    f'columns (missing: {missing_pk}). Add them to `outputs`.',
+                )
+            non_pk = [n for n in output_schema if n not in pk_names]
+            if not non_pk:
+                raise excs.RequestError(
+                    excs.ErrorCode.INVALID_ARGUMENT,
+                    f"{error_prefix}: method='update' requires at least one non-primary-key column "
+                    f'in the response columns (got only {pk_names!r})',
+                )
+            # SQLAlchemy reserves bare column names for SET-clause auto-binds, so the WHERE bindparam
+            # uses a 'b_' prefix; we translate the row dict at execute time
+            where = sql.and_(*(self.table.c[n] == sql.bindparam(f'b_{n}') for n in pk_names))
+            self._stmt = self.table.update().where(where).values({n: sql.bindparam(n) for n in non_pk})
+            self._pk_names = pk_names
+        else:
+            self._stmt = self.table.insert()
+            self._pk_names = []
+
+    def export_row(self, row: pydantic.BaseModel) -> None:
+        """Insert or update one response-body row, per spec.method.
+
+        Raises HTTPException(500) on SQL failure.
+        For method='update', also raises HTTPException(500) if the WHERE clause matched zero rows
+        """
+        params = row.model_dump(mode='python')
+        if self.method == 'update':
+            # add prefixed copies of PK values for the WHERE bindparams
+            params = {**params, **{f'b_{n}': params[n] for n in self._pk_names}}
+        try:
+            with self.engine.connect() as conn:
+                result = conn.execute(self._stmt, [params])
+                if self.method == 'update' and result.rowcount != 1:
+                    raise HTTPException(
+                        status_code=500, detail=f'export_sql update affected {result.rowcount} rows; expected 1'
+                    )
+                conn.commit()
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f'export_sql write failed: {e}') from e

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -24,7 +24,6 @@ import sqlalchemy as sql
 from typing_extensions import _AnnotatedAlias
 
 import pixeltable.exceptions as excs
-from pixeltable.env import Env
 from pixeltable.utils import parse_local_file_path
 
 
@@ -879,6 +878,8 @@ class TimestampType(ColumnType):
             raise TypeError(f'Expected datetime.datetime, got {val.__class__.__name__}')
 
     def _create_literal(self, val: Any) -> Any:
+        from pixeltable.env import Env  # local import to avoid circular imports
+
         if isinstance(val, str):
             return datetime.datetime.fromisoformat(val)
         # Place naive timestamps in the default time zone

--- a/pixeltable/utils/sql.py
+++ b/pixeltable/utils/sql.py
@@ -136,19 +136,19 @@ def _check_schema_compatible(
     table: sql.Table, source_schema: dict[str, 'ts.ColumnType'], engine: sql.Engine, error_prefix: str
 ) -> None:
     sample_literals = _sample_literals()
-    for col_name, source_type in source_schema.items():
-        if col_name not in table.c:
-            raise excs.NotFoundError(
-                excs.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}: column {col_name!r} not in table {table.name!r}'
-            )
+    with engine.connect() as conn:
+        for col_name, source_type in source_schema.items():
+            if col_name not in table.c:
+                raise excs.NotFoundError(
+                    excs.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}: column {col_name!r} not in table {table.name!r}'
+                )
 
-        target_type = table.c[col_name].type
-        # CAST(<literal> AS target_type)
-        cast_expr = sql.cast(sample_literals[source_type._type], target_type).label(col_name)
-        # 1 = 0: we only want to check whether the casts are legal, not run anything
-        query = sql.select(cast_expr).where(sql.literal(1) == sql.literal(0))
+            target_type = table.c[col_name].type
+            # CAST(<literal> AS target_type)
+            cast_expr = sql.cast(sample_literals[source_type._type], target_type).label(col_name)
+            # 1 = 0: we only want to check whether the casts are legal, not run anything
+            query = sql.select(cast_expr).where(sql.literal(1) == sql.literal(0))
 
-        with engine.connect() as conn:
             try:
                 conn.execute(query)
             except Exception:

--- a/pixeltable/utils/sql.py
+++ b/pixeltable/utils/sql.py
@@ -139,7 +139,7 @@ def _check_schema_compatible(
     for col_name, source_type in source_schema.items():
         if col_name not in table.c:
             raise excs.NotFoundError(
-                excs.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}Column {col_name!r} not in table {table.name!r}'
+                excs.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}: column {col_name!r} not in table {table.name!r}'
             )
 
         target_type = table.c[col_name].type
@@ -154,8 +154,8 @@ def _check_schema_compatible(
             except Exception:
                 raise excs.RequestError(
                     excs.ErrorCode.TYPE_MISMATCH,
-                    f'{error_prefix}Table {table.name!r}: column {col_name!r} of type {target_type} is not compatible '
-                    f'with the source type ({source_type})',
+                    f'{error_prefix}: in table {table.name!r}, column {col_name!r} of type {target_type} '
+                    f'is not compatible with the source type ({source_type})',
                 ) from None
 
 
@@ -194,7 +194,7 @@ def resolve_table(
         if if_exists == 'error':
             raise excs.AlreadyExistsError(
                 excs.ErrorCode.PATH_ALREADY_EXISTS,
-                f'{error_prefix}Table {table_name!r} already exists in:\n{engine.url}',
+                f'{error_prefix}: table {table_name!r} already exists in:\n{engine.url}',
             )
         metadata = sql.MetaData()
         table = sql.Table(table_name, metadata, schema=schema_name, autoload_with=engine)
@@ -206,6 +206,6 @@ def resolve_table(
 
     if if_not_exists == 'error':
         raise excs.NotFoundError(
-            excs.ErrorCode.PATH_NOT_FOUND, f'{error_prefix}Table {table_name!r} does not exist in:\n{engine.url}'
+            excs.ErrorCode.PATH_NOT_FOUND, f'{error_prefix}: table {table_name!r} does not exist in:\n{engine.url}'
         )
     return _create_table(engine, table_name, schema_name, source_schema)

--- a/pixeltable/utils/sql.py
+++ b/pixeltable/utils/sql.py
@@ -142,6 +142,12 @@ def _check_schema_compatible(
                 raise excs.NotFoundError(
                     excs.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}: column {col_name!r} not in table {table.name!r}'
                 )
+            if source_type._type not in sample_literals:
+                # mirrors the rejection in get_sa_type() for non-scalar source types
+                raise excs.RequestError(
+                    excs.ErrorCode.UNSUPPORTED_OPERATION,
+                    f'{error_prefix}: column {col_name!r} of source type {source_type} cannot be exported',
+                )
 
             target_type = table.c[col_name].type
             # CAST(<literal> AS target_type)

--- a/pixeltable/utils/sql.py
+++ b/pixeltable/utils/sql.py
@@ -1,8 +1,14 @@
+import datetime
 import logging
+import uuid
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import sqlalchemy as sql
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine import URL
+
+if TYPE_CHECKING:
+    import pixeltable.type_system as ts
 
 
 def log_stmt(logger: logging.Logger, stmt: sql.sql.ClauseElement) -> None:
@@ -43,3 +49,161 @@ def add_option_to_db_url(url: str | URL, option: str) -> URL:
 
     # Create new URL with updated options
     return db_url.set(query={**(dict(db_url.query) if db_url.query else {}), 'options': options_str})
+
+
+def _default_sa_type(col_type: 'ts.ColumnType') -> sql.types.TypeEngine:
+    """Default mapping of ColumnType to SQLAlchemy type (matches sqlite, mysql)."""
+    import pixeltable as pxt
+
+    if col_type.is_int_type():
+        return sql.Integer()
+    elif col_type.is_string_type():
+        return sql.String()
+    elif col_type.is_float_type():
+        return sql.Float()
+    elif col_type.is_bool_type():
+        return sql.Boolean()
+    elif col_type.is_timestamp_type():
+        return sql.TIMESTAMP()
+    elif col_type.is_date_type():
+        return sql.Date()
+    elif col_type.is_uuid_type():
+        return sql.UUID()
+    elif col_type.is_binary_type():
+        return sql.LargeBinary()
+    elif col_type.is_json_type():
+        return sql.JSON()
+    raise pxt.RequestError(pxt.ErrorCode.UNSUPPORTED_OPERATION, f'Cannot export column of type {col_type}')
+
+
+def _postgresql_sa_type(col_type: 'ts.ColumnType') -> sql.types.TypeEngine:
+    """Type mapping for dialect 'postgresql'."""
+    if col_type.is_json_type():
+        return sql.dialects.postgresql.JSONB()
+    return _default_sa_type(col_type)
+
+
+def _snowflake_sa_type(col_type: 'ts.ColumnType') -> sql.types.TypeEngine:
+    """Type mapping for dialect 'snowflake'."""
+    from pixeltable.env import Env
+
+    if col_type.is_json_type():
+        Env.get().require_package(
+            'snowflake.sqlalchemy',
+            not_installed_msg='Exporting json data to Snowflake requires the snowflake-sqlalchemy package',
+        )
+        from snowflake.sqlalchemy import VARIANT  # type: ignore[import-untyped]
+
+        return VARIANT()
+    return _default_sa_type(col_type)
+
+
+_DIALECT_TYPE: dict[str, Callable[['ts.ColumnType'], sql.types.TypeEngine]] = {
+    'postgresql': _postgresql_sa_type,
+    'snowflake': _snowflake_sa_type,
+}
+
+
+def get_sa_type(col_type: 'ts.ColumnType', engine: sql.Engine) -> sql.types.TypeEngine:
+    """Resolve a Pixeltable ColumnType to an SQLAlchemy type appropriate for the engine's dialect."""
+    return _DIALECT_TYPE.get(engine.dialect.name, _default_sa_type)(col_type)
+
+
+def table_exists(engine: sql.Engine, table_name: str, schema_name: str | None = None) -> bool:
+    """Check if a table exists in the database."""
+    inspector = sql.inspect(engine)
+    return table_name in inspector.get_table_names(schema=schema_name)
+
+
+def _sample_literals() -> dict[Any, Any]:
+    import pixeltable.type_system as ts
+
+    return {
+        ts.ColumnType.Type.STRING: 'test',
+        ts.ColumnType.Type.INT: 1,
+        ts.ColumnType.Type.FLOAT: 1.0,
+        ts.ColumnType.Type.BOOL: True,
+        # don't reference Env.default_time_zone here, Env may not be initialized yet
+        ts.ColumnType.Type.TIMESTAMP: datetime.datetime.now(tz=datetime.timezone.utc),
+        ts.ColumnType.Type.DATE: datetime.date.today(),
+        ts.ColumnType.Type.UUID: uuid.uuid4(),
+        ts.ColumnType.Type.BINARY: b'test',
+        ts.ColumnType.Type.JSON: {'a': 1, 'b': [2, 3], 'c': {'d': 4}},
+    }
+
+
+def _check_schema_compatible(
+    table: sql.Table, source_schema: dict[str, 'ts.ColumnType'], engine: sql.Engine, error_prefix: str
+) -> None:
+    import pixeltable as pxt
+
+    sample_literals = _sample_literals()
+    for col_name, source_type in source_schema.items():
+        if col_name not in table.c:
+            raise pxt.NotFoundError(
+                pxt.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}Column {col_name!r} not in table {table.name!r}'
+            )
+
+        target_type = table.c[col_name].type
+        # CAST(<literal> AS target_type)
+        cast_expr = sql.cast(sample_literals[source_type._type], target_type).label(col_name)
+        # 1 = 0: we only want to check whether the casts are legal, not run anything
+        query = sql.select(cast_expr).where(sql.literal(1) == sql.literal(0))
+
+        with engine.connect() as conn:
+            try:
+                conn.execute(query)
+            except Exception:
+                raise pxt.RequestError(
+                    pxt.ErrorCode.TYPE_MISMATCH,
+                    f'{error_prefix}Table {table.name!r}: column {col_name!r} of type {target_type} is not compatible '
+                    f'with the source type ({source_type})',
+                ) from None
+
+
+def _create_table(
+    engine: sql.Engine, table_name: str, schema_name: str | None, source_schema: dict[str, 'ts.ColumnType']
+) -> sql.Table:
+    columns = [sql.Column(col_name, get_sa_type(col_type, engine)) for col_name, col_type in source_schema.items()]
+    metadata = sql.MetaData()
+    table = sql.Table(table_name, metadata, *columns, schema=schema_name)
+    table.create(engine, checkfirst=True)
+    return table
+
+
+def resolve_table(
+    *,
+    engine: sql.Engine,
+    table_name: str,
+    schema_name: str | None,
+    source_schema: dict[str, 'ts.ColumnType'],
+    if_exists: Literal['error', 'replace', 'insert'],
+    if_not_exists: Literal['error', 'create'],
+    error_prefix: str,
+) -> sql.Table:
+    """
+    Resolve a target SQLAlchemy table for writes from a Pixeltable source schema.
+
+    - missing                   -> create from source_schema
+    - exists, if_exists=error   -> raise pxt.AlreadyExistsError
+    - exists, if_exists=replace -> drop, then create from source_schema
+    - exists, if_exists=insert  -> autoload and validate compatibility against source_schema
+
+    error_prefix is prepended to raised messages so callers can attribute errors.
+    """
+    import pixeltable as pxt
+
+    if table_exists(engine, table_name, schema_name):
+        if if_exists == 'error':
+            raise pxt.AlreadyExistsError(
+                pxt.ErrorCode.PATH_ALREADY_EXISTS,
+                f'{error_prefix}Table {table_name!r} already exists in:\n{engine.url}',
+            )
+        metadata = sql.MetaData()
+        table = sql.Table(table_name, metadata, schema=schema_name, autoload_with=engine)
+        if if_exists == 'replace':
+            table.drop(engine)
+            return _create_table(engine, table_name, schema_name, source_schema)
+        _check_schema_compatible(table, source_schema, engine, error_prefix)
+        return table
+    return _create_table(engine, table_name, schema_name, source_schema)

--- a/pixeltable/utils/sql.py
+++ b/pixeltable/utils/sql.py
@@ -7,6 +7,8 @@ import sqlalchemy as sql
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine import URL
 
+import pixeltable.exceptions as excs
+
 if TYPE_CHECKING:
     import pixeltable.type_system as ts
 
@@ -53,8 +55,6 @@ def add_option_to_db_url(url: str | URL, option: str) -> URL:
 
 def _default_sa_type(col_type: 'ts.ColumnType') -> sql.types.TypeEngine:
     """Default mapping of ColumnType to SQLAlchemy type (matches sqlite, mysql)."""
-    import pixeltable as pxt
-
     if col_type.is_int_type():
         return sql.Integer()
     elif col_type.is_string_type():
@@ -73,7 +73,7 @@ def _default_sa_type(col_type: 'ts.ColumnType') -> sql.types.TypeEngine:
         return sql.LargeBinary()
     elif col_type.is_json_type():
         return sql.JSON()
-    raise pxt.RequestError(pxt.ErrorCode.UNSUPPORTED_OPERATION, f'Cannot export column of type {col_type}')
+    raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, f'Cannot export column of type {col_type}')
 
 
 def _postgresql_sa_type(col_type: 'ts.ColumnType') -> sql.types.TypeEngine:
@@ -135,13 +135,11 @@ def _sample_literals() -> dict[Any, Any]:
 def _check_schema_compatible(
     table: sql.Table, source_schema: dict[str, 'ts.ColumnType'], engine: sql.Engine, error_prefix: str
 ) -> None:
-    import pixeltable as pxt
-
     sample_literals = _sample_literals()
     for col_name, source_type in source_schema.items():
         if col_name not in table.c:
-            raise pxt.NotFoundError(
-                pxt.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}Column {col_name!r} not in table {table.name!r}'
+            raise excs.NotFoundError(
+                excs.ErrorCode.COLUMN_NOT_FOUND, f'{error_prefix}Column {col_name!r} not in table {table.name!r}'
             )
 
         target_type = table.c[col_name].type
@@ -154,8 +152,8 @@ def _check_schema_compatible(
             try:
                 conn.execute(query)
             except Exception:
-                raise pxt.RequestError(
-                    pxt.ErrorCode.TYPE_MISMATCH,
+                raise excs.RequestError(
+                    excs.ErrorCode.TYPE_MISMATCH,
                     f'{error_prefix}Table {table.name!r}: column {col_name!r} of type {target_type} is not compatible '
                     f'with the source type ({source_type})',
                 ) from None
@@ -184,19 +182,18 @@ def resolve_table(
     """
     Resolve a target SQLAlchemy table for writes from a Pixeltable source schema.
 
-    - missing                   -> create from source_schema
-    - exists, if_exists=error   -> raise pxt.AlreadyExistsError
-    - exists, if_exists=replace -> drop, then create from source_schema
-    - exists, if_exists=insert  -> autoload and validate compatibility against source_schema
+    - exists, if_exists=error: raise AlreadyExistsError
+    - exists, if_exists=replace: drop, then create from source_schema
+    - exists, if_exists=insert: autoload and validate compatibility against source_schema
+    - missing, if_not_exists=create: create from source_schema
+    - missing, if_not_exists=error: raise NotFoundError
 
     error_prefix is prepended to raised messages so callers can attribute errors.
     """
-    import pixeltable as pxt
-
     if table_exists(engine, table_name, schema_name):
         if if_exists == 'error':
-            raise pxt.AlreadyExistsError(
-                pxt.ErrorCode.PATH_ALREADY_EXISTS,
+            raise excs.AlreadyExistsError(
+                excs.ErrorCode.PATH_ALREADY_EXISTS,
                 f'{error_prefix}Table {table_name!r} already exists in:\n{engine.url}',
             )
         metadata = sql.MetaData()
@@ -206,4 +203,9 @@ def resolve_table(
             return _create_table(engine, table_name, schema_name, source_schema)
         _check_schema_compatible(table, source_schema, engine, error_prefix)
         return table
+
+    if if_not_exists == 'error':
+        raise excs.NotFoundError(
+            excs.ErrorCode.PATH_NOT_FOUND, f'{error_prefix}Table {table_name!r} does not exist in:\n{engine.url}'
+        )
     return _create_table(engine, table_name, schema_name, source_schema)

--- a/pixeltable/utils/sql.py
+++ b/pixeltable/utils/sql.py
@@ -88,10 +88,7 @@ def _snowflake_sa_type(col_type: 'ts.ColumnType') -> sql.types.TypeEngine:
     from pixeltable.env import Env
 
     if col_type.is_json_type():
-        Env.get().require_package(
-            'snowflake.sqlalchemy',
-            not_installed_msg='Exporting json data to Snowflake requires the snowflake-sqlalchemy package',
-        )
+        Env.get().require_package('snowflake.sqlalchemy')
         from snowflake.sqlalchemy import VARIANT  # type: ignore[import-untyped]
 
         return VARIANT()

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -1,15 +1,30 @@
+import dataclasses
 import datetime
 import json
 import pathlib
 import uuid
+from typing import Any, Callable
 
 import sqlalchemy as sql
+import sqlalchemy.dialects.postgresql
+import sqlalchemy.dialects.sqlite  # noqa: F401
 
 import pixeltable as pxt
 from pixeltable.env import Env
 from pixeltable.io.sql import export_sql
 
 from ..utils import pxt_raises
+
+
+@dataclasses.dataclass(frozen=True)
+class _DialectSpec:
+    name: str
+    connect: Callable[[pathlib.Path], str]  # tmp_path -> connection string
+    sa_types: dict[str, type]  # pxt col -> SA type for create-table assertions
+    decode: dict[str, Callable[[Any], Any]]  # SA value -> python value comparable to rows[i][col]
+    # if_exists='insert' requires reflecting the target schema, which roundtrips through SA types;
+    # sqlite's UUID -> NUMERIC mismatch makes the compat probe fail, so skip it there.
+    supports_insert: bool = True
 
 
 class TestSql:
@@ -52,25 +67,11 @@ class TestSql:
         t.insert(rows)
         return t, rows
 
-    def validate_schema(self, engine: sql.Engine, table_name: str, expected_columns: dict[str, type]) -> None:
-        inspector = sql.inspect(engine)
-        columns = {col['name']: col['type'] for col in inspector.get_columns(table_name)}
-        assert set(columns.keys()) == set(expected_columns.keys())
-        for col_name, col_type in expected_columns.items():
-            assert type(columns[col_name]) is col_type
-
-    def test_export_sqlite(self, uses_db: None, tmp_path: pathlib.Path) -> None:
-        t, rows = self.create_test_data(100_000)
-        db_path = tmp_path / 'test.db'
-        connection_string = f'sqlite:///{db_path}'
-        engine = sql.create_engine(connection_string)
-
-        # Export full table
-        export_sql(t, 'test_table', db_connect_str=connection_string)
-        self.validate_schema(
-            engine,
-            'test_table',
-            {
+    def _sqlite_spec(self) -> _DialectSpec:
+        return _DialectSpec(
+            name='sqlite',
+            connect=lambda tmp: f'sqlite:///{tmp / "test.db"}',
+            sa_types={
                 'c_int': sql.INTEGER,
                 'c_string': sql.VARCHAR,
                 'c_float': sql.FLOAT,
@@ -81,47 +82,20 @@ class TestSql:
                 'c_binary': sql.BLOB,
                 'c_json': sql.dialects.sqlite.JSON,
             },
+            decode={
+                'c_timestamp': datetime.datetime.fromisoformat,
+                'c_date': datetime.date.fromisoformat,
+                'c_uuid': lambda v: uuid.UUID(hex=v),
+                'c_json': json.loads,
+            },
+            supports_insert=False,
         )
 
-        with engine.connect() as conn:
-            result = conn.execute(sql.text('SELECT * FROM test_table ORDER BY c_int')).fetchall()
-            assert len(result) == len(rows)
-            for col_idx, col_name in [(0, 'c_int'), (1, 'c_string'), (2, 'c_float'), (3, 'c_bool'), (7, 'c_binary')]:
-                assert all(row[col_idx] == rows[i][col_name] for i, row in enumerate(result)), col_name
-
-            assert all(
-                datetime.datetime.fromisoformat(row[4]) == rows[i]['c_timestamp'] for i, row in enumerate(result)
-            )
-            assert all(row[5] == rows[i]['c_date'].isoformat() for i, row in enumerate(result))
-            assert all(row[6] == rows[i]['c_uuid'].hex for i, row in enumerate(result))
-            assert all(json.loads(row[8]) == rows[i]['c_json'] for i, row in enumerate(result))
-
-        # Export subset of columns
-        export_sql(t.select(t.c_int, t.c_string), 'test_table', db_connect_str=connection_string, if_exists='replace')
-        with engine.connect() as conn:
-            result = conn.execute(sql.text('SELECT * FROM test_table ORDER BY c_int')).fetchall()
-            assert len(result) == len(rows)
-            assert all(row[0] == rows[i]['c_int'] and row[1] == rows[i]['c_string'] for i, row in enumerate(result))
-            for col_idx, col_name in enumerate(['c_int', 'c_string']):
-                assert all(row[col_idx] == rows[i][col_name] for i, row in enumerate(result)), col_name
-
-        # Export subset of rows
-        export_sql(t.where(t.c_int < 10), 'test_table', db_connect_str=connection_string, if_exists='replace')
-        with engine.connect() as conn:
-            result = conn.execute(sql.text('SELECT * FROM test_table ORDER BY c_int')).fetchall()
-            assert len(result) == 10
-
-    def test_export_postgresql(self, uses_db: None) -> None:
-        t, rows = self.create_test_data(100_000)
-        connection_string = Env.get().db_url
-        engine = sql.create_engine(connection_string)
-
-        # Export full table
-        export_sql(t, 'test_table', db_connect_str=connection_string)
-        self.validate_schema(
-            engine,
-            'test_table',
-            {
+    def _postgresql_spec(self) -> _DialectSpec:
+        return _DialectSpec(
+            name='postgresql',
+            connect=lambda _: Env.get().db_url,
+            sa_types={
                 'c_int': sql.INTEGER,
                 'c_string': sql.VARCHAR,
                 'c_float': sql.dialects.postgresql.DOUBLE_PRECISION,
@@ -132,36 +106,74 @@ class TestSql:
                 'c_binary': sql.dialects.postgresql.BYTEA,
                 'c_json': sql.dialects.postgresql.JSONB,
             },
+            decode={},
         )
 
-        with engine.connect() as conn:
-            result = conn.execute(sql.text('SELECT * FROM test_table ORDER BY c_int')).fetchall()
-            assert len(result) == len(rows)
-            for col_idx, col_name in enumerate(
-                ['c_int', 'c_string', 'c_float', 'c_bool', 'c_timestamp', 'c_date', 'c_uuid', 'c_binary', 'c_json']
-            ):
-                assert all(row[col_idx] == rows[i][col_name] for i, row in enumerate(result)), col_name
-            # assert bytes(row[7]) == rows[i]['c_binary']
+    def _verify_export(
+        self,
+        engine: sql.Engine,
+        table_name: str,
+        spec: _DialectSpec,
+        rows: list[dict],
+        col_names: list[str] | None = None,
+    ) -> None:
+        """Schema + value verification. col_names defaults to all spec.sa_types keys."""
+        cols = col_names if col_names is not None else list(spec.sa_types.keys())
+        expected = {c: spec.sa_types[c] for c in cols}
+        inspector = sql.inspect(engine)
+        actual = {col['name']: col['type'] for col in inspector.get_columns(table_name)}
+        assert set(actual.keys()) == set(cols)
+        assert all(type(actual[c]) is expected[c] for c in cols)
 
-        # insert into the same table
-        export_sql(t, 'test_table', db_connect_str=connection_string, if_exists='insert')
+        select = ', '.join(cols)
         with engine.connect() as conn:
-            result = conn.execute(sql.text('SELECT * FROM test_table ORDER BY c_int')).fetchall()
-            assert len(result) == 2 * len(rows)
+            result = conn.execute(sql.text(f'SELECT {select} FROM {table_name} ORDER BY c_int')).fetchall()
+        assert len(result) == len(rows)
+        identity = lambda v: v  # noqa: E731
+        for i, row in enumerate(result):
+            for j, c in enumerate(cols):
+                decoded = spec.decode.get(c, identity)(row[j])
+                assert decoded == rows[i][c], (c, i, decoded, rows[i][c])
 
-        # Export subset of columns
-        export_sql(t.select(t.c_int, t.c_string), 'test_table', db_connect_str=connection_string, if_exists='replace')
+    def _row_count(self, engine: sql.Engine, table_name: str) -> int:
         with engine.connect() as conn:
-            result = conn.execute(sql.text('SELECT * FROM test_table ORDER BY c_int')).fetchall()
-            assert len(result) == len(rows)
-            for col_idx, col_name in enumerate(['c_int', 'c_string']):
-                assert all(row[col_idx] == rows[i][col_name] for i, row in enumerate(result)), col_name
+            return conn.execute(sql.text(f'SELECT COUNT(*) FROM {table_name}')).scalar_one()
 
-        # Export subset of rows
-        export_sql(t.where(t.c_int < 10), 'test_table', db_connect_str=connection_string, if_exists='replace')
-        with engine.connect() as conn:
-            result = conn.execute(sql.text('SELECT * FROM test_table ORDER BY c_int')).fetchall()
-            assert len(result) == 10
+    def _run_export_suite(self, spec: _DialectSpec, tmp_path: pathlib.Path) -> None:
+        t, rows = self.create_test_data(100_000)
+        connect = spec.connect(tmp_path)
+        engine = sql.create_engine(connect)
+
+        # full export (default if_not_exists='create')
+        export_sql(t, 'test_table', db_connect_str=connect)
+        self._verify_export(engine, 'test_table', spec, rows)
+
+        # if_exists='insert' appends rows
+        if spec.supports_insert:
+            export_sql(t, 'test_table', db_connect_str=connect, if_exists='insert')
+            assert self._row_count(engine, 'test_table') == 2 * len(rows)
+
+        # if_exists='replace' + subset of columns
+        export_sql(t.select(t.c_int, t.c_string), 'test_table', db_connect_str=connect, if_exists='replace')
+        self._verify_export(engine, 'test_table', spec, rows, col_names=['c_int', 'c_string'])
+
+        # if_exists='replace' + subset of rows
+        export_sql(t.where(t.c_int < 10), 'test_table', db_connect_str=connect, if_exists='replace')
+        assert self._row_count(engine, 'test_table') == 10
+
+        # if_not_exists='error' against missing target
+        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"table 'never' does not exist"):
+            export_sql(t, 'never', db_connect_str=connect, if_not_exists='error')
+
+        # if_not_exists='create' explicit (creates a fresh table)
+        export_sql(t.where(t.c_int < 5), 'fresh_table', db_connect_str=connect, if_not_exists='create')
+        assert self._row_count(engine, 'fresh_table') == 5
+
+    def test_export_sqlite(self, uses_db: None, tmp_path: pathlib.Path) -> None:
+        self._run_export_suite(self._sqlite_spec(), tmp_path)
+
+    def test_export_postgresql(self, uses_db: None, tmp_path: pathlib.Path) -> None:
+        self._run_export_suite(self._postgresql_spec(), tmp_path)
 
     def test_errors(self, uses_db: None) -> None:
         connection_string = Env.get().db_url
@@ -188,7 +200,3 @@ class TestSql:
         t3.insert([{'c_int': {'key': 'value'}}])
         with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match=r"column 'c_int' of type INTEGER"):
             export_sql(t3, 'existing_table', db_connect_str=connection_string, if_exists='insert')
-
-        # missing target with if_not_exists='error'
-        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"table 'never_existed' does not exist"):
-            export_sql(t, 'never_existed', db_connect_str=connection_string, if_not_exists='error')

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -200,3 +200,11 @@ class TestSql:
         t3.insert([{'c_int': {'key': 'value'}}])
         with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match=r"column 'c_int' of type INTEGER"):
             export_sql(t3, 'existing_table', db_connect_str=connection_string, if_exists='insert')
+
+        # non-scalar source type into an existing target column
+        t_str = pxt.create_table('img_target_seed', {'img': pxt.String})
+        t_str.insert([{'img': 'placeholder'}])
+        export_sql(t_str, 'img_target', db_connect_str=connection_string)
+        t_img2 = pxt.create_table('test_img2', {'img': pxt.Image})
+        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match=r"column 'img' of source type Image"):
+            export_sql(t_img2, 'img_target', db_connect_str=connection_string, if_exists='insert')

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -180,11 +180,15 @@ class TestSql:
         # missing column in target table
         t2 = pxt.create_table('test2', {'c_int': pxt.Int, 'c_string': pxt.String, 'extra': pxt.Int})
         t2.insert([{'c_int': 1, 'c_string': 'a', 'extra': 100}])
-        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="Column 'extra' not in table"):
+        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="column 'extra' not in table"):
             export_sql(t2, 'existing_table', db_connect_str=connection_string, if_exists='insert')
 
         # incompatible schema
         t3 = pxt.create_table('test3', {'c_int': pxt.Json})
         t3.insert([{'c_int': {'key': 'value'}}])
-        with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match=r"column 'c_int' of type INTEGER is not compatible"):
+        with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match=r"column 'c_int' of type INTEGER"):
             export_sql(t3, 'existing_table', db_connect_str=connection_string, if_exists='insert')
+
+        # missing target with if_not_exists='error'
+        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"table 'never_existed' does not exist"):
+            export_sql(t, 'never_existed', db_connect_str=connection_string, if_not_exists='error')

--- a/tests/serving/test_config.py
+++ b/tests/serving/test_config.py
@@ -53,7 +53,7 @@ class TestConfig:
                     'path': '/insert-export',
                     'inputs': ['id', 'name'],
                     'outputs': ['id', 'name', 'name_upper'],
-                    'export_sql': {'db_connect': db_connect, 'target_table': 'items_out'},
+                    'export_sql': {'db_connect': db_connect, 'table': 'items_out'},
                 },
                 {
                     'type': 'update',
@@ -198,7 +198,7 @@ class TestConfig:
                     'routes': [
                         {
                             'type': 'insert', 'table': 'd.t', 'path': '/x',
-                            'export_sql': {'db_connect': 'sqlite:///x', 'target_table': 'y', 'typo_key': 'z'},
+                            'export_sql': {'db_connect': 'sqlite:///x', 'table': 'y', 'typo_key': 'z'},
                         }
                     ]
                 },
@@ -210,13 +210,13 @@ class TestConfig:
                     'routes': [
                         {
                             'type': 'insert', 'table': 'd.t', 'path': '/x',
-                            'export_sql': {'db_connect': 'sqlite:///x', 'target_table': 'y', 'method': 'bogus'},
+                            'export_sql': {'db_connect': 'sqlite:///x', 'table': 'y', 'method': 'bogus'},
                         }
                     ]
                 },
                 "input_value='bogus'",
             ),
-            # export_sql: missing target_table
+            # export_sql: missing table
             (
                 {
                     'routes': [
@@ -226,7 +226,7 @@ class TestConfig:
                         }
                     ]
                 },
-                'target_table',
+                r'export_sql\.[^\s]*table',
             ),
         ]  # fmt: skip
 

--- a/tests/serving/test_config.py
+++ b/tests/serving/test_config.py
@@ -1,11 +1,13 @@
 """Tests for TOML-based service configuration and app creation."""
 
 import os
+import pathlib
 import tempfile
 import textwrap
 from typing import Any
 
 import pytest
+import sqlalchemy as sql
 import toml
 
 import pixeltable as pxt
@@ -16,11 +18,12 @@ from pixeltable.serving._config import (
     create_app_from_config,
     load_app_config,
 )
+from tests.serving.test_fastapi import assert_sqlite_row, make_sqlite_target
 from tests.utils import skip_test_if_not_installed
 
 
 class TestConfig:
-    def test_load_valid_config(self, uses_db: None) -> None:
+    def test_load_valid_config(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """Load a valid TOML config, create an app, and exercise the routes via TestClient."""
         skip_test_if_not_installed('fastapi')
         from fastapi.testclient import TestClient
@@ -28,6 +31,11 @@ class TestConfig:
         pxt.create_dir('test_config')
         t = pxt.create_table('test_config.items', {'id': pxt.Required[pxt.Int], 'name': pxt.String}, primary_key='id')
         t.add_computed_column(name_upper=t.name.upper())
+
+        # sqlite target for the export_sql route
+        db_connect = make_sqlite_target(
+            tmp_path / 'export.db', 'items_out', {'id': sql.Integer, 'name': sql.VARCHAR, 'name_upper': sql.VARCHAR}
+        )
 
         config_dict = {
             'service': {'title': 'Test Service', 'port': 9999},
@@ -38,6 +46,14 @@ class TestConfig:
                     'path': '/insert',
                     'inputs': ['id', 'name'],
                     'outputs': ['id', 'name', 'name_upper'],
+                },
+                {
+                    'type': 'insert',
+                    'table': 'test_config.items',
+                    'path': '/insert-export',
+                    'inputs': ['id', 'name'],
+                    'outputs': ['id', 'name', 'name_upper'],
+                    'export_sql': {'db_connect': db_connect, 'target_table': 'items_out'},
                 },
                 {
                     'type': 'update',
@@ -58,7 +74,7 @@ class TestConfig:
             config = load_app_config(config_path)
             assert config.service.title == 'Test Service'
             assert config.service.port == 9999
-            assert len(config.routes) == 3
+            assert len(config.routes) == 4
 
             app = create_app_from_config(config)
             client = TestClient(app)
@@ -70,6 +86,12 @@ class TestConfig:
             assert data['id'] == 1
             assert data['name'] == 'alice'
             assert data['name_upper'] == 'ALICE'
+
+            # insert with export_sql: row should also land in the sqlite target
+            resp = client.post('/insert-export', json={'id': 2, 'name': 'carol'})
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == {'id': 2, 'name': 'carol', 'name_upper': 'CAROL'}
+            assert_sqlite_row(db_connect, 'items_out', {'id': 2}, {'id': 2, 'name': 'carol', 'name_upper': 'CAROL'})
 
             # update: change the name, verify cascade of name_upper
             resp = client.post('/update', json={'id': 1, 'name': 'bob'})
@@ -170,7 +192,43 @@ class TestConfig:
             ({'routes': [{'type': 'insert', 'table': 'd.t', 'path': 'no-slash'}]}, 'path'),
             # prefix missing leading slash
             ({'service': {'prefix': 'api'}, 'routes': [{'type': 'insert', 'table': 'd.t', 'path': '/x'}]}, 'prefix'),
-        ]
+            # export_sql: unknown nested key
+            (
+                {
+                    'routes': [
+                        {
+                            'type': 'insert', 'table': 'd.t', 'path': '/x',
+                            'export_sql': {'db_connect': 'sqlite:///x', 'target_table': 'y', 'typo_key': 'z'},
+                        }
+                    ]
+                },
+                'typo_key',
+            ),
+            # export_sql: invalid method
+            (
+                {
+                    'routes': [
+                        {
+                            'type': 'insert', 'table': 'd.t', 'path': '/x',
+                            'export_sql': {'db_connect': 'sqlite:///x', 'target_table': 'y', 'method': 'bogus'},
+                        }
+                    ]
+                },
+                "input_value='bogus'",
+            ),
+            # export_sql: missing target_table
+            (
+                {
+                    'routes': [
+                        {
+                            'type': 'insert', 'table': 'd.t', 'path': '/x',
+                            'export_sql': {'db_connect': 'sqlite:///x'},
+                        }
+                    ]
+                },
+                'target_table',
+            ),
+        ]  # fmt: skip
 
         for config_dict, expected_substring in cases:
             with tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False, encoding='utf-8') as f:

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -5,6 +5,7 @@ import time
 from typing import Any, Callable
 
 import pytest
+import sqlalchemy as sql
 
 import pixeltable as pxt
 import pixeltable.functions.json as pxt_json
@@ -97,11 +98,38 @@ def assert_fileresponse_ok(resp: Any, local_path: str, mime_prefix: str) -> None
         assert resp.content == f.read()
 
 
+def make_sqlite_target(db_path: pathlib.Path, table_name: str, columns: dict[str, type[sql.types.TypeEngine]]) -> str:
+    """Pre-create a sqlite table; return the SQLAlchemy connect string."""
+    connect = f'sqlite:///{db_path}'
+    eng = sql.create_engine(connect)
+    sql.Table(table_name, sql.MetaData(), *[sql.Column(name, sa_type()) for name, sa_type in columns.items()]).create(
+        eng
+    )
+    eng.dispose()
+    return connect
+
+
+def assert_sqlite_row(connect: str, table_name: str, where: dict[str, Any], expected: dict[str, Any]) -> None:
+    """SELECT a row matching `where` and assert each `expected` column equals.
+    JSON columns store as text in sqlite; decode dict/list values lazily."""
+    eng = sql.create_engine(connect)
+    try:
+        clause = ' AND '.join(f'{c} = :{c}' for c in where)
+        with eng.connect() as conn:
+            row = conn.execute(sql.text(f'SELECT * FROM {table_name} WHERE {clause}'), where).mappings().fetchone()
+    finally:
+        eng.dispose()
+    assert row is not None, f'no row in {table_name} matching {where}'
+    for k, v in expected.items():
+        actual = json.loads(row[k]) if isinstance(v, (dict, list)) else row[k]
+        assert actual == v, (k, actual, v)
+
+
 class TestFastAPI:
-    def test_add_insert_route_scalars(self, uses_db: None) -> None:
+    def test_add_insert_route_scalars(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """Test insert routes with all scalar types and various input/output combinations."""
         skip_test_if_not_installed('fastapi')
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
         t = pxt.create_table(
@@ -120,15 +148,41 @@ class TestFastAPI:
         t.add_computed_column(float_abs=t.float_col.abs())
         t.add_computed_column(json_str=pxt_json.dumps(t.json_col))
 
+        # sqlite targets for export_sql coverage
+        db_path = tmp_path / 'export.db'
+        all_cols: dict[str, type[sql.types.TypeEngine]] = {
+            'id': sql.Integer,
+            'str_col': sql.VARCHAR,
+            'int_col': sql.Integer,
+            'float_col': sql.Float,
+            'bool_col': sql.Boolean,
+            'json_col': sql.JSON,
+            'str_upper': sql.VARCHAR,
+            'int_plus1': sql.Integer,
+            'float_abs': sql.Float,
+            'json_str': sql.VARCHAR,
+        }
+        db_connect = make_sqlite_target(db_path, 'out_all', all_cols)
+        make_sqlite_target(db_path, 'out_minimal', {'int_plus1': sql.Integer})
+
         router = FastAPIRouter()
-        # default inputs and outputs
-        router.add_insert_route(t, path='/all')
+        # default inputs and outputs; with export_sql to out_all
+        router.add_insert_route(t, path='/all', export_sql=SqlExport(db_connect=db_connect, target_table='out_all'))
         # subset of inputs, all outputs
         router.add_insert_route(t, path='/partial-in', inputs=['id', 'str_col', 'int_col'])
         # all inputs, subset of outputs
         router.add_insert_route(t, path='/partial-out', outputs=['id', 'str_upper', 'int_plus1'])
-        # minimal inputs and outputs
-        router.add_insert_route(t, path='/minimal', inputs=['id', 'int_col'], outputs=['int_plus1'])
+        # minimal inputs and outputs; with export_sql to out_minimal (same db_connect)
+        router.add_insert_route(
+            t,
+            path='/minimal',
+            inputs=['id', 'int_col'],
+            outputs=['int_plus1'],
+            export_sql=SqlExport(db_connect=db_connect, target_table='out_minimal'),
+        )
+        # engine cache reuse: two export_sql routes against the same db_connect share one engine
+        assert len(router._engine_cache) == 1
+
         client = make_test_client(router)
 
         all_input = {
@@ -156,6 +210,7 @@ class TestFastAPI:
         assert resp.json() == expected
         row = t.where(t.id == 1).collect()[0]
         assert row == expected
+        assert_sqlite_row(db_connect, 'out_all', {'id': 1}, expected)
 
         resp = client.post('/partial-in', json={'id': 2, 'str_col': 'world', 'int_col': 10})
         assert resp.status_code == 200, resp.text
@@ -189,6 +244,11 @@ class TestFastAPI:
         assert resp.json() == expected
         row = t.where(t.id == 4).select(t.int_plus1).collect()[0]
         assert row == expected
+        assert_sqlite_row(db_connect, 'out_minimal', {'int_plus1': 100}, expected)
+
+        # shutdown disposes the engine cache
+        router._shutdown()
+        assert router._engine_cache == {}
 
     @pytest.mark.parametrize('use_uploadfile', [True, False])
     def test_add_insert_route_video(self, uses_db: None, use_uploadfile: bool) -> None:
@@ -267,11 +327,11 @@ class TestFastAPI:
         assert_fileresponse_ok(resp, thumbnail_path, 'image/')
 
     @pytest.mark.parametrize('use_uploadfile', [True, False])
-    def test_add_insert_route_image(self, uses_db: None, use_uploadfile: bool) -> None:
+    def test_add_insert_route_image(self, uses_db: None, use_uploadfile: bool, tmp_path: pathlib.Path) -> None:
         """Image counterpart of test_add_insert_route_video. Structurally parallel so the two
         tests can later be generalized over a media-kind fixture."""
         skip_test_if_not_installed('fastapi')
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         image_path = get_image_files()[0]
         pxt.create_dir('test_serve')
@@ -287,13 +347,33 @@ class TestFastAPI:
         # rotated: uses neither scalar input (mirrors video.extract_frame(timestamp=0.0))
         t.add_computed_column(rotated=t.image.rotate(angle=90))
 
+        # sqlite target with media columns as VARCHAR; exercises SqlExporter media->String coercion
+        db_connect = make_sqlite_target(
+            tmp_path / 'export.db',
+            'img_out',
+            {
+                'id': sql.Integer,
+                'image': sql.VARCHAR,
+                'width': sql.Integer,
+                'height': sql.Integer,
+                'resized': sql.VARCHAR,
+                'rotated': sql.VARCHAR,
+            },
+        )
+
         router = FastAPIRouter()
         # When uploading, 'image' moves from inputs into uploadfile_inputs. Other inputs
         # (defaulted for /all, explicit for /resize and /rotate) become Form fields
         # automatically once any upload is present.
         uploadfile_inputs = ['image'] if use_uploadfile else None
-        # /all: defaults for inputs/outputs (uploadfile_inputs still moves `image` into File)
-        router.add_insert_route(t, path='/all', uploadfile_inputs=uploadfile_inputs)
+        # /all: defaults for inputs/outputs (uploadfile_inputs still moves `image` into File);
+        # exports to sqlite to exercise the media->String coercion for both raw and computed media
+        router.add_insert_route(
+            t,
+            path='/all',
+            uploadfile_inputs=uploadfile_inputs,
+            export_sql=SqlExport(db_connect=db_connect, target_table='img_out'),
+        )
         # /resize: id + image + width + height, only resized image output
         router.add_insert_route(
             t,
@@ -340,6 +420,20 @@ class TestFastAPI:
         # verify persisted row
         row = t.where(t.id == 1).select(t.id, t.width, t.height).collect()[0]
         assert row == {'id': 1, 'width': 128, 'height': 96}
+        # verify the row landed in the sqlite target with the same media URLs as the response body
+        assert_sqlite_row(
+            db_connect,
+            'img_out',
+            {'id': 1},
+            {
+                'id': 1,
+                'image': result['image'],
+                'width': 128,
+                'height': 96,
+                'resized': result['resized'],
+                'rotated': result['rotated'],
+            },
+        )
 
         # route /resize: FileResponse with resized image; response bytes must match the stored file
         resp = post('/resize', 2, width=64, height=48)
@@ -440,11 +534,11 @@ class TestFastAPI:
         assert_fileresponse_ok(resp, normalized_path, 'audio/')
 
     @pytest.mark.parametrize('use_uploadfile', [True, False])
-    def test_add_insert_route_video_bg(self, uses_db: None, use_uploadfile: bool) -> None:
+    def test_add_insert_route_video_bg(self, uses_db: None, use_uploadfile: bool, tmp_path: pathlib.Path) -> None:
         """Background variant of test_add_insert_route_video: POST returns a job id/url, the
         work runs in FastAPIRouter._executor, and the result is fetched via /jobs/{id}."""
         skip_test_if_not_installed('fastapi')
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         video_path = get_video_files()[0]
         pxt.create_dir('test_serve')
@@ -458,11 +552,16 @@ class TestFastAPI:
         # between the POST and the first GET and we wouldn't exercise the polling path.
         t.add_computed_column(delay=sleep(1.0))
 
+        # sqlite target for the /resize route: confirms background + export_sql works end-to-end
+        # (the SQL write happens in the worker thread after the pxt insert commits).
+        db_connect = make_sqlite_target(tmp_path / 'export.db', 'bg_resize', {'resized': sql.VARCHAR})
+
         router = FastAPIRouter()
         uploadfile_inputs = ['video'] if use_uploadfile else None
         # /all: defaults for inputs/outputs, all columns in the response
         router.add_insert_route(t, path='/all', uploadfile_inputs=uploadfile_inputs, background=True)
-        # /resize: single-output JSON response (no FileResponse - mutually exclusive with background)
+        # /resize: single-output JSON response (no FileResponse - mutually exclusive with background);
+        # also exports to sqlite to cover the background + export_sql combination
         router.add_insert_route(
             t,
             path='/resize',
@@ -470,6 +569,7 @@ class TestFastAPI:
             uploadfile_inputs=uploadfile_inputs,
             outputs=['resized'],
             background=True,
+            export_sql=SqlExport(db_connect=db_connect, target_table='bg_resize'),
         )
         client = make_test_client(router)
         media_dir = str(Env.get().media_dir)
@@ -506,6 +606,8 @@ class TestFastAPI:
         assert set(result.keys()) == {'resized'}, result
         resize_local = t.where(t.id == 2).select(p=t.resized.localpath).collect()[0]['p']
         assert_media_fetchable(client, result['resized'], resize_local)
+        # SQL write happened in the worker thread; the URL string in sqlite matches the response
+        assert_sqlite_row(db_connect, 'bg_resize', {'resized': result['resized']}, {'resized': result['resized']})
 
     def test_openapi(self, uses_db: None) -> None:
         """Verify the generated OpenAPI schema reflects column comments, column types, and route shapes."""
@@ -1013,10 +1115,10 @@ class TestFastAPI:
                 t,
                 path='/e',
                 outputs=['id'],
-                export_sql=SqlExport(db_connect=db_connect, target_table='out', target_schema=None, method='merge'),
+                export_sql=SqlExport(db_connect=db_connect, target_table='out', method='merge'),
             )
 
-        spec_insert = SqlExport(db_connect=db_connect, target_table='out', target_schema=None, method='insert')
+        spec_insert = SqlExport(db_connect=db_connect, target_table='out')
         with pxt_raises(
             pxt.ErrorCode.INVALID_ARGUMENT, match='export_sql and return_fileresponse are mutually exclusive'
         ):
@@ -1032,22 +1134,12 @@ class TestFastAPI:
 
         with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match="column 'id'"):
             router.add_insert_route(
-                t,
-                path='/e',
-                outputs=['id'],
-                export_sql=SqlExport(
-                    db_connect=db_connect, target_table='out_bad', target_schema=None, method='insert'
-                ),
+                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='out_bad')
             )
 
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="column 'id' not in table"):
             router.add_insert_route(
-                t,
-                path='/e',
-                outputs=['id'],
-                export_sql=SqlExport(
-                    db_connect=db_connect, target_table='out_missing', target_schema=None, method='insert'
-                ),
+                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='out_missing')
             )
 
     def test_insert_route(self, uses_db: None) -> None:

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -1331,12 +1331,12 @@ class TestFastAPI:
             def _bad(*, id: int) -> BadResponse:
                 return BadResponse(x=id)
 
-    def test_update_route_type_validation(self, uses_db: None) -> None:
+    def test_update_route_type_validation(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """Update-route parameter annotations are validated against column types (strict nullability)."""
         skip_test_if_not_installed('fastapi')
         import pydantic
 
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
         t = pxt.create_table('test_serve.types', {'id': pxt.Required[pxt.Int], 'prompt': pxt.String}, primary_key='id')
@@ -1382,6 +1382,24 @@ class TestFastAPI:
         @router.update_route(t, path='/ok2', outputs=['length'])
         def _ok2(*, length: int | None) -> R:
             return R(x=length or 0)
+
+        # export_sql + response model field with an annotation from_python_type can't interpret
+        class CustomThing:
+            pass
+
+        class BadResponse(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            x: int
+            weird: CustomThing | None = None
+
+        db_connect = make_sqlite_target(tmp_path / 'export.db', 'bad', {'x': sql.Integer, 'weird': sql.VARCHAR})
+        with pxt_raises(pxt.ErrorCode.INVALID_TYPE, match="cannot interpret response field 'weird'"):
+
+            @router.update_route(
+                t, path='/e_export', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='bad')
+            )
+            def _bad(*, id: int) -> BadResponse:
+                return BadResponse(x=id)
 
     def test_route_decorators_future_annotations(self, uses_db: None) -> None:
         """Decorated function defined in a module with `from __future__ import annotations`.
@@ -1626,10 +1644,10 @@ class TestFastAPI:
             def _(*, id: int):  # type: ignore[no-untyped-def]  # intentionally missing return annotation
                 return {'x': id}
 
-    def test_add_update_route(self, uses_db: None) -> None:
+    def test_add_update_route(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """Update routes: JSON, subset inputs/outputs, FileResponse, 404 for missing row, background."""
         skip_test_if_not_installed('fastapi')
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         image_path = get_image_files()[0]
         pxt.create_dir('test_serve')
@@ -1647,6 +1665,20 @@ class TestFastAPI:
             ]
         )
 
+        # sqlite target keyed on id, pre-populated with a baseline row for id=1; method='update'
+        # exports the post-update response as an UPDATE on the target keyed by id.
+        db_connect = make_sqlite_target(
+            tmp_path / 'export.db',
+            'items_out',
+            {'id': sql.Integer, 'text': sql.VARCHAR, 'value': sql.Integer, 'text_upper': sql.VARCHAR},
+            pk_cols=['id'],
+        )
+        eng = sql.create_engine(db_connect)
+        with eng.connect() as conn:
+            conn.execute(sql.text("INSERT INTO items_out (id, text, value, text_upper) VALUES (1, 'OLD', 0, 'OLD')"))
+            conn.commit()
+        eng.dispose()
+
         router = FastAPIRouter()
         # /all: default inputs (text + value, excludes PK, computed, and media), all outputs
         router.add_update_route(t, path='/all')
@@ -1656,6 +1688,14 @@ class TestFastAPI:
         router.add_update_route(t, path='/thumb', inputs=['value'], outputs=['thumb'], return_fileresponse=True)
         # /bg: background variant
         router.add_update_route(t, path='/bg', inputs=['value'], background=True)
+        # /export: pxt update -> SQL UPDATE keyed on id
+        router.add_update_route(
+            t,
+            path='/export',
+            inputs=['text', 'value'],
+            outputs=['id', 'text', 'value', 'text_upper'],
+            export_sql=SqlExport(db_connect=db_connect, target_table='items_out', method='update'),
+        )
         client = make_test_client(router)
 
         # /all: update row 1 (text + value; image excluded from default inputs)
@@ -1690,9 +1730,22 @@ class TestFastAPI:
         assert result['value'] == 42
         assert t.where(t.id == 1).select(t.value).collect()[0] == {'value': 42}
 
-    def test_add_update_route_errors(self, uses_db: None) -> None:
+        # /export: pxt update + SQL UPDATE on the target keyed on id (id=1 pre-populated)
+        resp = client.post('/export', json={'id': 1, 'text': 'fresh', 'value': 7})
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {'id': 1, 'text': 'fresh', 'value': 7, 'text_upper': 'FRESH'}
+        assert_sqlite_row(
+            db_connect, 'items_out', {'id': 1}, {'id': 1, 'text': 'fresh', 'value': 7, 'text_upper': 'FRESH'}
+        )
+
+        # /export against id=2 (not in the target): pxt update succeeds, SQL UPDATE matches zero rows -> 500
+        resp = client.post('/export', json={'id': 2, 'text': 'ghost', 'value': 0})
+        assert resp.status_code == 500, resp.text
+        assert 'expected 1' in resp.json()['detail']
+
+    def test_add_update_route_errors(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         skip_test_if_not_installed('fastapi')
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
         t = pxt.create_table(
@@ -1722,12 +1775,26 @@ class TestFastAPI:
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='exactly one media-typed output column'):
             router.add_update_route(t, path='/e', outputs=['text'], return_fileresponse=True)
 
-    def test_update_route(self, uses_db: None) -> None:
+        # export_sql + return_fileresponse: mutex (one case; SqlExporter validations are covered
+        # exhaustively by test_add_insert_route_errors -- same code path)
+        db_connect = make_sqlite_target(tmp_path / 'export.db', 'tgt', {'image': sql.VARCHAR}, pk_cols=[])
+        with pxt_raises(
+            pxt.ErrorCode.INVALID_ARGUMENT, match='export_sql and return_fileresponse are mutually exclusive'
+        ):
+            router.add_update_route(
+                t,
+                path='/e',
+                outputs=['image'],
+                return_fileresponse=True,
+                export_sql=SqlExport(db_connect=db_connect, target_table='tgt'),
+            )
+
+    def test_update_route(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """`update_route()` decorator: custom response model, 404, background, function still callable."""
         skip_test_if_not_installed('fastapi')
         import pydantic
 
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
         t = pxt.create_table(
@@ -1736,6 +1803,11 @@ class TestFastAPI:
         t.add_computed_column(text_upper=t.text.upper())
         t.insert([{'id': 1, 'text': 'hello', 'value': 10}, {'id': 2, 'text': 'world', 'value': 20}])
 
+        # sqlite target whose columns match UpdateResp's fields
+        db_connect = make_sqlite_target(
+            tmp_path / 'export.db', 'upd_out', {'key': sql.Integer, 'upper': sql.VARCHAR, 'doubled': sql.Integer}
+        )
+
         router = FastAPIRouter()
 
         class UpdateResp(pydantic.BaseModel):
@@ -1743,7 +1815,13 @@ class TestFastAPI:
             upper: str
             doubled: int
 
-        @router.update_route(t, path='/update', inputs=['text', 'value'], outputs=['id', 'text_upper', 'value'])
+        @router.update_route(
+            t,
+            path='/update',
+            inputs=['text', 'value'],
+            outputs=['id', 'text_upper', 'value'],
+            export_sql=SqlExport(db_connect=db_connect, target_table='upd_out'),
+        )
         def format_response(*, id: int, text_upper: str | None, value: int | None) -> UpdateResp:
             assert text_upper is not None and value is not None
             return UpdateResp(key=id, upper=text_upper, doubled=value * 2)
@@ -1760,6 +1838,8 @@ class TestFastAPI:
         assert resp.status_code == 200, resp.text
         assert resp.json() == {'key': 1, 'upper': 'UPDATED', 'doubled': 198}
         assert t.where(t.id == 1).select(t.text, t.value).collect()[0] == {'text': 'updated', 'value': 99}
+        # the user fn's response model fields landed in sqlite
+        assert_sqlite_row(db_connect, 'upd_out', {'key': 1}, {'key': 1, 'upper': 'UPDATED', 'doubled': 198})
 
         # 404 for missing row
         resp = client.post('/update', json={'id': 9999, 'text': 'x', 'value': 0})

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -98,13 +98,21 @@ def assert_fileresponse_ok(resp: Any, local_path: str, mime_prefix: str) -> None
         assert resp.content == f.read()
 
 
-def make_sqlite_target(db_path: pathlib.Path, table_name: str, columns: dict[str, type[sql.types.TypeEngine]]) -> str:
+def make_sqlite_target(
+    db_path: pathlib.Path,
+    table_name: str,
+    columns: dict[str, type[sql.types.TypeEngine]],
+    pk_cols: list[str] | None = None,
+) -> str:
     """Pre-create a sqlite table; return the SQLAlchemy connect string."""
     connect = f'sqlite:///{db_path}'
     eng = sql.create_engine(connect)
-    sql.Table(table_name, sql.MetaData(), *[sql.Column(name, sa_type()) for name, sa_type in columns.items()]).create(
-        eng
-    )
+    pk_set = set(pk_cols or [])
+    sql.Table(
+        table_name,
+        sql.MetaData(),
+        *[sql.Column(name, sa_type(), primary_key=name in pk_set) for name, sa_type in columns.items()],
+    ).create(eng)
     eng.dispose()
     return connect
 
@@ -164,6 +172,18 @@ class TestFastAPI:
         }
         db_connect = make_sqlite_target(db_path, 'out_all', all_cols)
         make_sqlite_target(db_path, 'out_minimal', {'int_plus1': sql.Integer})
+        # update-mode target: PK on id, pre-populated with a baseline row keyed on id=42
+        make_sqlite_target(
+            db_path,
+            'out_update',
+            {'id': sql.Integer, 'str_upper': sql.VARCHAR, 'int_plus1': sql.Integer},
+            pk_cols=['id'],
+        )
+        eng = sql.create_engine(db_connect)
+        with eng.connect() as conn:
+            conn.execute(sql.text("INSERT INTO out_update (id, str_upper, int_plus1) VALUES (42, 'OLD', 0)"))
+            conn.commit()
+        eng.dispose()
 
         router = FastAPIRouter()
         # default inputs and outputs; with export_sql to out_all
@@ -180,7 +200,15 @@ class TestFastAPI:
             outputs=['int_plus1'],
             export_sql=SqlExport(db_connect=db_connect, target_table='out_minimal'),
         )
-        # engine cache reuse: two export_sql routes against the same db_connect share one engine
+        # update-mode export: pxt insert triggers a UPDATE on the target keyed on id
+        router.add_insert_route(
+            t,
+            path='/update',
+            inputs=['id', 'str_col', 'int_col'],
+            outputs=['id', 'str_upper', 'int_plus1'],
+            export_sql=SqlExport(db_connect=db_connect, target_table='out_update', method='update'),
+        )
+        # engine cache reuse: three export_sql routes against the same db_connect share one engine
         assert len(router._engine_cache) == 1
 
         client = make_test_client(router)
@@ -245,6 +273,19 @@ class TestFastAPI:
         row = t.where(t.id == 4).select(t.int_plus1).collect()[0]
         assert row == expected
         assert_sqlite_row(db_connect, 'out_minimal', {'int_plus1': 100}, expected)
+
+        # method='update': pxt insert triggers UPDATE of the existing target row keyed on id=42
+        resp = client.post('/update', json={'id': 42, 'str_col': 'fresh', 'int_col': 7})
+        assert resp.status_code == 200, resp.text
+        expected = {'id': 42, 'str_upper': 'FRESH', 'int_plus1': 8}
+        assert resp.json() == expected
+        # the baseline ('OLD', 0) was replaced by the new values
+        assert_sqlite_row(db_connect, 'out_update', {'id': 42}, expected)
+
+        # method='update' against an id that doesn't exist in the target -> HTTP 500 (zero rowcount)
+        resp = client.post('/update', json={'id': 999, 'str_col': 'ghost', 'int_col': 0})
+        assert resp.status_code == 500, resp.text
+        assert 'expected 1' in resp.json()['detail']
 
         # shutdown disposes the engine cache
         router._shutdown()
@@ -1140,6 +1181,37 @@ class TestFastAPI:
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="column 'id' not in table"):
             router.add_insert_route(
                 t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='out_missing')
+            )
+
+        # method='update' validation: target needs a PK
+        make_sqlite_target(tmp_path / 'export.db', 'no_pk', {'id': sql.Integer, 'text_upper': sql.VARCHAR})
+        with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='has no primary key'):
+            router.add_insert_route(
+                t,
+                path='/e',
+                outputs=['id', 'text_upper'],
+                export_sql=SqlExport(db_connect=db_connect, target_table='no_pk', method='update'),
+            )
+
+        # method='update' validation: response columns must include the PK
+        make_sqlite_target(
+            tmp_path / 'export.db', 'with_pk', {'id': sql.Integer, 'text_upper': sql.VARCHAR}, pk_cols=['id']
+        )
+        with pxt_raises(pxt.ErrorCode.MISSING_REQUIRED, match=r"missing: \['id'\]"):
+            router.add_insert_route(
+                t,
+                path='/e',
+                outputs=['text_upper'],
+                export_sql=SqlExport(db_connect=db_connect, target_table='with_pk', method='update'),
+            )
+
+        # method='update' validation: at least one non-PK column must be present
+        with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='at least one non-primary-key column'):
+            router.add_insert_route(
+                t,
+                path='/e',
+                outputs=['id'],
+                export_sql=SqlExport(db_connect=db_connect, target_table='with_pk', method='update'),
             )
 
     def test_insert_route(self, uses_db: None, tmp_path: pathlib.Path) -> None:

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -1142,17 +1142,20 @@ class TestFastAPI:
                 t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='out_missing')
             )
 
-    def test_insert_route(self, uses_db: None) -> None:
+    def test_insert_route(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """`insert_route()` as a decorator: user fn consumes inserted outputs and shapes the response."""
         skip_test_if_not_installed('fastapi')
         import pydantic
 
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
         t = pxt.create_table('test_serve.decorated', {'id': pxt.Int, 'prompt': pxt.String})
         t.add_computed_column(greeting='hello, ' + t.prompt)
         t.add_computed_column(length=t.prompt.len())
+
+        # sqlite target whose columns match the user pydantic response model fields
+        db_connect = make_sqlite_target(tmp_path / 'export.db', 'gen_out', {'tag': sql.VARCHAR, 'size': sql.Integer})
 
         router = FastAPIRouter()
 
@@ -1160,7 +1163,13 @@ class TestFastAPI:
             tag: str
             size: int
 
-        @router.insert_route(t, path='/generate', inputs=['id', 'prompt'], outputs=['greeting', 'length'])
+        @router.insert_route(
+            t,
+            path='/generate',
+            inputs=['id', 'prompt'],
+            outputs=['greeting', 'length'],
+            export_sql=SqlExport(db_connect=db_connect, target_table='gen_out'),
+        )
         def format_response(*, greeting: str | None, length: int | None) -> GenResponse:
             assert greeting is not None and length is not None
             return GenResponse(tag=greeting.upper(), size=length * 2)
@@ -1172,17 +1181,19 @@ class TestFastAPI:
         assert resp.status_code == 200, resp.text
         assert resp.json() == {'tag': 'HELLO, WORLD', 'size': 10}
         assert t.where(t.id == 1).count() == 1
+        # the decorator's response model fields landed in sqlite
+        assert_sqlite_row(db_connect, 'gen_out', {'tag': 'HELLO, WORLD'}, {'tag': 'HELLO, WORLD', 'size': 10})
 
         # decorator should return the function unchanged (callable for unit tests)
         direct = format_response(greeting='hi', length=2)
         assert isinstance(direct, GenResponse) and direct.tag == 'HI' and direct.size == 4
 
-    def test_insert_route_type_validation(self, uses_db: None) -> None:
+    def test_insert_route_type_validation(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """Parameter annotations are validated against the column types (strict nullability)."""
         skip_test_if_not_installed('fastapi')
         import pydantic
 
-        from pixeltable.serving import FastAPIRouter
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
         t = pxt.create_table('test_serve.types', {'id': pxt.Required[pxt.Int], 'prompt': pxt.String})
@@ -1229,6 +1240,24 @@ class TestFastAPI:
         @router.insert_route(t, path='/ok2', outputs=['length'])
         def _ok2(*, length: int | None) -> R:
             return R(x=length or 0)
+
+        # export_sql + response model field with an annotation from_python_type can't interpret
+        class CustomClass:
+            pass
+
+        class BadResponse(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+            x: int
+            weird: CustomClass | None = None
+
+        db_connect = make_sqlite_target(tmp_path / 'export.db', 'bad', {'x': sql.Integer, 'weird': sql.VARCHAR})
+        with pxt_raises(pxt.ErrorCode.INVALID_TYPE, match="cannot interpret response field 'weird'"):
+
+            @router.insert_route(
+                t, path='/e_export', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='bad')
+            )
+            def _bad(*, id: int) -> BadResponse:
+                return BadResponse(x=id)
 
     def test_update_route_type_validation(self, uses_db: None) -> None:
         """Update-route parameter annotations are validated against column types (strict nullability)."""

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 import time
 from typing import Any, Callable
 
@@ -957,9 +958,11 @@ class TestFastAPI:
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='GET endpoints cannot have uploadfile_inputs'):
             router.add_query_route(path='/e', query=by_image, uploadfile_inputs=['img'], method='get')
 
-    def test_add_insert_route_errors(self, uses_db: None) -> None:
+    def test_add_insert_route_errors(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         skip_test_if_not_installed('fastapi')
-        from pixeltable.serving import FastAPIRouter
+        import sqlalchemy as sql
+
+        from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
         t = pxt.create_table(
@@ -1001,6 +1004,51 @@ class TestFastAPI:
             router.add_insert_route(t, path='/e', outputs=['id', 'frame'], return_fileresponse=True)
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='exactly one media-typed output column'):
             router.add_insert_route(t, path='/e', outputs=['text_upper'], return_fileresponse=True)
+
+        # export_sql validation
+        db_connect = f'sqlite:///{tmp_path / "export.db"}'
+
+        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match="'merge' is not yet supported"):
+            router.add_insert_route(
+                t,
+                path='/e',
+                outputs=['id'],
+                export_sql=SqlExport(db_connect=db_connect, target_table='out', target_schema=None, method='merge'),
+            )
+
+        spec_insert = SqlExport(db_connect=db_connect, target_table='out', target_schema=None, method='insert')
+        with pxt_raises(
+            pxt.ErrorCode.INVALID_ARGUMENT, match='export_sql and return_fileresponse are mutually exclusive'
+        ):
+            router.add_insert_route(t, path='/e', outputs=['frame'], return_fileresponse=True, export_sql=spec_insert)
+        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match="table 'out' does not exist"):
+            router.add_insert_route(t, path='/e', outputs=['id'], export_sql=spec_insert)
+
+        # pre-create incompatible target tables for the remaining cases
+        eng = sql.create_engine(db_connect)
+        sql.Table('out_bad', sql.MetaData(), sql.Column('id', sql.Date())).create(eng)
+        sql.Table('out_missing', sql.MetaData(), sql.Column('other', sql.Integer())).create(eng)
+        eng.dispose()
+
+        with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match="column 'id'"):
+            router.add_insert_route(
+                t,
+                path='/e',
+                outputs=['id'],
+                export_sql=SqlExport(
+                    db_connect=db_connect, target_table='out_bad', target_schema=None, method='insert'
+                ),
+            )
+
+        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="column 'id' not in table"):
+            router.add_insert_route(
+                t,
+                path='/e',
+                outputs=['id'],
+                export_sql=SqlExport(
+                    db_connect=db_connect, target_table='out_missing', target_schema=None, method='insert'
+                ),
+            )
 
     def test_insert_route(self, uses_db: None) -> None:
         """`insert_route()` as a decorator: user fn consumes inserted outputs and shapes the response."""

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -187,7 +187,7 @@ class TestFastAPI:
 
         router = FastAPIRouter()
         # default inputs and outputs; with export_sql to out_all
-        router.add_insert_route(t, path='/all', export_sql=SqlExport(db_connect=db_connect, target_table='out_all'))
+        router.add_insert_route(t, path='/all', export_sql=SqlExport(db_connect=db_connect, table='out_all'))
         # subset of inputs, all outputs
         router.add_insert_route(t, path='/partial-in', inputs=['id', 'str_col', 'int_col'])
         # all inputs, subset of outputs
@@ -198,7 +198,7 @@ class TestFastAPI:
             path='/minimal',
             inputs=['id', 'int_col'],
             outputs=['int_plus1'],
-            export_sql=SqlExport(db_connect=db_connect, target_table='out_minimal'),
+            export_sql=SqlExport(db_connect=db_connect, table='out_minimal'),
         )
         # update-mode export: pxt insert triggers a UPDATE on the target keyed on id
         router.add_insert_route(
@@ -206,7 +206,7 @@ class TestFastAPI:
             path='/update',
             inputs=['id', 'str_col', 'int_col'],
             outputs=['id', 'str_upper', 'int_plus1'],
-            export_sql=SqlExport(db_connect=db_connect, target_table='out_update', method='update'),
+            export_sql=SqlExport(db_connect=db_connect, table='out_update', method='update'),
         )
         # engine cache reuse: three export_sql routes against the same db_connect share one engine
         assert len(router._engine_cache) == 1
@@ -413,7 +413,7 @@ class TestFastAPI:
             t,
             path='/all',
             uploadfile_inputs=uploadfile_inputs,
-            export_sql=SqlExport(db_connect=db_connect, target_table='img_out'),
+            export_sql=SqlExport(db_connect=db_connect, table='img_out'),
         )
         # /resize: id + image + width + height, only resized image output
         router.add_insert_route(
@@ -610,7 +610,7 @@ class TestFastAPI:
             uploadfile_inputs=uploadfile_inputs,
             outputs=['resized'],
             background=True,
-            export_sql=SqlExport(db_connect=db_connect, target_table='bg_resize'),
+            export_sql=SqlExport(db_connect=db_connect, table='bg_resize'),
         )
         client = make_test_client(router)
         media_dir = str(Env.get().media_dir)
@@ -1153,13 +1153,10 @@ class TestFastAPI:
 
         with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match="'merge' is not yet supported"):
             router.add_insert_route(
-                t,
-                path='/e',
-                outputs=['id'],
-                export_sql=SqlExport(db_connect=db_connect, target_table='out', method='merge'),
+                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out', method='merge')
             )
 
-        spec_insert = SqlExport(db_connect=db_connect, target_table='out')
+        spec_insert = SqlExport(db_connect=db_connect, table='out')
         with pxt_raises(
             pxt.ErrorCode.INVALID_ARGUMENT, match='export_sql and return_fileresponse are mutually exclusive'
         ):
@@ -1175,12 +1172,12 @@ class TestFastAPI:
 
         with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match="column 'id'"):
             router.add_insert_route(
-                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='out_bad')
+                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_bad')
             )
 
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="column 'id' not in table"):
             router.add_insert_route(
-                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='out_missing')
+                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_missing')
             )
 
         # method='update' validation: target needs a PK
@@ -1190,7 +1187,7 @@ class TestFastAPI:
                 t,
                 path='/e',
                 outputs=['id', 'text_upper'],
-                export_sql=SqlExport(db_connect=db_connect, target_table='no_pk', method='update'),
+                export_sql=SqlExport(db_connect=db_connect, table='no_pk', method='update'),
             )
 
         # method='update' validation: response columns must include the PK
@@ -1202,7 +1199,7 @@ class TestFastAPI:
                 t,
                 path='/e',
                 outputs=['text_upper'],
-                export_sql=SqlExport(db_connect=db_connect, target_table='with_pk', method='update'),
+                export_sql=SqlExport(db_connect=db_connect, table='with_pk', method='update'),
             )
 
         # method='update' validation: at least one non-PK column must be present
@@ -1211,7 +1208,7 @@ class TestFastAPI:
                 t,
                 path='/e',
                 outputs=['id'],
-                export_sql=SqlExport(db_connect=db_connect, target_table='with_pk', method='update'),
+                export_sql=SqlExport(db_connect=db_connect, table='with_pk', method='update'),
             )
 
     def test_insert_route(self, uses_db: None, tmp_path: pathlib.Path) -> None:
@@ -1240,7 +1237,7 @@ class TestFastAPI:
             path='/generate',
             inputs=['id', 'prompt'],
             outputs=['greeting', 'length'],
-            export_sql=SqlExport(db_connect=db_connect, target_table='gen_out'),
+            export_sql=SqlExport(db_connect=db_connect, table='gen_out'),
         )
         def format_response(*, greeting: str | None, length: int | None) -> GenResponse:
             assert greeting is not None and length is not None
@@ -1326,7 +1323,7 @@ class TestFastAPI:
         with pxt_raises(pxt.ErrorCode.INVALID_TYPE, match="cannot interpret response field 'weird'"):
 
             @router.insert_route(
-                t, path='/e_export', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='bad')
+                t, path='/e_export', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='bad')
             )
             def _bad(*, id: int) -> BadResponse:
                 return BadResponse(x=id)
@@ -1396,7 +1393,7 @@ class TestFastAPI:
         with pxt_raises(pxt.ErrorCode.INVALID_TYPE, match="cannot interpret response field 'weird'"):
 
             @router.update_route(
-                t, path='/e_export', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, target_table='bad')
+                t, path='/e_export', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='bad')
             )
             def _bad(*, id: int) -> BadResponse:
                 return BadResponse(x=id)
@@ -1694,7 +1691,7 @@ class TestFastAPI:
             path='/export',
             inputs=['text', 'value'],
             outputs=['id', 'text', 'value', 'text_upper'],
-            export_sql=SqlExport(db_connect=db_connect, target_table='items_out', method='update'),
+            export_sql=SqlExport(db_connect=db_connect, table='items_out', method='update'),
         )
         client = make_test_client(router)
 
@@ -1786,7 +1783,7 @@ class TestFastAPI:
                 path='/e',
                 outputs=['image'],
                 return_fileresponse=True,
-                export_sql=SqlExport(db_connect=db_connect, target_table='tgt'),
+                export_sql=SqlExport(db_connect=db_connect, table='tgt'),
             )
 
     def test_update_route(self, uses_db: None, tmp_path: pathlib.Path) -> None:
@@ -1820,7 +1817,7 @@ class TestFastAPI:
             path='/update',
             inputs=['text', 'value'],
             outputs=['id', 'text_upper', 'value'],
-            export_sql=SqlExport(db_connect=db_connect, target_table='upd_out'),
+            export_sql=SqlExport(db_connect=db_connect, table='upd_out'),
         )
         def format_response(*, id: int, text_upper: str | None, value: int | None) -> UpdateResp:
             assert text_upper is not None and value is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,9 +209,42 @@ class TestCLI:
             assert route.outputs == ['id', 'name', 'name_upper']
             assert route.return_fileresponse is True
             assert route.background is False
+            assert route.export_sql is None
 
             mock_create.reset_mock()
             mock_run.reset_mock()
+
+            # insert with --export-sql-* flags wires up SqlExport
+            argv = [
+                'pxt', 'serve', 'insert',
+                '--table', 'd.items', '--path', '/insert',
+                '--inputs', 'id', 'name',
+                '--outputs', 'id', 'name', 'name_upper',
+                '--export-sql-db-connect', 'sqlite:///x.db',
+                '--export-sql-target-table', 'items_out',
+                '--export-sql-method', 'update',
+            ]  # fmt: skip
+            with patch('sys.argv', argv):
+                cli_main()
+            route = mock_create.call_args.args[0].routes[0]
+            assert isinstance(route, InsertRouteConfig)
+            assert route.export_sql is not None
+            assert route.export_sql.db_connect == 'sqlite:///x.db'
+            assert route.export_sql.target_table == 'items_out'
+            assert route.export_sql.method == 'update'
+
+            mock_create.reset_mock()
+            mock_run.reset_mock()
+
+            # --export-sql-target-table without --export-sql-db-connect: argument error
+            argv = [
+                'pxt', 'serve', 'insert',
+                '--table', 'd.items', '--path', '/insert',
+                '--inputs', 'id',
+                '--export-sql-target-table', 'items_out',
+            ]  # fmt: skip
+            with patch('sys.argv', argv), pytest.raises(SystemExit):
+                cli_main()
 
             # delete
             with patch(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,7 +221,7 @@ class TestCLI:
                 '--inputs', 'id', 'name',
                 '--outputs', 'id', 'name', 'name_upper',
                 '--export-sql-db-connect', 'sqlite:///x.db',
-                '--export-sql-target-table', 'items_out',
+                '--export-sql-table', 'items_out',
                 '--export-sql-method', 'update',
             ]  # fmt: skip
             with patch('sys.argv', argv):
@@ -230,18 +230,18 @@ class TestCLI:
             assert isinstance(route, InsertRouteConfig)
             assert route.export_sql is not None
             assert route.export_sql.db_connect == 'sqlite:///x.db'
-            assert route.export_sql.target_table == 'items_out'
+            assert route.export_sql.table == 'items_out'
             assert route.export_sql.method == 'update'
 
             mock_create.reset_mock()
             mock_run.reset_mock()
 
-            # --export-sql-target-table without --export-sql-db-connect: argument error
+            # --export-sql-table without --export-sql-db-connect: argument error
             argv = [
                 'pxt', 'serve', 'insert',
                 '--table', 'd.items', '--path', '/insert',
                 '--inputs', 'id',
-                '--export-sql-target-table', 'items_out',
+                '--export-sql-table', 'items_out',
             ]  # fmt: skip
             with patch('sys.argv', argv), pytest.raises(SystemExit):
                 cli_main()


### PR DESCRIPTION
  - New SqlExport / SqlExporter types in pixeltable/serving/globals.py with insert/update/merge methods (merge unimplemented). Validates target schema, primary-key requirements for update, and  caches the SQLAlchemy construct for compiled-statement reuse.                                                                                                                                   
  - export_sql parameter added to add_insert_route, insert_route, add_update_route, update_route        
  - export_sql also wired into the TOML service file (nested [routes.export_sql]) and the CLI (--export-sql-db-connect / --target-table / --target-schema / --method).                            
  - Refactor: ColumnType to SQLAlchemy mapping and target-table resolution moved to pixeltable/utils/sql.py (resolve_table, get_sa_type, table_exists)
  - io/sql.py::export_sql now delegates. Adds if_not_exists parameter.                                                                                                                                                                        
  - Docs: new "Exporting rows to an external database" section in serving.mdx covering Python/TOML/CLI; SqlExport class docstring with full method semantics; SqlExport added to public_api.opml. 
