### PR TITLE
Dashboard performance and correctness fixes

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,7 @@
     "lucide-react": "^0.468.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^6.21.0",
     "tailwind-merge": "^2.2.0"
   },

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelHandle } from 'react-resizable-panels'
 import { Routes, Route, useNavigate, useParams, useLocation } from 'react-router-dom'
 import { DirectoryTree } from '@/components/DirectoryTree'
 import { TableDetailView } from '@/components/TableDetailView'
@@ -6,7 +7,7 @@ import { SearchPanel } from '@/components/SearchPanel'
 import { PipelineInspector } from '@/components/PipelineInspector'
 import { getDirectoryTree, getStatus } from '@/api/client'
 import type { SystemStatus } from '@/api/client'
-import type { TreeNode } from '@/types'
+import type { TableNode, TreeNode } from '@/types'
 import { cn } from '@/lib/utils'
 import {
   Search,
@@ -51,17 +52,18 @@ function TableView() {
 function findTreeNode(nodes: TreeNode[], path: string): TreeNode | null {
   for (const n of nodes) {
     if (n.path === path) return n
-    if (n.children) {
-      const found = findTreeNode(n.children, path)
+    if (n.kind === 'directory') {
+      const found = findTreeNode(n.entries, path)
       if (found) return found
     }
   }
   return null
 }
 
-function flattenTables(node: TreeNode): TreeNode[] {
-  const tables: TreeNode[] = []
-  for (const c of node.children ?? []) {
+function flattenTables(node: TreeNode): TableNode[] {
+  if (node.kind !== 'directory') return []
+  const tables: TableNode[] = []
+  for (const c of node.entries) {
     if (c.kind === 'directory') tables.push(...flattenTables(c))
     else tables.push(c)
   }
@@ -83,7 +85,7 @@ function DirectoryView({ tree }: { tree: TreeNode[] }) {
   )
 
   const tables = flattenTables(dirNode)
-  const totalErrors = tables.reduce((s, t) => s + (t.error_count ?? 0), 0)
+  const totalErrors = tables.reduce((s, t) => s + t.error_count, 0)
 
   return (
     <div className="flex flex-col h-full p-6 animate-fade-in">
@@ -124,7 +126,7 @@ function DirectoryView({ tree }: { tree: TreeNode[] }) {
                   <td className="py-2 px-3 font-mono text-xs font-medium">{t.name}</td>
                   <td className="py-2 px-3 text-xs text-muted-foreground">{t.kind}</td>
                   <td className="py-2 px-3 text-xs tabular-nums text-right">
-                    {(t.error_count ?? 0) > 0 ? (
+                    {t.error_count > 0 ? (
                       <span className="text-destructive flex items-center justify-end gap-1">
                         <AlertTriangle className="h-3 w-3" />{t.error_count}
                       </span>
@@ -230,8 +232,16 @@ export default function App() {
   const [loading, setLoading] = useState(true)
   const [searchOpen, setSearchOpen] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(true)
+  const sidebarPanelRef = useRef<ImperativePanelHandle>(null)
   const [status, setStatus] = useState<SystemStatus | null>(null)
   const [dark, toggleTheme] = useTheme()
+
+  const toggleSidebar = () => {
+    const panel = sidebarPanelRef.current
+    if (!panel) return
+    if (panel.isCollapsed()) panel.expand()
+    else panel.collapse()
+  }
   const navigate = useNavigate()
   const location = useLocation()
 
@@ -275,14 +285,20 @@ export default function App() {
   const isNavActive = (path: string) => location.pathname === path
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
-      {/* ── Sidebar ─────────────────────────────────────────────────── */}
-      <aside
-        className={cn(
-          'flex flex-col border-r border-border/60 bg-card/40 transition-all duration-200 ease-out',
-          sidebarOpen ? 'w-[220px]' : 'w-14',
-        )}
-      >
+    <div className="h-screen overflow-hidden bg-background">
+      <PanelGroup direction="horizontal" autoSaveId="pxt-layout" className="h-full">
+        {/* ── Sidebar ─────────────────────────────────────────────────── */}
+        <Panel
+          ref={sidebarPanelRef}
+          defaultSize={18}
+          minSize={10}
+          maxSize={40}
+          collapsible
+          collapsedSize={3.5}
+          onCollapse={() => setSidebarOpen(false)}
+          onExpand={() => setSidebarOpen(true)}
+          className="flex flex-col border-r border-border/60 bg-card/40"
+        >
         {/* Header: logo + connection */}
         <div className={cn('group relative shrink-0 px-3 pt-3 pb-2', !sidebarOpen && 'flex justify-center pt-3 pb-2')}>
           <button onClick={() => navigate('/')} className="flex items-center gap-2.5 hover:opacity-80 transition-opacity">
@@ -403,7 +419,7 @@ export default function App() {
               'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-[7px] text-[13px] font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground',
               sidebarOpen ? '' : 'justify-center',
             )}
-            onClick={() => setSidebarOpen(!sidebarOpen)}
+            onClick={toggleSidebar}
           >
             {sidebarOpen ? (
               <>
@@ -416,10 +432,12 @@ export default function App() {
           </button>
 
         </div>
-      </aside>
+        </Panel>
 
-      {/* ── Main Content ────────────────────────────────────────────── */}
-      <main className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        <PanelResizeHandle className="w-px bg-border/60 hover:w-1 hover:bg-accent transition-all data-[resize-handle-state=drag]:bg-accent data-[resize-handle-state=drag]:w-1 cursor-col-resize" />
+
+        {/* ── Main Content ────────────────────────────────────────────── */}
+        <Panel className="flex flex-col min-h-0 overflow-hidden">
         <div className="flex items-center justify-end gap-1 px-4 py-1.5 border-b border-border/40 shrink-0">
           <a
             href="https://docs.pixeltable.com"
@@ -454,7 +472,8 @@ export default function App() {
           <Route path="/table/*" element={<div className="flex-1 flex flex-col h-full"><TableView /></div>} />
           <Route path="/dir/*" element={<div className="flex-1 overflow-auto h-full"><DirectoryView tree={tree} /></div>} />
         </Routes>
-      </main>
+        </Panel>
+      </PanelGroup>
 
       {/* ── Search Panel ────────────────────────────────────────────── */}
       <SearchPanel

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -51,8 +51,9 @@ export async function search(query: string, limit = 50): Promise<SearchResults> 
   return fetchJson<SearchResults>(`${API_BASE}/search?${params}`);
 }
 
-export async function getPipeline(): Promise<PipelineResponse> {
-  return fetchJson<PipelineResponse>(`${API_BASE}/pipeline`);
+export async function getPipeline(tablePath?: string): Promise<PipelineResponse> {
+  const query = tablePath !== undefined ? `?path=${encodeURIComponent(tablePath)}` : '';
+  return fetchJson<PipelineResponse>(`${API_BASE}/pipeline${query}`);
 }
 
 interface SystemConfig {

--- a/dashboard/src/components/ColumnFlowDiagram.tsx
+++ b/dashboard/src/components/ColumnFlowDiagram.tsx
@@ -119,7 +119,6 @@ function ColumnNodeComponent({ data, selected }: { data: ColumnNodeData; selecte
               'bg-card',
               data.isComputed ? 'border-k-yellow/30' : 'border-border/60',
             ),
-        data.errorCount > 0 && 'border-destructive/40',
         selected && 'ring-1 ring-k-yellow/50 shadow-md border-k-yellow/50 opacity-100',
       )}>
         {/* Origin tag for inherited columns */}
@@ -266,11 +265,6 @@ function ColumnDetailPanel({
           {node.isIteratorCol && (
             <span className="text-[10px] text-violet-400 bg-violet-400/10 px-1.5 py-0.5 rounded font-medium">
               iterator
-            </span>
-          )}
-          {node.errorCount > 0 && (
-            <span className="text-[10px] text-destructive bg-destructive/10 px-1.5 py-0.5 rounded">
-              {node.errorCount} errors
             </span>
           )}
         </div>

--- a/dashboard/src/components/DirectoryTree.tsx
+++ b/dashboard/src/components/DirectoryTree.tsx
@@ -42,17 +42,20 @@ function getNodeIcon(type: string, isOpen: boolean = false) {
 }
 
 function countDescendants(node: TreeNode): number {
-  if (!node.children || node.children.length === 0) return 0
-  return node.children.reduce((sum, child) => sum + 1 + countDescendants(child), 0)
+  if (node.kind !== 'directory' || node.entries.length === 0) return 0
+  return node.entries.reduce((sum, child) => sum + 1 + countDescendants(child), 0)
 }
 
 function countAllNodes(nodes: TreeNode[]): number {
-  return nodes.reduce((sum, n) => sum + 1 + countAllNodes(n.children || []), 0)
+  return nodes.reduce(
+    (sum, n) => sum + 1 + (n.kind === 'directory' ? countAllNodes(n.entries) : 0),
+    0,
+  )
 }
 
 function nodeMatchesFilter(node: TreeNode, q: string): boolean {
   if (node.name.toLowerCase().includes(q)) return true
-  if (node.children) return node.children.some(c => nodeMatchesFilter(c, q))
+  if (node.kind === 'directory') return node.entries.some(c => nodeMatchesFilter(c, q))
   return false
 }
 
@@ -61,10 +64,10 @@ function TreeItem({ node, level, selectedPath, onSelect, filter, collapsedAll }:
   onSelect: (path: string, type: string) => void; filter: string; collapsedAll: number
 }) {
   const [manualOpen, setManualOpen] = useState<boolean | null>(null)
-  const hasChildren = node.children && node.children.length > 0
   const isDirectory = node.kind === 'directory'
+  const hasChildren = isDirectory && node.entries.length > 0
   const descendantCount = useMemo(() => countDescendants(node), [node])
-  const hasErrors = (node.error_count ?? 0) > 0
+  const hasErrors = !isDirectory && node.error_count > 0
 
   useEffect(() => {
     if (collapsedAll > 0) setManualOpen(false)
@@ -110,7 +113,7 @@ function TreeItem({ node, level, selectedPath, onSelect, filter, collapsedAll }:
         {getNodeIcon(node.kind, isOpen)}
         <span className="flex-1 text-[13px] truncate">{node.name}</span>
 
-        {hasErrors && (
+        {hasErrors && !isDirectory && (
           <span className="flex items-center gap-0.5 text-[10px] text-destructive shrink-0" title={`${node.error_count} errors`}>
             <AlertTriangle className="h-2.5 w-2.5" />
           </span>
@@ -122,7 +125,7 @@ function TreeItem({ node, level, selectedPath, onSelect, filter, collapsedAll }:
           </span>
         )}
 
-        {!isDirectory && node.version !== null && node.version !== undefined && (
+        {!isDirectory && node.version !== null && (
           <span className="text-[10px] text-muted-foreground/40 tabular-nums shrink-0">
             v{node.version}
           </span>
@@ -131,7 +134,7 @@ function TreeItem({ node, level, selectedPath, onSelect, filter, collapsedAll }:
 
       {isDirectory && hasChildren && isOpen && (
         <div>
-          {node.children!.map((child) => (
+          {node.entries.map((child) => (
             <TreeItem
               key={child.path}
               node={child}

--- a/dashboard/src/components/PipelineInspector.tsx
+++ b/dashboard/src/components/PipelineInspector.tsx
@@ -115,7 +115,6 @@ interface TableNodeData extends PipelineNodeType {
 }
 
 function PipelineTableNode({ data }: { data: TableNodeData }) {
-  const hasErrors = data.total_errors > 0
   const iteratorCols = data.columns.filter((c) => c.is_iterator_col)
   const computedCols = data.columns.filter((c) => c.is_computed && !c.is_iterator_col)
   const insertableCols = data.columns.filter((c) => !c.is_computed && !c.is_iterator_col)
@@ -123,8 +122,7 @@ function PipelineTableNode({ data }: { data: TableNodeData }) {
   return (
     <div
       className={cn(
-        'rounded-lg border bg-card shadow-sm min-w-[200px] max-w-[240px] cursor-pointer transition-all',
-        hasErrors ? 'border-destructive/30' : 'border-border/60',
+        'rounded-lg border bg-card shadow-sm min-w-[200px] max-w-[240px] cursor-pointer transition-all border-border/60',
         data.isSelected && 'ring-1 ring-k-yellow/50 border-k-yellow/30',
       )}
       onClick={() => data.onSelect(data.path)}
@@ -149,11 +147,6 @@ function PipelineTableNode({ data }: { data: TableNodeData }) {
           {data.indices.length > 0 && (
             <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
               <SearchIcon className="h-2.5 w-2.5" />{data.indices.length}
-            </span>
-          )}
-          {hasErrors && (
-            <span className="text-[10px] text-destructive flex items-center gap-0.5">
-              <AlertTriangle className="h-2.5 w-2.5" />{data.total_errors}
             </span>
           )}
           {data.iterator_type && (
@@ -198,16 +191,8 @@ function PipelineTableNode({ data }: { data: TableNodeData }) {
               const ft = col.func_type ? FUNC_STYLES[col.func_type] : null
               return (
                 <div key={col.name} className="flex items-center gap-1">
-                  <Zap className={cn(
-                    'h-2 w-2 shrink-0',
-                    col.error_count > 0 ? 'text-destructive' : 'text-k-yellow/50',
-                  )} />
-                  <span className={cn(
-                    'text-[10px] truncate',
-                    col.error_count > 0 ? 'text-destructive' : 'text-foreground/80',
-                  )}>
-                    {col.name}
-                  </span>
+                  <Zap className="h-2 w-2 shrink-0 text-k-yellow/50" />
+                  <span className="text-[10px] truncate text-foreground/80">{col.name}</span>
                   {col.func_name && ft && (
                     <span className={cn('text-[9px] shrink-0 font-mono', ft.text)}>
                       {col.func_name}
@@ -289,20 +274,14 @@ function DetailPanel({
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-4 px-5 py-3 border-b border-border">
+      <div className="grid grid-cols-3 px-5 py-3 border-b border-border">
         {[
-          { label: 'Rows', value: node.row_count.toLocaleString(), isError: false },
-          { label: 'Version', value: `v${node.version}`, isError: false },
-          { label: 'Computed', value: String(node.computed_count), isError: false },
-          { label: 'Errors', value: String(node.total_errors), isError: node.total_errors > 0 },
+          { label: 'Rows', value: node.row_count.toLocaleString() },
+          { label: 'Version', value: `v${node.version}` },
+          { label: 'Computed', value: String(node.computed_count) },
         ].map((s) => (
           <div key={s.label} className="text-center">
-            <div className={cn(
-              'text-sm font-semibold tabular-nums',
-              s.isError ? 'text-destructive' : 'text-foreground',
-            )}>
-              {s.value}
-            </div>
+            <div className="text-sm font-semibold tabular-nums text-foreground">{s.value}</div>
             <div className="text-[11px] text-muted-foreground mt-0.5">{s.label}</div>
           </div>
         ))}
@@ -464,12 +443,7 @@ function ComputedColumnRow({ col, step }: { col: PipelineColumn; step: number })
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <span className="text-[11px] text-muted-foreground w-5 shrink-0 tabular-nums">#{step}</span>
-        <span className={cn(
-          'text-xs font-medium truncate',
-          col.error_count > 0 ? 'text-destructive' : 'text-foreground',
-        )}>
-          {col.name}
-        </span>
+        <span className="text-xs font-medium truncate text-foreground">{col.name}</span>
         {ft && (
           <span className={cn('text-[11px] px-1.5 py-0.5 rounded bg-accent font-mono shrink-0', ft.text)}>
             {ft.label}
@@ -500,12 +474,6 @@ function ComputedColumnRow({ col, step }: { col: PipelineColumn; step: number })
               {col.depends_on.map((d) => (
                 <span key={d} className="text-[11px] bg-accent text-muted-foreground px-1.5 py-0.5 rounded">{d}</span>
               ))}
-            </div>
-          )}
-          {col.error_count > 0 && (
-            <div className="text-xs text-destructive flex items-center gap-1.5">
-              <AlertTriangle className="h-3 w-3" />
-              {col.error_count} errors in sampled rows
             </div>
           )}
         </div>
@@ -680,9 +648,6 @@ function NodeFinder({
                   <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
                     {n.row_count.toLocaleString()}
                   </span>
-                  {n.total_errors > 0 && (
-                    <AlertTriangle className="h-2.5 w-2.5 text-destructive shrink-0" />
-                  )}
                 </button>
               ))
             )}
@@ -794,9 +759,8 @@ function PipelineInspectorInner() {
     const views = pipeline.nodes.filter((n) => n.is_view).length
     const totalRows = pipeline.nodes.reduce((s, n) => s + n.row_count, 0)
     const totalComputed = pipeline.nodes.reduce((s, n) => s + n.computed_count, 0)
-    const totalErrors = pipeline.nodes.reduce((s, n) => s + n.total_errors, 0)
     const totalIndices = pipeline.nodes.reduce((s, n) => s + n.indices.length, 0)
-    return { tables, views, totalRows, totalComputed, totalErrors, totalIndices }
+    return { tables, views, totalRows, totalComputed, totalIndices }
   }, [pipeline])
 
   if (isLoading) {
@@ -870,13 +834,6 @@ function PipelineInspectorInner() {
               <span className="text-muted-foreground/80">{s.label}</span>
             </div>
           ))}
-          {stats.totalErrors > 0 && (
-            <div className="flex items-center gap-1.5 text-[11px] text-destructive">
-              <AlertTriangle className="h-3 w-3" />
-              <span>{stats.totalErrors} errors</span>
-            </div>
-          )}
-
           {/* Auto-refresh + manual refresh */}
           <div className="ml-auto flex items-center gap-2">
             {lastRefreshed && (

--- a/dashboard/src/components/PipelineInspector.tsx
+++ b/dashboard/src/components/PipelineInspector.tsx
@@ -143,7 +143,7 @@ function PipelineTableNode({ data }: { data: TableNodeData }) {
         </div>
         <div className="flex items-center gap-2 mt-1 flex-wrap">
           <span className="text-[10px] text-muted-foreground tabular-nums">{data.row_count.toLocaleString()} rows</span>
-          <span className="text-[10px] text-muted-foreground/80">v{data.version}</span>
+          {data.version !== null && <span className="text-[10px] text-muted-foreground/80">v{data.version}</span>}
           {data.indices.length > 0 && (
             <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
               <SearchIcon className="h-2.5 w-2.5" />{data.indices.length}
@@ -277,7 +277,7 @@ function DetailPanel({
       <div className="grid grid-cols-3 px-5 py-3 border-b border-border">
         {[
           { label: 'Rows', value: node.row_count.toLocaleString() },
-          { label: 'Version', value: `v${node.version}` },
+          { label: 'Version', value: node.version !== null ? `v${node.version}` : '—' },
           { label: 'Computed', value: String(node.computed_count) },
         ].map((s) => (
           <div key={s.label} className="text-center">

--- a/dashboard/src/components/TableDetailView.tsx
+++ b/dashboard/src/components/TableDetailView.tsx
@@ -796,16 +796,20 @@ function ColResizeHandle({ atMin, getStartWidth, onResize, onReset }: {
         e.preventDefault()
         e.stopPropagation()
         const el = e.currentTarget
-        el.setPointerCapture(e.pointerId)
+        const pointerId = e.pointerId
+        el.setPointerCapture(pointerId)
         const startX = e.clientX
         const startW = getStartWidth()
         const onMove = (m: PointerEvent) => onResize(startW + (m.clientX - startX))
-        const onUp = () => {
+        const cleanup = () => {
           el.removeEventListener('pointermove', onMove)
-          el.removeEventListener('pointerup', onUp)
+          el.removeEventListener('pointerup', cleanup)
+          el.removeEventListener('pointercancel', cleanup)
+          if (el.hasPointerCapture(pointerId)) el.releasePointerCapture(pointerId)
         }
         el.addEventListener('pointermove', onMove)
-        el.addEventListener('pointerup', onUp)
+        el.addEventListener('pointerup', cleanup)
+        el.addEventListener('pointercancel', cleanup)
       }}
       onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); onReset() }}
       className="group absolute right-0 top-0 h-full w-2 cursor-col-resize select-none flex items-center justify-end"

--- a/dashboard/src/components/TableDetailView.tsx
+++ b/dashboard/src/components/TableDetailView.tsx
@@ -1932,7 +1932,7 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
                             'text-left px-3.5 py-2 font-medium text-muted-foreground transition-colors group whitespace-nowrap font-mono',
                             sortable ? 'cursor-pointer hover:text-foreground' : 'cursor-default text-muted-foreground/60',
                           )}
-                          title={sortable ? undefined : 'Unstored — cannot sort'}
+                          title={sortable ? undefined : (col.is_stored ? 'Not indexed - cannot sort' : 'Unstored - cannot sort')}
                         >
                         <div className="flex items-center gap-1">
                           <ColumnTypeIcon type={col.type} className="h-3 w-3" />

--- a/dashboard/src/components/TableDetailView.tsx
+++ b/dashboard/src/components/TableDetailView.tsx
@@ -1,5 +1,12 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
+import {
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+  type ImperativePanelGroupHandle,
+  type ImperativePanelHandle,
+} from 'react-resizable-panels'
 import { getTableMetadata, getTableData, getPipeline } from '@/api/client'
 import { useDebounce } from '@/hooks/useDebounce'
 import type {
@@ -280,7 +287,9 @@ function JsonNode({ keyName, value, depth, expandLevel, searchMatch, path }: {
 
 // ── Expandable Cell Detail ─────────────────────────────────────────────────
 
-function CellDetail({ value, onClose }: { value: string; onClose: () => void }) {
+function CellDetail({ value, onClose, pythonHighlight = false }: {
+  value: string; onClose: () => void; pythonHighlight?: boolean
+}) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
     window.addEventListener('keydown', onKey)
@@ -386,6 +395,10 @@ function CellDetail({ value, onClose }: { value: string; onClose: () => void }) 
         <div className="flex-1 overflow-auto p-3 text-[11px] font-mono leading-relaxed select-text">
           {isJson && !viewRaw ? (
             <JsonNode value={parsed} depth={0} expandLevel={expandLevel} searchMatch={searchLower} path="$" />
+          ) : pythonHighlight && !viewRaw ? (
+            <div className="whitespace-pre-wrap break-all text-foreground/90">
+              <PythonExpr code={value} />
+            </div>
           ) : (
             <pre className="whitespace-pre-wrap break-words text-foreground/90">{formatted}</pre>
           )}
@@ -403,6 +416,9 @@ const TRUNCATE_JSON_CHARS = 80
 function Cell({ value, column, error, onMediaExpand }: { value: unknown; column: DataColumn; error?: CellError; onMediaExpand?: () => void }) {
   const [expanded, setExpanded] = useState(false)
 
+  if (!column.is_stored) {
+    return <span className="text-muted-foreground/40 italic text-[11px]" title="Unstored column — value not loaded">unstored</span>
+  }
   if (error) {
     return (
       <div className="group/err relative flex items-center gap-1.5 rounded px-1.5 py-0.5 bg-destructive/10 border border-destructive/30 cursor-default" title={`${error.error_type}: ${error.error_msg}`}>
@@ -740,12 +756,93 @@ function FilterPanel({ columns, data, filters, onChange, onClose }: {
 // ── Column Chips ───────────────────────────────────────────────────────────
 
 const SCHEMA_FILTER_THRESHOLD = 20
-const SCHEMA_MAX_HEIGHT = 'max-h-[50vh]'
+
+type SchemaColKey = 'name' | 'type' | 'expr'
+type SchemaColWidths = Record<SchemaColKey, number>
+const SCHEMA_COL_DEFAULTS: SchemaColWidths = { name: 160, type: 140, expr: 360 }
+const SCHEMA_COL_MIN: SchemaColWidths = { name: 80, type: 80, expr: 120 }
+const SCHEMA_COL_MAX = 800
+const SCHEMA_COLS_STORAGE_KEY = 'pxt-schema-cols'
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n))
+}
+
+function loadSchemaColWidths(): SchemaColWidths {
+  try {
+    const raw = localStorage.getItem(SCHEMA_COLS_STORAGE_KEY)
+    if (!raw) return SCHEMA_COL_DEFAULTS
+    const parsed = JSON.parse(raw) as Partial<SchemaColWidths>
+    if (!parsed || typeof parsed !== 'object') return SCHEMA_COL_DEFAULTS
+    return {
+      name: Number.isFinite(parsed.name) ? clamp(parsed.name as number, SCHEMA_COL_MIN.name, SCHEMA_COL_MAX) : SCHEMA_COL_DEFAULTS.name,
+      type: Number.isFinite(parsed.type) ? clamp(parsed.type as number, SCHEMA_COL_MIN.type, SCHEMA_COL_MAX) : SCHEMA_COL_DEFAULTS.type,
+      expr: Number.isFinite(parsed.expr) ? clamp(parsed.expr as number, SCHEMA_COL_MIN.expr, SCHEMA_COL_MAX) : SCHEMA_COL_DEFAULTS.expr,
+    }
+  } catch {
+    return SCHEMA_COL_DEFAULTS
+  }
+}
+
+function ColResizeHandle({ atMin, getStartWidth, onResize, onReset }: {
+  atMin: boolean
+  getStartWidth: () => number
+  onResize: (newWidth: number) => void
+  onReset: () => void
+}) {
+  return (
+    <div
+      onPointerDown={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        const el = e.currentTarget
+        el.setPointerCapture(e.pointerId)
+        const startX = e.clientX
+        const startW = getStartWidth()
+        const onMove = (m: PointerEvent) => onResize(startW + (m.clientX - startX))
+        const onUp = () => {
+          el.removeEventListener('pointermove', onMove)
+          el.removeEventListener('pointerup', onUp)
+        }
+        el.addEventListener('pointermove', onMove)
+        el.addEventListener('pointerup', onUp)
+      }}
+      onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); onReset() }}
+      className="group absolute right-0 top-0 h-full w-2 cursor-col-resize select-none flex items-center justify-end"
+      title="Drag to resize · double-click to reset"
+    >
+      <div className={cn(
+        'w-px h-full transition-all',
+        atMin
+          ? 'bg-destructive/70 group-hover:bg-destructive group-hover:w-0.5'
+          : 'bg-border group-hover:bg-foreground/60 group-hover:w-0.5',
+      )} />
+    </div>
+  )
+}
 
 function ColumnChips({ columns, indices, expanded, onToggle }: {
   columns: ColumnInfo[]; indices: IndexInfo[]; expanded: boolean; onToggle: () => void
 }) {
   const [filter, setFilter] = useState('')
+  const [expandedExpr, setExpandedExpr] = useState<string | null>(null)
+  const [colWidths, setColWidths] = useState<SchemaColWidths>(() => loadSchemaColWidths())
+  useEffect(() => {
+    localStorage.setItem(SCHEMA_COLS_STORAGE_KEY, JSON.stringify(colWidths))
+  }, [colWidths])
+
+  const handleResize = useCallback(
+    (key: SchemaColKey) => (newWidth: number) =>
+      setColWidths(w => {
+        const next = clamp(newWidth, SCHEMA_COL_MIN[key], SCHEMA_COL_MAX)
+        return w[key] === next ? w : { ...w, [key]: next }
+      }),
+    [],
+  )
+  const resetCol = useCallback(
+    (key: SchemaColKey) => setColWidths(w => ({ ...w, [key]: SCHEMA_COL_DEFAULTS[key] })),
+    [],
+  )
   const sourceCount = columns.filter(c => !c.is_computed).length
   const computedCount = columns.filter(c => c.is_computed).length
   const showFilter = columns.length >= SCHEMA_FILTER_THRESHOLD
@@ -757,8 +854,8 @@ function ColumnChips({ columns, indices, expanded, onToggle }: {
   }, [columns, filter])
 
   return (
-    <div className="border-b border-border/40">
-      <div className="flex items-center gap-2 px-4 py-2">
+    <div className="border-b border-border/40 flex flex-col h-full min-h-0">
+      <div className="flex items-center gap-2 px-4 py-2 shrink-0">
         <button
           onClick={onToggle}
           className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors"
@@ -797,7 +894,7 @@ function ColumnChips({ columns, indices, expanded, onToggle }: {
       </div>
 
       {!expanded && (
-        <div className={cn('overflow-y-auto px-4 pb-2.5', SCHEMA_MAX_HEIGHT)}>
+        <div data-schema-scroll className="overflow-y-auto px-4 pb-2.5 flex-1 min-h-0">
           <div className="flex flex-wrap gap-1.5">
             {filtered.map(col => (
               <div
@@ -830,36 +927,77 @@ function ColumnChips({ columns, indices, expanded, onToggle }: {
       )}
 
       {expanded && (
-        <div className={cn('border-t border-border/30 overflow-y-auto', SCHEMA_MAX_HEIGHT)}>
-          <div className="px-4 py-2.5">
-            <table className="w-full text-[11px]">
+        <div data-schema-scroll className="border-t border-border/30 overflow-y-auto overflow-x-auto flex-1 min-h-0">
+          <div className="px-4 py-1">
+            <table className="w-full text-[11px] table-fixed">
+              <colgroup>
+                <col style={{ width: colWidths.name }} />
+                <col style={{ width: colWidths.type }} />
+                <col style={{ width: colWidths.expr }} />
+                <col />
+              </colgroup>
               <thead className="sticky top-0 bg-background z-10">
                 <tr className="border-b border-border/30 text-left text-muted-foreground">
-                  <th className="py-1.5 px-2 font-medium">Name</th>
-                  <th className="py-1.5 px-2 font-medium">Type</th>
-                  <th className="py-1.5 px-2 font-medium">Expression</th>
+                  <th className="relative py-1.5 px-2 font-medium overflow-visible">
+                    Name
+                    <ColResizeHandle
+                      atMin={colWidths.name <= SCHEMA_COL_MIN.name}
+                      getStartWidth={() => colWidths.name}
+                      onResize={handleResize('name')}
+                      onReset={() => resetCol('name')}
+                    />
+                  </th>
+                  <th className="relative py-1.5 px-2 font-medium overflow-visible">
+                    Type
+                    <ColResizeHandle
+                      atMin={colWidths.type <= SCHEMA_COL_MIN.type}
+                      getStartWidth={() => colWidths.type}
+                      onResize={handleResize('type')}
+                      onReset={() => resetCol('type')}
+                    />
+                  </th>
+                  <th className="relative py-1.5 px-2 font-medium overflow-visible">
+                    Expression
+                    <ColResizeHandle
+                      atMin={colWidths.expr <= SCHEMA_COL_MIN.expr}
+                      getStartWidth={() => colWidths.expr}
+                      onResize={handleResize('expr')}
+                      onReset={() => resetCol('expr')}
+                    />
+                  </th>
                   <th className="py-1.5 px-2 font-medium">Info</th>
                 </tr>
               </thead>
               <tbody>
                 {filtered.map(col => (
                   <tr key={col.name} className="border-b border-border/20 hover:bg-accent/20 transition-colors">
-                    <td className="py-1.5 px-2">
+                    <td className="py-1.5 px-2 overflow-hidden" title={col.name}>
                       <div className="flex items-center gap-1.5">
                         {col.is_primary_key && <Key className="h-3 w-3 text-k-yellow shrink-0" />}
                         {col.is_computed && <Zap className="h-3 w-3 text-k-yellow/60 shrink-0" />}
-                        <span className="font-mono font-medium text-foreground">{col.name}</span>
+                        <span className="font-mono font-medium text-foreground truncate">{col.name}</span>
                       </div>
                     </td>
-                    <td className="py-1.5 px-2">
+                    <td className="py-1.5 px-2 overflow-hidden" title={col.type_}>
                       <ColumnTypeBadge type={col.type_} />
                     </td>
-                    <td className="py-1.5 px-2">
-                      {col.is_computed && col.computed_with ? (
-                        <div className="bg-accent/50 px-2 py-0.5 rounded max-w-lg line-clamp-3 overflow-hidden" title={col.computed_with}>
-                          <PythonExpr code={col.computed_with} className="text-[11px] font-mono leading-relaxed break-all" />
-                        </div>
-                      ) : (
+                    <td className="py-1.5 px-2 overflow-hidden">
+                      {col.is_computed && col.computed_with ? (() => {
+                        const expr = col.computed_with
+                        const isLong = expr.length > 60
+                        return (
+                          <div
+                            className={cn(
+                              'bg-accent/50 px-2 py-0.5 rounded line-clamp-3 overflow-hidden',
+                              isLong && 'cursor-pointer hover:bg-accent/80 transition-colors',
+                            )}
+                            title={isLong ? 'Click to expand' : expr}
+                            onClick={isLong ? () => setExpandedExpr(expr) : undefined}
+                          >
+                            <PythonExpr code={expr} className="text-[11px] font-mono leading-relaxed break-all" />
+                          </div>
+                        )
+                      })() : (
                         <span className="text-muted-foreground/60 text-[11px]">—</span>
                       )}
                     </td>
@@ -943,6 +1081,7 @@ function ColumnChips({ columns, indices, expanded, onToggle }: {
           Showing {filtered.length} of {columns.length} columns
         </div>
       )}
+      {expandedExpr && <CellDetail value={expandedExpr} onClose={() => setExpandedExpr(null)} pythonHighlight />}
     </div>
   )
 }
@@ -981,7 +1120,7 @@ function SdkSnippet({ metadata }: { metadata: TableMetadata }) {
   )
 }
 
-function TableHeader({ metadata, onTableClick, totalErrors }: { metadata: TableMetadata; onTableClick: (path: string) => void; totalErrors: number }) {
+function TableHeader({ metadata, onTableClick }: { metadata: TableMetadata; onTableClick: (path: string) => void }) {
   const [showSnippet, setShowSnippet] = useState(false)
   const kind = metadata.kind
 
@@ -1011,12 +1150,15 @@ function TableHeader({ metadata, onTableClick, totalErrors }: { metadata: TableM
           {kind}
         </span>
         <span className="text-xs text-muted-foreground tabular-nums">v{metadata.version}</span>
-        {Object.keys(metadata.indices).length > 0 && (
-          <span className="flex items-center gap-1 text-xs text-muted-foreground">
-            <Info className="h-3 w-3" />
-            <span className="tabular-nums">{Object.keys(metadata.indices).length} idx</span>
-          </span>
-        )}
+        {(() => {
+          const embeddingIdxCount = Object.values(metadata.indices).filter(i => i.index_type === 'embedding').length
+          return embeddingIdxCount > 0 && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Info className="h-3 w-3" />
+              <span className="tabular-nums">{embeddingIdxCount} idx</span>
+            </span>
+          )
+        })()}
         {metadata.media_validation && (
           <span className="text-[10px] text-muted-foreground/70 bg-muted/30 px-1.5 py-0.5 rounded border border-border/30"
             title={`Media validation: ${metadata.media_validation}`}>
@@ -1025,12 +1167,6 @@ function TableHeader({ metadata, onTableClick, totalErrors }: { metadata: TableM
         )}
         {metadata.version_created && (
           <span className="text-[11px] text-muted-foreground">{new Date(metadata.version_created).toLocaleDateString()}</span>
-        )}
-        {totalErrors > 0 && (
-          <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-destructive/10 text-destructive border border-destructive/20">
-            <AlertTriangle className="h-2.5 w-2.5" />
-            {totalErrors} error{totalErrors !== 1 ? 's' : ''}
-          </span>
         )}
         <button
           onClick={() => setShowSnippet(!showSnippet)}
@@ -1122,11 +1258,6 @@ function LineagePanel({ tablePath, pipelineData, pipelineColumns, onTableClick, 
         <div className="flex items-center gap-3 mt-1.5 text-[11px] text-muted-foreground">
           <span className="tabular-nums">{node.row_count.toLocaleString()} rows</span>
           <span>v{node.version}</span>
-          {node.total_errors > 0 && (
-            <span className="text-destructive flex items-center gap-0.5">
-              <AlertTriangle className="h-2.5 w-2.5" />{node.total_errors}
-            </span>
-          )}
         </div>
         <div className="flex items-center gap-1 mt-1 text-[11px] text-muted-foreground">
           <span>{node.insertable_count} stored</span>
@@ -1319,6 +1450,18 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
   const [errorsOnly, setErrorsOnly] = useState(false)
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
   const [schemaExpanded, setSchemaExpanded] = useState(true)
+  const schemaPanelRef = useRef<ImperativePanelHandle>(null)
+  const groupRef = useRef<ImperativePanelGroupHandle>(null)
+  const groupContainerRef = useRef<HTMLDivElement>(null)
+  const schemaContentRef = useRef<HTMLDivElement>(null)
+  const fittingRef = useRef(false)
+  const mountedRef = useRef(false)
+  const toggleSchema = useCallback(() => {
+    const p = schemaPanelRef.current
+    if (!p) return
+    if (p.isCollapsed()) p.expand()
+    else p.collapse()
+  }, [])
   const [pipelineColumns, setPipelineColumns] = useState<PipelineColumn[] | null>(null)
   const [pipelineData, setPipelineData] = useState<{ nodes: PipelineNodeType[]; edges: PipelineEdge[] } | null>(null)
   const [contentTab, setContentTab] = useState<'data' | 'lineage' | 'history'>('data')
@@ -1338,15 +1481,10 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
       .finally(() => setMetaLoading(false))
   }, [tablePath])
 
-  const totalErrors = useMemo(
-    () => pipelineData?.nodes.find(n => n.path === tablePath)?.total_errors ?? 0,
-    [pipelineData, tablePath],
-  )
-
-  // Fetch pipeline data (needed for error counts and lineage/history tabs)
+  // Fetch scoped pipeline data for the lineage/history tabs.
   useEffect(() => {
     if (pipelineData) return
-    getPipeline()
+    getPipeline(tablePath)
       .then(p => {
         setPipelineData(p)
         const node = p.nodes.find(n => n.path === tablePath)
@@ -1386,7 +1524,34 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
     setSchemaExpanded(true)
     setPipelineColumns(null); setPipelineData(null)
     setContentTab('data'); setSearchQuery('')
+    mountedRef.current = false
   }, [tablePath])
+
+  // Fit schema panel to its natural content height the first time we open this table.
+  // Subsequent visits restore the user's last drag via autoSaveId.
+  useLayoutEffect(() => {
+    if (!metadata) return
+    if (localStorage.getItem(`pxt-table-layout-customized-${metadata.id}`) === '1') return
+    const group = groupRef.current
+    const groupEl = groupContainerRef.current
+    const wrapperEl = schemaContentRef.current
+    if (!group || !groupEl || !wrapperEl) return
+    const scrollableEl = wrapperEl.querySelector<HTMLElement>('[data-schema-scroll]')
+    const contentEl = scrollableEl?.firstElementChild as HTMLElement | null
+    if (!scrollableEl || !contentEl) return
+    const groupHeight = groupEl.clientHeight
+    // The scrollable div is flex-1 and grows to fill the panel, so its scrollHeight matches the
+    // panel's allotment whenever content fits. Measure the inner block child instead — it sizes
+    // to its natural content height regardless of the panel's current size.
+    const fixedHeight = wrapperEl.clientHeight - scrollableEl.clientHeight
+    const contentHeight = contentEl.getBoundingClientRect().height
+    const naturalHeight = fixedHeight + contentHeight
+    if (groupHeight === 0 || naturalHeight === 0) return
+    const pct = Math.min(70, Math.max(5, (naturalHeight / groupHeight) * 100))
+    fittingRef.current = true
+    group.setLayout([pct, 100 - pct])
+    queueMicrotask(() => { fittingRef.current = false })
+  }, [metadata])
 
   // ⌘F shortcut → focus inline search
   useEffect(() => {
@@ -1476,16 +1641,50 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
   return (
     <div className="flex flex-col h-full animate-fade-in">
       {/* ── Header ──────────────────────────────────────────────────── */}
-      <TableHeader metadata={metadata} onTableClick={(path) => navigate(`/table/${path}`)} totalErrors={totalErrors} />
+      <TableHeader metadata={metadata} onTableClick={(path) => navigate(`/table/${path}`)} />
 
-      {/* ── Column Chips ────────────────────────────────────────────── */}
-      <ColumnChips
-        columns={Object.values(metadata.columns)}
-        indices={Object.values(metadata.indices)}
-        expanded={schemaExpanded}
-        onToggle={() => setSchemaExpanded(!schemaExpanded)}
-      />
+      <div ref={groupContainerRef} className="flex-1 min-h-0 flex flex-col">
+      <PanelGroup
+        key={metadata.id}
+        ref={groupRef}
+        direction="vertical"
+        autoSaveId={`pxt-table-layout-${metadata.id}`}
+        onLayout={() => {
+          if (!mountedRef.current) {
+            mountedRef.current = true
+            return
+          }
+          if (fittingRef.current) return
+          localStorage.setItem(`pxt-table-layout-customized-${metadata.id}`, '1')
+        }}
+        className="flex-1 min-h-0"
+      >
+        {/* ── Schema Panel ──────────────────────────────────────────── */}
+        <Panel
+          ref={schemaPanelRef}
+          defaultSize={25}
+          minSize={5}
+          maxSize={70}
+          collapsible
+          collapsedSize={5}
+          onCollapse={() => setSchemaExpanded(false)}
+          onExpand={() => setSchemaExpanded(true)}
+          className="flex flex-col min-h-0 overflow-hidden"
+        >
+          <div ref={schemaContentRef} className="flex flex-col h-full min-h-0">
+          <ColumnChips
+            columns={Object.values(metadata.columns)}
+            indices={Object.values(metadata.indices).filter(idx => idx.index_type === 'embedding')}
+            expanded={schemaExpanded}
+            onToggle={toggleSchema}
+          />
+          </div>
+        </Panel>
 
+        <PanelResizeHandle className="h-px bg-border/60 hover:h-1 hover:bg-accent transition-all data-[resize-handle-state=drag]:bg-accent data-[resize-handle-state=drag]:h-1 cursor-row-resize" />
+
+        {/* ── Data Panel ────────────────────────────────────────────── */}
+        <Panel className="flex flex-col min-h-0 overflow-hidden">
       {/* ── Content Tab Toggle + Toolbar ──────────────────────────── */}
       <div className="flex items-center justify-between px-4 py-2 border-b border-border/40 gap-3 shrink-0">
         {/* Left: tab toggle + row count/search */}
@@ -1501,7 +1700,7 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
               Data
             </button>
             <button
-              onClick={() => { setContentTab('lineage'); setSchemaExpanded(false) }}
+              onClick={() => setContentTab('lineage')}
               className={cn('flex items-center gap-1.5 px-2.5 py-1 rounded text-[11px] font-medium transition-colors',
                 contentTab === 'lineage' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground')}
             >
@@ -1615,21 +1814,19 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
           )}
 
           {/* Error rows only toggle */}
-          {totalErrors > 0 && (
-            <button
-              onClick={() => { setErrorsOnly(!errorsOnly); setPage(0) }}
-              className={cn(
-                'flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium transition-colors',
-                errorsOnly
-                  ? 'bg-destructive/15 text-destructive border border-destructive/30'
-                  : 'hover:bg-accent text-muted-foreground',
-              )}
-              title="Show only rows with errors"
-            >
-              <AlertTriangle className="h-3 w-3" />
-              {errorsOnly && 'Errors'}
-            </button>
-          )}
+          <button
+            onClick={() => { setErrorsOnly(!errorsOnly); setPage(0) }}
+            className={cn(
+              'flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium transition-colors',
+              errorsOnly
+                ? 'bg-destructive/15 text-destructive border border-destructive/30'
+                : 'hover:bg-accent text-muted-foreground',
+            )}
+            title="Show only rows with errors"
+          >
+            <AlertTriangle className="h-3 w-3" />
+            {errorsOnly && 'Errors'}
+          </button>
 
           {/* Faceted filter toggle */}
           <button
@@ -1725,16 +1922,26 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
               <table className="w-full text-xs">
                 <thead className="sticky top-0 bg-card/95 backdrop-blur-sm z-10">
                   <tr className="border-b border-border/60">
-                    {data.columns.map(col => (
-                      <th key={col.name} onClick={() => handleSort(col.name)}
-                        className="text-left px-3.5 py-2 font-medium text-muted-foreground cursor-pointer hover:text-foreground transition-colors group whitespace-nowrap font-mono">
+                    {data.columns.map(col => {
+                      const sortable = col.is_sorted
+                      return (
+                        <th
+                          key={col.name}
+                          onClick={sortable ? () => handleSort(col.name) : undefined}
+                          className={cn(
+                            'text-left px-3.5 py-2 font-medium text-muted-foreground transition-colors group whitespace-nowrap font-mono',
+                            sortable ? 'cursor-pointer hover:text-foreground' : 'cursor-default text-muted-foreground/60',
+                          )}
+                          title={sortable ? undefined : 'Unstored — cannot sort'}
+                        >
                         <div className="flex items-center gap-1">
                           <ColumnTypeIcon type={col.type} className="h-3 w-3" />
                           {col.name}
                           {orderBy === col.name && (orderDesc ? <ChevronDown className="h-3 w-3 text-k-yellow" /> : <ChevronUp className="h-3 w-3 text-k-yellow" />)}
                         </div>
-                      </th>
-                    ))}
+                        </th>
+                      )
+                    })}
                   </tr>
                 </thead>
                 <tbody>
@@ -1835,6 +2042,9 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
           </div>
         </div>
       )}
+        </Panel>
+      </PanelGroup>
+      </div>
 
       {/* Media Lightbox (from clicking a media cell in table view) */}
       {lightboxCell && data && (() => {

--- a/dashboard/src/components/TableDetailView.tsx
+++ b/dashboard/src/components/TableDetailView.tsx
@@ -1153,7 +1153,9 @@ function TableHeader({ metadata, onTableClick }: { metadata: TableMetadata; onTa
         )}>
           {kind}
         </span>
-        <span className="text-xs text-muted-foreground tabular-nums">v{metadata.version}</span>
+        {metadata.version !== null && (
+          <span className="text-xs text-muted-foreground tabular-nums">v{metadata.version}</span>
+        )}
         {(() => {
           const embeddingIdxCount = Object.values(metadata.indices).filter(i => i.index_type === 'embedding').length
           return embeddingIdxCount > 0 && (
@@ -1261,7 +1263,7 @@ function LineagePanel({ tablePath, pipelineData, pipelineColumns, onTableClick, 
         </div>
         <div className="flex items-center gap-3 mt-1.5 text-[11px] text-muted-foreground">
           <span className="tabular-nums">{node.row_count.toLocaleString()} rows</span>
-          <span>v{node.version}</span>
+          {node.version !== null && <span>v{node.version}</span>}
         </div>
         <div className="flex items-center gap-1 mt-1 text-[11px] text-muted-foreground">
           <span>{node.insertable_count} stored</span>

--- a/dashboard/src/lib/column-lineage.ts
+++ b/dashboard/src/lib/column-lineage.ts
@@ -16,7 +16,6 @@ export interface ColumnNodeData extends Record<string, unknown> {
   computeExpression: string | null
   funcName: string | null
   funcType: FuncType
-  errorCount: number
   upstreamColumns: string[]
   downstreamColumns: string[]
   comment?: string
@@ -121,7 +120,6 @@ export function buildLineageGraph(columns: PipelineColumn[]): LineageResult {
       computeExpression: col.computed_with,
       funcName: col.func_name,
       funcType: col.func_type,
-      errorCount: col.error_count,
       upstreamColumns: upstream.get(col.name) || [],
       downstreamColumns: downstream.get(col.name) || [],
       comment: col.comment,

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -161,6 +161,7 @@ export interface PipelineEdge {
   target: string;
   type: string;
   label: string;
+  base_version?: number;
 }
 
 export interface PipelineResponse {

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -62,7 +62,7 @@ export interface TableMetadata {
   is_replica: boolean;
   is_view: boolean;
   is_snapshot: boolean;
-  version: number;
+  version: number | null;
   version_created: string;
   schema_version: number;
   comment: string | null;
@@ -146,7 +146,7 @@ export interface PipelineNode extends Record<string, unknown> {
   is_view: boolean;
   base: string | null;
   row_count: number;
-  version: number;
+  version: number | null;
   columns: PipelineColumn[];
   indices: PipelineIndex[];
   versions: PipelineVersion[];

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -1,13 +1,23 @@
 // API response types
 
-export interface TreeNode {
+export type TableKind = 'table' | 'view' | 'snapshot' | 'replica';
+
+export interface DirectoryNode {
   name: string;
   path: string;
-  kind: 'directory' | 'table' | 'view' | 'snapshot' | 'replica';
-  version?: number | null;
-  error_count?: number;
-  children?: TreeNode[];
+  kind: 'directory';
+  entries: TreeNode[];
 }
+
+export interface TableNode {
+  name: string;
+  path: string;
+  kind: TableKind;
+  version: number | null;
+  error_count: number;
+}
+
+export type TreeNode = DirectoryNode | TableNode;
 
 // Matches Python ColumnMetadata TypedDict
 export interface ColumnInfo {
@@ -37,12 +47,13 @@ export interface EmbeddingIndexParams {
 export interface IndexInfo {
   name: string;
   columns: string[];
-  index_type: string;
-  parameters: EmbeddingIndexParams;
+  index_type: 'embedding' | 'btree';
+  parameters: EmbeddingIndexParams | null;
 }
 
 // Matches Python TableMetadata TypedDict
 export interface TableMetadata {
+  id: string;
   name: string;
   path: string;
   columns: Record<string, ColumnInfo>;
@@ -66,6 +77,8 @@ export interface DataColumn {
   type: string;
   is_media: boolean;
   is_computed: boolean;
+  is_stored: boolean;
+  is_sorted: boolean;
 }
 
 export interface CellError {
@@ -105,7 +118,6 @@ export interface PipelineColumn {
   defined_in_self: boolean;
   func_name: string | null;
   func_type: 'builtin' | 'custom_udf' | 'query' | 'iterator' | 'unknown' | null;
-  error_count: number;
   depends_on?: string[];
   comment?: string;
 }
@@ -134,7 +146,6 @@ export interface PipelineNode extends Record<string, unknown> {
   base: string | null;
   row_count: number;
   version: number;
-  total_errors: number;
   columns: PipelineColumn[];
   indices: PipelineIndex[];
   versions: PipelineVersion[];

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -15,6 +15,7 @@ export interface TableNode {
   kind: TableKind;
   version: number | null;
   error_count: number;
+  base: string | null;
 }
 
 export type TreeNode = DirectoryNode | TableNode;

--- a/docs/public_api.opml
+++ b/docs/public_api.opml
@@ -20,6 +20,7 @@
           <outline text="func|pixeltable.create_dir" />
           <outline text="func|pixeltable.drop_dir" />
           <outline text="func|pixeltable.get_dir_contents" />
+          <outline text="func|pixeltable.get_dir_tree" />
           <outline text="func|pixeltable.home" />
           <outline text="func|pixeltable.ls" />
           <outline text="func|pixeltable.move" />

--- a/docs/public_api.opml
+++ b/docs/public_api.opml
@@ -126,8 +126,11 @@
 
           <outline text="class|pixeltable.ColumnMetadata" />
           <outline text="class|pixeltable.DirContents" />
+          <outline text="class|pixeltable.DirectoryNode" />
           <outline text="class|pixeltable.IndexMetadata" />
           <outline text="class|pixeltable.TableMetadata" />
+          <outline text="class|pixeltable.TableNode" />
+          <outline text="class|pixeltable.TreeNode" />
           <outline text="class|pixeltable.UpdateStatus" />
           <outline text="class|pixeltable.VersionMetadata" />
         </outline>

--- a/pixeltable/__init__.py
+++ b/pixeltable/__init__.py
@@ -46,6 +46,10 @@ from .func import (
 )
 from .globals import (
     DirContents,
+    DirectoryNode,
+    TableKind,
+    TableNode,
+    TreeNode,
     array,
     configure_logging,
     create_dir,
@@ -55,6 +59,7 @@ from .globals import (
     drop_dir,
     drop_table,
     get_dir_contents,
+    get_dir_tree,
     get_table,
     home,
     init,

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1068,7 +1068,7 @@ class Catalog:
         dir_entries: dict[str, Catalog.DirEntry]
         table: schema.Table | None
 
-        # Only populated for table entries when get_dir_contents() was called with error_counts=True;
+        # Only populated for table entries when get_dir_contents() was called with with_error_counts=True;
         # None otherwise (including for directory entries).
         table_error_count: int | None = None
 

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1041,18 +1041,44 @@ class Catalog:
             dir_id = dir.parent_id
         return Path.parse('/'.join(names), allow_empty_path=True, allow_system_path=True)
 
+    def _table_error_counts(self) -> dict[UUID, int]:
+        """Returns map from table id to the sum of tableversions.num_excs"""
+
+        # JSONB path mirrors UpdateStatus.row_count_stats / cascade_row_count_stats -> RowCountStats.num_excs
+        # (see pixeltable/catalog/update_status.py). If those dataclass fields are renamed, this query
+        # silently returns 0.
+        stmt = sql.text("""
+            SELECT tbl_id, COALESCE(SUM(
+                COALESCE((md -> 'update_status' -> 'row_count_stats' ->> 'num_excs')::int, 0)
+              + COALESCE((md -> 'update_status' -> 'cascade_row_count_stats' ->> 'num_excs')::int, 0)
+            ), 0) AS errors
+            FROM tableversions
+            GROUP BY tbl_id
+        """)
+        rows = get_runtime().conn.execute(stmt).all()
+        return {r.tbl_id: r.errors for r in rows}
+
     @dataclasses.dataclass
     class DirEntry:
         dir: schema.Dir | None
         dir_entries: dict[str, Catalog.DirEntry]
         table: schema.Table | None
 
-    @retry_loop(for_write=False)
-    def get_dir_contents(self, dir_path: Path, recursive: bool = False) -> dict[str, DirEntry]:
-        dir = self._get_schema_object(dir_path, expected=Dir, raise_if_not_exists=True)
-        return self._get_dir_contents(dir._id, recursive=recursive)
+        # Only populated for table entries when get_dir_contents() was called with error_counts=True;
+        # None otherwise (including for directory entries).
+        table_error_count: int | None = None
 
-    def _get_dir_contents(self, dir_id: UUID, recursive: bool = False) -> dict[str, DirEntry]:
+    @retry_loop(for_write=False)
+    def get_dir_contents(
+        self, dir_path: Path, recursive: bool = False, error_counts: bool = False
+    ) -> dict[str, DirEntry]:
+        dir = self._get_schema_object(dir_path, expected=Dir, raise_if_not_exists=True)
+        error_counts = self._table_error_counts() if error_counts else None
+        return self._get_dir_contents(dir._id, recursive=recursive, error_counts=error_counts)
+
+    def _get_dir_contents(
+        self, dir_id: UUID, recursive: bool = False, *, error_counts: dict[UUID, int] | None = None
+    ) -> dict[str, DirEntry]:
         """Returns a dict mapping the entry names to DirEntry objects"""
         conn = get_runtime().conn
         result: dict[str, Catalog.DirEntry] = {}
@@ -1063,14 +1089,15 @@ class Catalog:
             dir = schema.Dir(**row._mapping)
             dir_contents: dict[str, Catalog.DirEntry] = {}
             if recursive:
-                dir_contents = self._get_dir_contents(dir.id, recursive=True)
+                dir_contents = self._get_dir_contents(dir.id, recursive=True, error_counts=error_counts)
             result[dir.md['name']] = self.DirEntry(dir=dir, dir_entries=dir_contents, table=None)
 
         q = sql.select(schema.Table).where(self._active_tbl_clause(dir_id=dir_id))
         rows = conn.execute(q).all()
         for row in rows:
             tbl = schema.Table(**row._mapping)
-            result[tbl.md['name']] = self.DirEntry(dir=None, dir_entries={}, table=tbl)
+            err_count = error_counts.get(tbl.id, 0) if error_counts is not None else None
+            result[tbl.md['name']] = self.DirEntry(dir=None, dir_entries={}, table=tbl, table_error_count=err_count)
 
         return result
 

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1042,7 +1042,11 @@ class Catalog:
         return Path.parse('/'.join(names), allow_empty_path=True, allow_system_path=True)
 
     def _table_error_counts(self) -> dict[UUID, int]:
-        """Returns map from table id to the sum of tableversions.num_excs"""
+        """Returns map from table id to the sum of num_excs across that table's versions.
+
+        Sums tableversions.md -> update_status -> row_count_stats / cascade_row_count_stats -> num_excs
+        for each row, grouped by tbl_id.
+        """
 
         # JSONB path mirrors UpdateStatus.row_count_stats / cascade_row_count_stats -> RowCountStats.num_excs
         # (see pixeltable/catalog/update_status.py). If those dataclass fields are renamed, this query
@@ -1070,10 +1074,10 @@ class Catalog:
 
     @retry_loop(for_write=False)
     def get_dir_contents(
-        self, dir_path: Path, recursive: bool = False, error_counts: bool = False
+        self, dir_path: Path, recursive: bool = False, with_error_counts: bool = False
     ) -> dict[str, DirEntry]:
         dir = self._get_schema_object(dir_path, expected=Dir, raise_if_not_exists=True)
-        error_counts = self._table_error_counts() if error_counts else None
+        error_counts = self._table_error_counts() if with_error_counts else None
         return self._get_dir_contents(dir._id, recursive=recursive, error_counts=error_counts)
 
     def _get_dir_contents(

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1053,23 +1053,15 @@ class Catalog:
         return Path.parse('/'.join(names), allow_empty_path=True, allow_system_path=True)
 
     def _table_error_counts(self) -> dict[UUID, int]:
-        """Returns map from table id to the sum of num_excs across that table's versions.
-
-        Sums tableversions.md -> update_status -> row_count_stats / cascade_row_count_stats -> num_excs
-        for each row, grouped by tbl_id.
-        """
-
-        # JSONB path mirrors UpdateStatus.row_count_stats / cascade_row_count_stats -> RowCountStats.num_excs
-        # (see pixeltable/catalog/update_status.py). If those dataclass fields are renamed, this query
-        # silently returns 0.
-        stmt = sql.text("""
-            SELECT tbl_id, COALESCE(SUM(
-                COALESCE((md -> 'update_status' -> 'row_count_stats' ->> 'num_excs')::int, 0)
-              + COALESCE((md -> 'update_status' -> 'cascade_row_count_stats' ->> 'num_excs')::int, 0)
-            ), 0) AS errors
-            FROM tableversions
-            GROUP BY tbl_id
-        """)
+        """Returns map from table id to the sum of num_excs across that table's versions."""
+        md = schema.TableVersion.md
+        update_status = md['update_status']
+        row_count_excs = sql.func.coalesce(update_status['row_count_stats']['num_excs'].astext.cast(sql.Integer), 0)
+        cascade_row_count_excs = sql.func.coalesce(
+            update_status['cascade_row_count_stats']['num_excs'].astext.cast(sql.Integer), 0
+        )
+        errors = sql.func.coalesce(sql.func.sum(row_count_excs + cascade_row_count_excs), 0).label('errors')
+        stmt = sql.select(schema.TableVersion.tbl_id, errors).group_by(schema.TableVersion.tbl_id)
         rows = get_runtime().conn.execute(stmt).all()
         return {r.tbl_id: r.errors for r in rows}
 

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -148,6 +148,9 @@ class Table(SchemaObject):
         indices = tv.idxs_by_name.values()
         index_info: dict[str, IndexMetadata] = {}
         for info in indices:
+            # Only surface indexes whose underlying column is user-visible.
+            if info.col.name not in column_info:
+                continue
             if isinstance(info.idx, index.EmbeddingIndex):
                 col_ref = ColumnRef(info.col)
                 embedding = info.idx.embeddings[info.col.col_type._type](col_ref)
@@ -160,6 +163,10 @@ class Table(SchemaObject):
                         embedding=str(embedding),
                         embedding_functions=[str(fn) for fn in info.idx.embeddings.values()],
                     ),
+                )
+            elif isinstance(info.idx, index.BtreeIndex):
+                index_info[info.name] = IndexMetadata(
+                    name=info.name, columns=[info.col.name], index_type='btree', parameters=None
                 )
 
         primary_key: list[str] | None = None

--- a/pixeltable/catalog/table_metadata.py
+++ b/pixeltable/catalog/table_metadata.py
@@ -50,16 +50,16 @@ class EmbeddingIndexParams(TypedDict):
 
 
 class IndexMetadata(TypedDict):
-    """Metadata for a column of a Pixeltable table."""
+    """Metadata for an index on a Pixeltable table."""
 
     name: str
     """The name of the index."""
     columns: list[str]
     """The table columns that are indexed."""
-    index_type: Literal['embedding']
-    """The type of index (currently only `'embedding'` is supported, but others will be added in the future)."""
-    parameters: EmbeddingIndexParams
-    """Parameters specific to the index type."""
+    index_type: Literal['embedding', 'btree']
+    """The type of index. New types may be added in the future."""
+    parameters: EmbeddingIndexParams | None
+    """Parameters specific to the index type. `None` for index types without parameters."""
 
 
 class TableMetadata(TypedDict):

--- a/pixeltable/dashboard/bridge.py
+++ b/pixeltable/dashboard/bridge.py
@@ -113,7 +113,8 @@ def get_table_data(
     columns, select_dict, media_url_cols, error_cols = _build_select(tbl, include_errors=True)
     query = tbl.select(**select_dict)
 
-    if errors_only and error_cols:
+    error_predicate: exprs.Expr | None = None
+    if errors_only:
         error_predicates = []
         for col_name in error_cols:
             try:
@@ -121,11 +122,14 @@ def get_table_data(
                 error_predicates.append(col_ref.errortype != None)
             except Exception:
                 pass
-        if len(error_predicates) > 0:
-            combined = error_predicates[0]
-            for pred in error_predicates[1:]:
-                combined |= pred
-            query = query.where(combined)
+        if len(error_predicates) == 0:
+            # 'errors only' was requested but the table has no columns that can carry errors.
+            # Short-circuit: nothing to return.
+            return {'columns': columns, 'rows': [], 'total_count': 0, 'offset': offset, 'limit': limit}
+        error_predicate = error_predicates[0]
+        for pred in error_predicates[1:]:
+            error_predicate |= pred
+        query = query.where(error_predicate)
 
     if order_by is not None:
         # only sort by columns with a B-tree index; other columns would force a full sort
@@ -134,8 +138,11 @@ def get_table_data(
             col = getattr(tbl, order_by)
             query = query.order_by(col, asc=not order_desc)
 
-    total_count = tbl.count() if not errors_only else None
-    results = list(query.limit(limit, offset=offset if offset else None).collect())
+    if error_predicate is not None:
+        total_count = tbl.where(error_predicate).count()
+    else:
+        total_count = tbl.count()
+    results = list(query.limit(limit, offset=offset if offset != 0 else None).collect())
 
     rows: list[dict[str, Any]] = []
     for row in results:
@@ -171,13 +178,7 @@ def get_table_data(
             row_data['_errors'] = cell_errors
         rows.append(row_data)
 
-    return {
-        'columns': columns,
-        'rows': rows,
-        'total_count': total_count if total_count is not None else len(rows),
-        'offset': offset,
-        'limit': limit,
-    }
+    return {'columns': columns, 'rows': rows, 'total_count': total_count, 'offset': offset, 'limit': limit}
 
 
 def export_table_csv(table_path: str, limit: int = 100_000) -> bytes:
@@ -199,7 +200,7 @@ def export_table_csv(table_path: str, limit: int = 100_000) -> bytes:
         for col_name in col_names:
             if col_name in media_url_cols:
                 fileurl = row.get(media_url_cols[col_name])
-                csv_row.append(_resolve_fileurl(fileurl, http_address) if fileurl else '')
+                csv_row.append(_resolve_fileurl(fileurl, http_address) if fileurl is not None else '')
             else:
                 val = row.get(col_name)
                 if val is None:
@@ -284,7 +285,7 @@ def _collect_tbl_nodes(nodes: list[pxt.TreeNode], out: list[pxt.TableNode]) -> N
 def _split_tbl_path(tbl_path: str) -> tuple[str, int | None]:
     """Split a Pixeltable path of the form 'p' or 'p:N' into (path, version)."""
     head, sep, tail = tbl_path.rpartition(':')
-    if sep is not None and tail.isdigit():
+    if sep != '' and tail.isdigit():
         return head, int(tail)
     return tbl_path, None
 
@@ -354,7 +355,7 @@ def get_pipeline(tbl_path: str | None = None) -> dict[str, Any]:
             iterator_name: str | None = None
             if md['is_view'] and md['iterator_call'] is not None:
                 m = _FIRST_FUNC_RE.search(md['iterator_call'])
-                iterator_name = m.group(1) if m else md['iterator_call']
+                iterator_name = m.group(1) if m is not None else md['iterator_call']
 
             columns: list[dict[str, Any]] = []
             computed_cols: list[str] = []

--- a/pixeltable/dashboard/bridge.py
+++ b/pixeltable/dashboard/bridge.py
@@ -18,8 +18,7 @@ import urllib.request
 from typing import TYPE_CHECKING, Any
 
 import pixeltable as pxt
-import pixeltable.functions as pxtf
-from pixeltable.catalog.table_metadata import ColumnMetadata, TableMetadata
+from pixeltable.catalog.table_metadata import TableMetadata
 from pixeltable.config import Config
 from pixeltable.env import Env
 
@@ -29,30 +28,13 @@ if TYPE_CHECKING:
     from pixeltable import exprs
 
 
-def _version_error_total(tbl: pxt.Table) -> int:
-    """Sum errors across all versions of a table (cheap, no row scans)."""
-    return sum(v['errors'] for v in tbl.get_versions())
-
-
-def _column_error_counts(tbl: pxt.Table) -> dict[str, int]:
-    """Count rows with errors per computed or media column. Returns {col_name: count}."""
-    md = tbl.get_metadata()
-    select_list: dict[str, exprs.Expr] = {}
-    for col_name, info in md['columns'].items():
-        if info['is_computed'] or info['media_validation'] is not None:
-            col_ref = getattr(tbl, col_name)
-            select_list[col_name] = pxtf.count(col_ref.errortype)
-    if not select_list:
-        return {}
-    results = tbl.select(**select_list).collect()
-    assert len(results) == 1
-    return results[0]
-
-
 def _build_select(
     tbl: pxt.Table, *, include_errors: bool = False
 ) -> tuple[list[dict[str, Any]], dict[str, exprs.Expr], dict[str, str], dict[str, tuple[str, str]]]:
     """Build column info list, select dict, media URL map, and error column map.
+
+    Unstored columns appear in the returned columns list with is_stored=False, but are
+    excluded from select_dict and error_cols.
 
     Returns (columns, select_dict, media_url_cols, error_cols).
     """
@@ -62,14 +44,32 @@ def _build_select(
     media_url_cols: dict[str, str] = {}
     error_cols: dict[str, tuple[str, str]] = {}
 
+    # Columns backed by a B-tree index can be ordered cheaply; the rest cannot.
+    sorted_cols: set[str] = {
+        c for idx in md['indices'].values() if idx['index_type'] == 'btree' for c in idx['columns']
+    }
+
     for col_name, info in md['columns'].items():
-        col_ref = getattr(tbl, col_name)
         is_media = info['media_validation'] is not None
         is_computed = info['is_computed']
-        columns.append({'name': col_name, 'type': info['type_'], 'is_media': is_media, 'is_computed': is_computed})
+        is_stored = info['is_stored']
+        columns.append(
+            {
+                'name': col_name,
+                'type': info['type_'],
+                'is_media': is_media,
+                'is_computed': is_computed,
+                'is_stored': is_stored,
+                'is_sorted': col_name in sorted_cols,
+            }
+        )
 
+        if not is_stored:
+            continue
+
+        col_ref = getattr(tbl, col_name)
         if is_media:
-            # Only fetch the URL — never download the actual media file
+            # only fetch the URL
             url_key = f'{col_name}__url'
             select_dict[url_key] = col_ref.fileurl
             media_url_cols[col_name] = url_key
@@ -77,14 +77,11 @@ def _build_select(
             select_dict[col_name] = col_ref
 
         if include_errors and (is_computed or is_media):
-            try:
-                et_key = f'{col_name}__errortype'
-                em_key = f'{col_name}__errormsg'
-                select_dict[et_key] = col_ref.errortype
-                select_dict[em_key] = col_ref.errormsg
-                error_cols[col_name] = (et_key, em_key)
-            except Exception:
-                pass
+            error_type_key = f'{col_name}__errortype'
+            error_msg_key = f'{col_name}__errormsg'
+            select_dict[error_type_key] = col_ref.errortype
+            select_dict[error_msg_key] = col_ref.errormsg
+            error_cols[col_name] = (error_type_key, error_msg_key)
 
     return columns, select_dict, media_url_cols, error_cols
 
@@ -98,68 +95,6 @@ def _resolve_fileurl(fileurl: str, http_address: str) -> str:
     return fileurl
 
 
-def get_directory_tree() -> list[dict[str, Any]]:
-    """
-    Get the complete directory tree with all tables/views/snapshots.
-
-    Returns:
-        List of directory nodes with nested children.
-    """
-    all_dirs = pxt.list_dirs('', recursive=True)
-    all_tables = pxt.list_tables('', recursive=True)
-
-    root_children: list[dict[str, Any]] = []
-    dir_nodes: dict[str, dict[str, Any]] = {}
-
-    # First pass: create all directory nodes
-    for dir_path in sorted(all_dirs):
-        parts = dir_path.split('/')
-        node = {'name': parts[-1], 'path': dir_path, 'kind': 'directory', 'children': []}
-        dir_nodes[dir_path] = node
-
-        if len(parts) == 1:
-            root_children.append(node)
-        else:
-            parent_path = '/'.join(parts[:-1])
-            if parent_path in dir_nodes:
-                dir_nodes[parent_path]['children'].append(node)
-
-    # Second pass: add tables to their directories
-    for tbl_path in sorted(all_tables):
-        parts = tbl_path.split('/')
-        tbl_name = parts[-1]
-        parent_path = '/'.join(parts[:-1]) if len(parts) > 1 else ''
-
-        error_count = 0
-        try:
-            tbl = pxt.get_table(tbl_path)
-            md = tbl.get_metadata()
-            kind = md['kind']
-            version = md['version'] if kind != 'snapshot' else None
-            error_count = _version_error_total(tbl)
-        except Exception as e:
-            _logger.warning(f'Failed to get metadata for {tbl_path}: {e}')
-            kind = 'table'
-            version = None
-
-        table_node = {'name': tbl_name, 'path': tbl_path, 'kind': kind, 'version': version, 'error_count': error_count}
-
-        if parent_path and parent_path in dir_nodes:
-            dir_nodes[parent_path]['children'].append(table_node)
-        elif not parent_path:
-            root_children.append(table_node)
-
-    return root_children
-
-
-def get_table_metadata(table_path: str) -> TableMetadata:
-    """
-    Get detailed metadata for a table including schema, indices, and lineage info.
-    """
-    tbl = pxt.get_table(table_path)
-    return tbl.get_metadata()
-
-
 def get_table_data(
     table_path: str,
     offset: int = 0,
@@ -169,13 +104,13 @@ def get_table_data(
     errors_only: bool = False,
 ) -> dict[str, Any]:
     """
-    Get paginated data from a table with media URLs resolved.
+    Get paginated data from a table with media URLs resolved:
+    - ignores order_by if it is a column without a B-tree index
+    - doesn't return data for unstored computed columns
     """
     tbl = pxt.get_table(table_path)
     http_address = Env.get().http_address
-
     columns, select_dict, media_url_cols, error_cols = _build_select(tbl, include_errors=True)
-
     query = tbl.select(**select_dict)
 
     if errors_only and error_cols:
@@ -186,25 +121,30 @@ def get_table_data(
                 error_predicates.append(col_ref.errortype != None)
             except Exception:
                 pass
-        if error_predicates:
+        if len(error_predicates) > 0:
             combined = error_predicates[0]
             for pred in error_predicates[1:]:
                 combined |= pred
             query = query.where(combined)
 
-    if order_by is not None and order_by in tbl.columns():
-        col = getattr(tbl, order_by)
-        query = query.order_by(col, asc=not order_desc)
+    if order_by is not None:
+        # only sort by columns with a B-tree index; other columns would force a full sort
+        order_col = next((c for c in columns if c['name'] == order_by), None)
+        if order_col is not None and order_col['is_sorted']:
+            col = getattr(tbl, order_by)
+            query = query.order_by(col, asc=not order_desc)
 
     total_count = tbl.count() if not errors_only else None
     results = list(query.limit(limit, offset=offset if offset else None).collect())
 
-    rows = []
+    rows: list[dict[str, Any]] = []
     for row in results:
         row_data: dict[str, Any] = {}
         cell_errors: dict[str, dict[str, str]] = {}
         for col_info in columns:
             col_name = col_info['name']
+            if not col_info['is_stored']:
+                continue  # omitted
             value = row.get(col_name)
 
             if col_info['is_media']:
@@ -218,13 +158,16 @@ def get_table_data(
                 row_data[col_name] = str(value)
 
             if col_name in error_cols:
-                et_key, em_key = error_cols[col_name]
-                etype = row.get(et_key)
-                emsg = row.get(em_key)
-                if etype is not None:
-                    cell_errors[col_name] = {'error_type': str(etype), 'error_msg': str(emsg) if emsg else ''}
+                error_type_key, error_msg_key = error_cols[col_name]
+                error_type = row.get(error_type_key)
+                error_msg = row.get(error_msg_key)
+                if error_type is not None:
+                    cell_errors[col_name] = {
+                        'error_type': str(error_type),
+                        'error_msg': str(error_msg) if error_msg is not None else '',
+                    }
 
-        if cell_errors:
+        if len(cell_errors) > 0:
             row_data['_errors'] = cell_errors
         rows.append(row_data)
 
@@ -241,7 +184,6 @@ def export_table_csv(table_path: str, limit: int = 100_000) -> bytes:
     """Export a table as CSV bytes. Media columns export their file URL."""
     tbl = pxt.get_table(table_path)
     http_address = Env.get().http_address
-
     columns, select_dict, media_url_cols, _ = _build_select(tbl)
     col_names = [c['name'] for c in columns]
 
@@ -329,22 +271,72 @@ def search(query: str, limit: int = 50) -> dict[str, Any]:
 _FIRST_FUNC_RE = re.compile(r'(\w+)\(')
 
 
-def get_pipeline() -> dict[str, Any]:
-    """Return the full DAG metadata for the Pipeline Inspector."""
-    table_paths = sorted(pxt.list_tables('', recursive=True))
+def _collect_tbl_nodes(nodes: list[pxt.TreeNode], out: list[pxt.TableNode]) -> None:
+    """Collect all transitively reachable TableNodes in 'nodes' and return them in 'out'"""
+    for n in nodes:
+        if n['kind'] == 'directory':
+            _collect_tbl_nodes(n['entries'], out)
+        else:
+            out.append(n)
+
+
+def _collect_pipeline_paths(table_nodes: list[pxt.TableNode], tbl_path: str) -> set[str] | None:
+    """Return paths of all tables/views that are transitively connected to tbl_path"""
+    by_path = {n['path']: n for n in table_nodes}
+    if tbl_path not in by_path:
+        return None
+    view_map: dict[str, list[str]] = {}  # base path -> list[view path]
+    for n in table_nodes:
+        if n['base'] is not None:
+            view_map.setdefault(n['base'], []).append(n['path'])
+
+    connected: set[str] = {tbl_path}
+    # collect ancestors
+    current: str | None = tbl_path
+    while True:
+        base = by_path[current]['base']
+        if base is None:
+            break
+        connected.add(base)
+        current = base
+
+    stack = [tbl_path]
+    while stack:
+        p = stack.pop()
+        for view_path in view_map.get(p, []):
+            if view_path not in connected:
+                connected.add(view_path)
+                stack.append(view_path)
+    return connected
+
+
+def get_pipeline(tbl_path: str | None = None) -> dict[str, Any]:
+    """Return DAG metadata for the Pipeline Inspector.
+
+    If tbl_path is None, returns the full catalog. If tbl_path is given, returns only the
+    connected component containing that table (transitive ancestors + the table + transitive
+    descendants). Returns an empty result if tbl_path is not in the catalog.
+    """
+    tbl_nodes: list[pxt.TableNode] = []
+    _collect_tbl_nodes(pxt.get_dir_tree(), tbl_nodes)
+
+    pipeline_paths: set[str] | None
+    if tbl_path is None:
+        pipeline_paths = {n['path'] for n in tbl_nodes}
+    else:
+        pipeline_paths = _collect_pipeline_paths(tbl_nodes, tbl_path)
+        if pipeline_paths is None:
+            return {'nodes': [], 'edges': []}
 
     nodes: list[dict[str, Any]] = []
     edges: list[dict[str, Any]] = []
 
-    for path in table_paths:
+    for path in sorted(pipeline_paths):
         try:
             tbl = pxt.get_table(path)
             md = tbl.get_metadata()
-            column_md: dict[str, ColumnMetadata] = md['columns']
+            column_md = md['columns']
             row_count = tbl.count()
-
-            col_errors = _column_error_counts(tbl)
-            table_error_total = _version_error_total(tbl)
 
             iterator_name: str | None = None
             if md['is_view'] and md['iterator_call'] is not None:
@@ -355,8 +347,6 @@ def get_pipeline() -> dict[str, Any]:
             computed_cols: list[str] = []
 
             for col_name, info in column_md.items():
-                # col_ref: exprs.ColumnRef = getattr(tbl, col_name)
-                # col = col_ref.col
                 value_expr = info['computed_with']
                 is_iter_col = info['is_iterator_col']
 
@@ -398,7 +388,6 @@ def get_pipeline() -> dict[str, Any]:
                     'defined_in_self': defined_in == md['name'],
                     'func_name': func_name,
                     'func_type': func_type,
-                    'error_count': col_errors.get(col_name, 0),
                 }
 
                 if is_computed and value_expr is not None and not is_iter_col:
@@ -406,16 +395,19 @@ def get_pipeline() -> dict[str, Any]:
 
                 columns.append(col_entry)
 
-            # Indices
-            raw_indices = md['indices']
+            # indices: surface only embedding indices here, the dashboard doesn't want to know about B-trees
             indices: list[dict[str, Any]] = []
-            for idx_name, idx_info in raw_indices.items():
+            for idx_name, idx_info in md['indices'].items():
+                if idx_info['index_type'] != 'embedding':
+                    continue
+                params = idx_info['parameters']
+                assert params is not None
                 indices.append(
                     {
                         'name': idx_name,
                         'columns': idx_info['columns'],
                         'type': idx_info['index_type'],
-                        'embedding': str(idx_info['parameters']['embedding'])[:120],
+                        'embedding': str(params['embedding'])[:120],
                     }
                 )
 
@@ -430,7 +422,6 @@ def get_pipeline() -> dict[str, Any]:
                     'base': base_path,
                     'row_count': row_count,
                     'version': md['version'],
-                    'total_errors': table_error_total,
                     'columns': columns,
                     'indices': indices,
                     'versions': tbl.get_versions(),
@@ -440,8 +431,12 @@ def get_pipeline() -> dict[str, Any]:
                 }
             )
 
-            if is_view and base_path:
-                edges.append({'source': base_path, 'target': path, 'type': 'view', 'label': iterator_name or 'view'})
+            if base_path is not None:
+                assert base_path in pipeline_paths
+                edge_type = md['kind']
+                edges.append(
+                    {'source': base_path, 'target': path, 'type': edge_type, 'label': iterator_name or edge_type}
+                )
 
         except Exception as e:
             _logger.warning(f'Pipeline: could not inspect {path}: {e}')
@@ -453,7 +448,6 @@ def get_pipeline() -> dict[str, Any]:
                     'base': None,
                     'row_count': 0,
                     'version': 0,
-                    'total_errors': 0,
                     'columns': [],
                     'indices': [],
                     'versions': [],
@@ -472,14 +466,20 @@ def get_status() -> dict[str, Any]:
     Get system status including version, environment, connection info, and table count.
     """
     version = pxt.__version__
-    all_tables = pxt.list_tables('', recursive=True)
 
+    total_tables = 0
     total_errors = 0
-    for path in all_tables:
-        try:
-            total_errors += _version_error_total(pxt.get_table(path))
-        except Exception:
-            pass
+
+    def walk(nodes: list[pxt.TreeNode]) -> None:
+        nonlocal total_tables, total_errors
+        for n in nodes:
+            if n['kind'] == 'directory':
+                walk(n['entries'])
+            else:
+                total_tables += 1
+                total_errors += n['error_count']
+
+    walk(pxt.get_dir_tree())
 
     config_info: dict[str, Any] = {}
     try:
@@ -498,7 +498,7 @@ def get_status() -> dict[str, Any]:
     return {
         'version': version,
         'environment': 'local',
-        'total_tables': len(all_tables),
+        'total_tables': total_tables,
         'total_errors': total_errors,
         'config': config_info,
     }

--- a/pixeltable/dashboard/bridge.py
+++ b/pixeltable/dashboard/bridge.py
@@ -185,7 +185,8 @@ def export_table_csv(table_path: str, limit: int = 100_000) -> bytes:
     tbl = pxt.get_table(table_path)
     http_address = Env.get().http_address
     columns, select_dict, media_url_cols, _ = _build_select(tbl)
-    col_names = [c['name'] for c in columns]
+    # Unstored columns have no value to export; their cells would be empty anyway.
+    col_names = [c['name'] for c in columns if c['is_stored']]
 
     results = list(tbl.select(**select_dict).limit(limit).collect())
 
@@ -280,26 +281,38 @@ def _collect_tbl_nodes(nodes: list[pxt.TreeNode], out: list[pxt.TableNode]) -> N
             out.append(n)
 
 
+def _split_tbl_path(tbl_path: str) -> tuple[str, int | None]:
+    """Split a Pixeltable path of the form 'p' or 'p:N' into (path, version)."""
+    head, sep, tail = tbl_path.rpartition(':')
+    if sep is not None and tail.isdigit():
+        return head, int(tail)
+    return tbl_path, None
+
+
 def _collect_pipeline_paths(table_nodes: list[pxt.TableNode], tbl_path: str) -> set[str] | None:
-    """Return paths of all tables/views that are transitively connected to tbl_path"""
+    """Return the version-free paths of all tables/views transitively connected to tbl_path."""
     by_path = {n['path']: n for n in table_nodes}
     if tbl_path not in by_path:
         return None
-    view_map: dict[str, list[str]] = {}  # base path -> list[view path]
+    view_map: dict[str, list[str]] = {}  # unpinned base path -> list[view path]
     for n in table_nodes:
         if n['base'] is not None:
-            view_map.setdefault(n['base'], []).append(n['path'])
+            # make sure we record the base path w/o the version suffix
+            base, _ = _split_tbl_path(n['base'])
+            view_map.setdefault(base, []).append(n['path'])
 
     connected: set[str] = {tbl_path}
-    # collect ancestors
-    current: str | None = tbl_path
+    # ancestors
+    current = tbl_path
     while True:
         base = by_path[current]['base']
         if base is None:
             break
-        connected.add(base)
-        current = base
+        # make sure we record the base path w/o the version suffix
+        current, _ = _split_tbl_path(base)
+        connected.add(current)
 
+    # descendants
     stack = [tbl_path]
     while stack:
         p = stack.pop()
@@ -432,11 +445,18 @@ def get_pipeline(tbl_path: str | None = None) -> dict[str, Any]:
             )
 
             if base_path is not None:
-                assert base_path in pipeline_paths
+                source, base_version = _split_tbl_path(base_path)
+                assert source in pipeline_paths
                 edge_type = md['kind']
-                edges.append(
-                    {'source': base_path, 'target': path, 'type': edge_type, 'label': iterator_name or edge_type}
-                )
+                edge: dict[str, Any] = {
+                    'source': source,
+                    'target': path,
+                    'type': edge_type,
+                    'label': iterator_name or edge_type,
+                }
+                if base_version is not None:
+                    edge['base_version'] = base_version
+                edges.append(edge)
 
         except Exception as e:
             _logger.warning(f'Pipeline: could not inspect {path}: {e}')
@@ -470,16 +490,16 @@ def get_status() -> dict[str, Any]:
     total_tables = 0
     total_errors = 0
 
-    def walk(nodes: list[pxt.TreeNode]) -> None:
+    def collect_totals(nodes: list[pxt.TreeNode]) -> None:
         nonlocal total_tables, total_errors
         for n in nodes:
             if n['kind'] == 'directory':
-                walk(n['entries'])
+                collect_totals(n['entries'])
             else:
                 total_tables += 1
                 total_errors += n['error_count']
 
-    walk(pxt.get_dir_tree())
+    collect_totals(pxt.get_dir_tree())
 
     config_info: dict[str, Any] = {}
     try:

--- a/pixeltable/dashboard/server.py
+++ b/pixeltable/dashboard/server.py
@@ -63,8 +63,6 @@ def _(_path: str, _query: dict) -> dict:
 
 @_api_route('/api/dirs')
 def _(_path: str, _query: dict) -> list:
-    import pixeltable as pxt
-
     return pxt.get_dir_tree()
 
 

--- a/pixeltable/dashboard/server.py
+++ b/pixeltable/dashboard/server.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, NamedTuple
 from urllib.parse import parse_qs, unquote, urlparse
 
+import pixeltable as pxt
 from pixeltable.dashboard import bridge
 
 _logger = logging.getLogger('pixeltable.dashboard')
@@ -62,12 +63,14 @@ def _(_path: str, _query: dict) -> dict:
 
 @_api_route('/api/dirs')
 def _(_path: str, _query: dict) -> list:
-    return bridge.get_directory_tree()
+    import pixeltable as pxt
+
+    return pxt.get_dir_tree()
 
 
 @_api_route('/api/pipeline')
 def _(_path: str, _query: dict) -> dict:
-    return bridge.get_pipeline()
+    return bridge.get_pipeline(tbl_path=_query.get('path'))
 
 
 @_api_route('/api/status')
@@ -98,7 +101,7 @@ def _(path: str, query: dict) -> dict:
 
 @_api_route('/api/tables/meta')
 def _(path: str, _query: dict) -> dict:
-    return dict(bridge.get_table_metadata(path))
+    return dict(pxt.get_table(path).get_metadata())
 
 
 @_api_route('/api/tables/export')

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -18,7 +18,7 @@ from pixeltable.env import Env
 from pixeltable.io.table_data_conduit import QueryTableDataConduit, TableDataConduit
 from pixeltable.runtime import get_runtime
 from pixeltable.share.protocol import PxtUri
-from pixeltable.types import ColumnSpec
+from pixeltable.types import ColumnSpec, DirectoryNode, TableKind, TableNode, TreeNode
 
 if TYPE_CHECKING:
     import datasets  # type: ignore[import-untyped]
@@ -1196,34 +1196,6 @@ class DirContents(TypedDict):
     """List of directory paths contained in this directory."""
     tables: list[str]
     """List of table paths contained in this directory."""
-
-
-class DirectoryNode(TypedDict):
-    """A directory entry in a [`TreeNode`][pixeltable.TreeNode] tree."""
-
-    name: str
-    path: str
-    kind: Literal['directory']
-    entries: list['TreeNode']
-
-
-TableKind = Literal['table', 'view', 'snapshot', 'replica']
-
-
-class TableNode(TypedDict):
-    """A table/view/snapshot/replica entry in a [`TreeNode`][pixeltable.TreeNode] tree."""
-
-    name: str
-    path: str
-    kind: TableKind
-    version: int | None
-    error_count: int
-    """Cumulative error count as recorded in table's history."""
-    base: str | None
-    """Path of the immediate base table for views/snapshots; None for plain tables."""
-
-
-TreeNode = Union[DirectoryNode, TableNode]
 
 
 def _parse_pxt_uri(uri_str: str, param_name: str) -> PxtUri:

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping, TypedDict, Union
+from uuid import UUID
 
 import pandas as pd
 import pydantic
@@ -752,6 +754,88 @@ def _assemble_dir_contents(
             tables.append(path)
 
 
+def get_dir_tree() -> list['TreeNode']:
+    """Get a tree representation of the Pixeltable directory structure.
+
+    Returns:
+        A list of [`TreeNode`][pixeltable.TreeNode] dicts. Each node is either a `DirectoryNode` or a `TableNode`.
+    """
+    path_obj = catalog.Path.parse('', allow_empty_path=True)
+    catalog_entries = get_runtime().catalog.get_dir_contents(path_obj, recursive=True, error_counts=True)
+    path_by_id: dict[UUID, str] = {}
+    _create_path_map('', catalog_entries, path_by_id)
+    return _get_subtree('', catalog_entries, path_by_id)
+
+
+def _create_path_map(dir_path: str, catalog_entries: dict[str, Catalog.DirEntry], path_map: dict[UUID, str]) -> None:
+    """Populate path_map (table id -> table path) for every table reachable from catalog_entries."""
+    for name, entry in catalog_entries.items():
+        if name.startswith('_'):
+            continue
+        path = f'{dir_path}/{name}' if len(dir_path) > 0 else name
+        if entry.dir is not None:
+            _create_path_map(path, entry.dir_entries or {}, path_map)
+        else:
+            assert entry.table is not None
+            path_map[uuid.UUID(entry.table.md['tbl_id'])] = path
+
+
+def _get_subtree(
+    dir_path: str, catalog_entries: dict[str, Catalog.DirEntry], path_by_id: dict[UUID, str]
+) -> list['TreeNode']:
+    nodes: list[TreeNode] = []
+    for name, entry in sorted(catalog_entries.items()):
+        if name.startswith('_'):
+            continue  # Skip system paths
+        path = f'{dir_path}/{name}' if len(dir_path) > 0 else name
+
+        if entry.dir is not None:
+            nodes.append(
+                DirectoryNode(
+                    name=name,
+                    path=path,
+                    kind='directory',
+                    entries=_get_subtree(path, entry.dir_entries or {}, path_by_id),
+                )
+            )
+
+        else:
+            assert entry.table is not None
+            tbl_md = entry.table.md
+            view_md = tbl_md.get('view_md')
+            current_version = tbl_md.get('current_version')
+            kind: TableKind
+            version: int | None
+            if view_md is not None and view_md.get('is_snapshot'):
+                kind = 'snapshot'
+                version = None
+            elif view_md is not None:
+                kind = 'view'
+                version = current_version
+            elif tbl_md.get('is_replica'):
+                kind = 'replica'
+                version = current_version
+            else:
+                kind = 'table'
+                version = current_version
+
+            base: str | None = None
+            if view_md is not None:
+                base_versions = view_md['base_versions']
+                assert len(base_versions) > 0
+                base_id = UUID(base_versions[0][0])
+                base = path_by_id.get(base_id)
+
+            assert entry.table_error_count is not None
+            nodes.append(
+                TableNode(
+                    name=name, path=path, kind=kind, version=version, error_count=entry.table_error_count, base=base
+                )
+            )
+
+    return nodes
+
+
 def list_tables(dir_path: str = '', recursive: bool = True) -> list[str]:
     """List the [`Table`][pixeltable.Table]s in a directory.
 
@@ -1110,6 +1194,34 @@ class DirContents(TypedDict):
     """List of directory paths contained in this directory."""
     tables: list[str]
     """List of table paths contained in this directory."""
+
+
+class DirectoryNode(TypedDict):
+    """A directory entry in a [`TreeNode`][pixeltable.TreeNode] tree."""
+
+    name: str
+    path: str
+    kind: Literal['directory']
+    entries: list['TreeNode']
+
+
+TableKind = Literal['table', 'view', 'snapshot', 'replica']
+
+
+class TableNode(TypedDict):
+    """A table/view/snapshot/replica entry in a [`TreeNode`][pixeltable.TreeNode] tree."""
+
+    name: str
+    path: str
+    kind: TableKind
+    version: int | None
+    error_count: int
+    """Cumulative error count as recorded in table's history."""
+    base: str | None
+    """Path of the immediate base table for views/snapshots; None for plain tables."""
+
+
+TreeNode = Union[DirectoryNode, TableNode]
 
 
 def _parse_pxt_uri(uri_str: str, param_name: str) -> PxtUri:

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -761,7 +761,7 @@ def get_dir_tree() -> list['TreeNode']:
         A list of [`TreeNode`][pixeltable.TreeNode] dicts. Each node is either a `DirectoryNode` or a `TableNode`.
     """
     path_obj = catalog.Path.parse('', allow_empty_path=True)
-    catalog_entries = get_runtime().catalog.get_dir_contents(path_obj, recursive=True, error_counts=True)
+    catalog_entries = get_runtime().catalog.get_dir_contents(path_obj, recursive=True, with_error_counts=True)
     path_by_id: dict[UUID, str] = {}
     _create_path_map('', catalog_entries, path_by_id)
     return _get_subtree('', catalog_entries, path_by_id)
@@ -824,7 +824,10 @@ def _get_subtree(
                 base_versions = view_md['base_versions']
                 assert len(base_versions) > 0
                 base_id = UUID(base_versions[0][0])
-                base = path_by_id.get(base_id)
+                base_path = path_by_id.get(base_id)
+                base_version = base_versions[0][1]
+                if base_path is not None:
+                    base = f'{base_path}:{base_version}' if base_version is not None else base_path
 
             assert entry.table_error_count is not None
             nodes.append(

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping, TypedDict, Union
 from uuid import UUID
@@ -777,7 +776,7 @@ def _create_path_map(dir_path: str, catalog_entries: dict[str, Catalog.DirEntry]
             _create_path_map(path, entry.dir_entries or {}, path_map)
         else:
             assert entry.table is not None
-            path_map[uuid.UUID(entry.table.md['tbl_id'])] = path
+            path_map[entry.table.id] = path
 
 
 def _get_subtree(

--- a/pixeltable/types.py
+++ b/pixeltable/types.py
@@ -1,10 +1,40 @@
 """User-facing types used for type annotations across the Pixeltable codebase."""
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
 
 if TYPE_CHECKING:
     from pixeltable import exprs
+
+
+TableKind = Literal['table', 'view', 'snapshot', 'replica']
+
+
+class DirectoryNode(TypedDict):
+    """A directory entry in a [`TreeNode`][pixeltable.TreeNode] tree."""
+
+    name: str
+    path: str
+    kind: Literal['directory']
+    entries: list['TreeNode']
+
+
+class TableNode(TypedDict):
+    """A table/view/snapshot/replica entry in a [`TreeNode`][pixeltable.TreeNode] tree."""
+
+    name: str
+    path: str
+    kind: TableKind
+    version: int | None
+    error_count: int
+    """Cumulative error count as recorded in table's history."""
+    base: str | None
+    """Path of the immediate base table for views/snapshots; None for plain tables."""
+
+
+TreeNode = Union[DirectoryNode, TableNode]
 
 
 class ColumnSpec(TypedDict, total=False):

--- a/tests/dashboard/test_bridge.py
+++ b/tests/dashboard/test_bridge.py
@@ -250,6 +250,31 @@ class TestBridge:
             'plus_one': ('my_udf', 'custom_udf'),
         }
 
+    def test_pipeline_snapshot_edge(self, uses_db: None) -> None:
+        # Snapshot of an iterator view: validates snapshot edge wiring + version metadata.
+        video_path = get_test_video_files()[0]
+        video_t = pxt.create_table('videos', {'video': pxt.Video})
+        video_t.insert([{'video': video_path}])
+        view = pxt.create_view('frames', video_t, iterator=frame_iterator(video_t.video, fps=1))
+        pxt.create_view('frames_snap', view, is_snapshot=True)
+
+        pipeline = bridge.get_pipeline()
+        snap_node = next(n for n in pipeline['nodes'] if n['path'] == 'frames_snap')
+        snap_edges = [e for e in pipeline['edges'] if e['target'] == 'frames_snap']
+
+        assert len(snap_edges) == 1
+        assert (snap_edges[0]['source'], snap_edges[0]['type'], snap_edges[0]['base_version']) == (
+            'frames',
+            'snapshot',
+            0,
+        )
+        # Snapshot inherits its base view's iterator_call, so iterator_type is populated.
+        # is_view is False (gate is kind == 'view'), even though iterator_type is set — surface
+        # this so any future change to the gating logic is caught.
+        assert snap_node['iterator_type'] == 'frame_iterator'
+        assert snap_node['is_view'] is False
+        assert snap_node['base'] == 'frames:0'
+
     def test_status(self, uses_db: None) -> None:
         result = bridge.get_status()
         assert (result['version'], result['environment']) == (pxt.__version__, 'local')

--- a/tests/dashboard/test_bridge.py
+++ b/tests/dashboard/test_bridge.py
@@ -4,6 +4,9 @@ import numpy as np
 
 import pixeltable as pxt
 from pixeltable.dashboard import bridge
+from pixeltable.functions.video import frame_iterator
+
+from ..utils import get_test_video_files
 
 
 @pxt.udf
@@ -12,79 +15,55 @@ def my_udf(x: int) -> int:
 
 
 @pxt.udf
+def fail_on_neg(x: int) -> int:
+    if x < 0:
+        raise ValueError('negative')
+    return x
+
+
+@pxt.udf
 def dummy_embed(text: str) -> pxt.Array[(3,), pxt.Float]:
     return np.array([1.0, 2.0, 3.0])
 
 
 class TestBridge:
-    def test_directory_tree_empty(self, uses_db: None) -> None:
-        assert bridge.get_directory_tree() == []
-
-    def test_directory_tree(self, uses_db: None) -> None:
-        pxt.create_dir('a')
-        pxt.create_dir('a/b')
-        t = pxt.create_table('a/t1', {'c1': pxt.String})
-        pxt.create_table('a/b/t2', {'c1': pxt.String})
-        pxt.create_view('a/v', t)
-        pxt.create_view('a/snap', t, is_snapshot=True)
-
-        tree = bridge.get_directory_tree()
-        assert len(tree) == 1
-        root = tree[0]
-        assert root['name'] == 'a'
-        assert root['kind'] == 'directory'
-
-        children_by_name = {n['name']: n for n in root['children']}
-        assert children_by_name['t1']['kind'] == 'table'
-        assert children_by_name['v']['kind'] == 'view'
-        assert children_by_name['snap']['kind'] == 'snapshot'
-        assert children_by_name['t1']['error_count'] == 0
-        assert children_by_name['b']['kind'] == 'directory'
-        assert len(children_by_name['b']['children']) == 1
-
     def test_table_metadata_basic(self, uses_db: None) -> None:
         pxt.create_dir('md')
         t = pxt.create_table('md/t', {'c1': pxt.String, 'c2': pxt.Required[pxt.Int]}, primary_key='c2')
         t.add_computed_column(upper=t.c1.upper())
         t.insert([{'c1': 'hello', 'c2': 1}])
 
-        result = bridge.get_table_metadata('md/t')
-        assert result['path'] == 'md/t'
-        assert result['name'] == 't'
-        assert result['is_view'] is False
-        assert result['is_snapshot'] is False
-        assert result['base'] is None
-        assert result['iterator_call'] is None
+        result = pxt.get_table('md/t').get_metadata()
+        assert (
+            result['path'],
+            result['name'],
+            result['is_view'],
+            result['is_snapshot'],
+            result['base'],
+            result['iterator_call'],
+        ) == ('md/t', 't', False, False, None, None)
         assert isinstance(result['version'], int)
 
-        # columns is a dict keyed by column name
-        assert isinstance(result['columns'], dict)
-        assert 'c1' in result['columns']
-        assert result['columns']['c1']['is_computed'] is False
-        assert result['columns']['c2']['is_primary_key'] is True
-        assert result['columns']['upper']['is_computed'] is True
-        assert result['columns']['upper']['computed_with'] is not None
+        cols = result['columns']
+        assert {n: c['is_computed'] for n, c in cols.items()} == {'c1': False, 'c2': False, 'upper': True}
+        assert cols['c2']['is_primary_key'] is True
+        assert cols['upper']['computed_with'] is not None
 
     def test_table_metadata_view(self, uses_db: None) -> None:
         pxt.create_dir('md')
         t = pxt.create_table('md/base', {'c1': pxt.String})
         pxt.create_view('md/v', t)
-        result = bridge.get_table_metadata('md/v')
-        assert result['is_view'] is True
-        assert result['base'] == 'md/base'
+        result = pxt.get_table('md/v').get_metadata()
+        assert (result['is_view'], result['base']) == (True, 'md/base')
 
     def test_table_metadata_indices(self, uses_db: None) -> None:
         pxt.create_dir('md')
         t = pxt.create_table('md/t', {'c1': pxt.String})
         t.add_embedding_index('c1', embedding=dummy_embed)
-        result = bridge.get_table_metadata('md/t')
-        # indices is a dict keyed by index name
-        assert isinstance(result['indices'], dict)
+        result = pxt.get_table('md/t').get_metadata()
         assert len(result['indices']) > 0
         idx = next(iter(result['indices'].values()))
-        assert 'name' in idx
-        assert 'columns' in idx
-        assert 'index_type' in idx
+        assert {'name', 'columns', 'index_type'} <= idx.keys()
 
     def test_table_data_basic(self, uses_db: None) -> None:
         pxt.create_dir('td')
@@ -92,15 +71,9 @@ class TestBridge:
         t.insert([{'c1': 'hello', 'c2': 1}, {'c1': 'world', 'c2': 2}])
 
         result = bridge.get_table_data('td/t')
-        assert result['total_count'] == 2
-        assert len(result['rows']) == 2
-        col_names = [c['name'] for c in result['columns']]
-        assert 'c1' in col_names
-        assert 'c2' in col_names
-        for col in result['columns']:
-            assert 'type' in col
-            assert 'is_media' in col
-            assert 'is_computed' in col
+        assert (result['total_count'], len(result['rows'])) == (2, 2)
+        assert {c['name'] for c in result['columns']} == {'c1', 'c2'}
+        assert all({'type', 'is_media', 'is_computed', 'is_stored'} <= c.keys() for c in result['columns'])
 
     def test_table_data_empty(self, uses_db: None) -> None:
         pxt.create_dir('td')
@@ -140,9 +113,7 @@ class TestBridge:
         pxt.create_dir('td')
         t = pxt.create_table('td/t', {'c1': pxt.String, 'c2': pxt.Int})
         t.insert([{'c1': None, 'c2': None}])
-        row = bridge.get_table_data('td/t')['rows'][0]
-        assert row['c1'] is None
-        assert row['c2'] is None
+        assert bridge.get_table_data('td/t')['rows'][0] == {'c1': None, 'c2': None}
 
     def test_table_data_json(self, uses_db: None) -> None:
         pxt.create_dir('td')
@@ -182,28 +153,16 @@ class TestBridge:
         assert 'key' in csv_str
 
     def test_search_empty_db(self, uses_db: None) -> None:
-        result = bridge.search('anything')
-        assert result['query'] == 'anything'
-        assert result['directories'] == []
-        assert result['tables'] == []
-        assert result['columns'] == []
+        assert bridge.search('anything') == {'query': 'anything', 'directories': [], 'tables': [], 'columns': []}
 
     def test_search_finds_dir_table_column(self, uses_db: None) -> None:
         pxt.create_dir('proj')
         pxt.create_table('proj/users', {'email': pxt.String, 'age': pxt.Int})
 
-        r = bridge.search('proj')
-        assert len(r['directories']) == 1
-        assert r['directories'][0]['path'] == 'proj'
-
-        r = bridge.search('users')
-        assert len(r['tables']) == 1
-        assert r['tables'][0]['path'] == 'proj/users'
-
-        r = bridge.search('email')
-        assert len(r['columns']) == 1
-        assert r['columns'][0]['name'] == 'email'
-        assert r['columns'][0]['table'] == 'proj/users'
+        assert [d['path'] for d in bridge.search('proj')['directories']] == ['proj']
+        assert [t['path'] for t in bridge.search('users')['tables']] == ['proj/users']
+        col = bridge.search('email')['columns']
+        assert [(c['name'], c['table']) for c in col] == [('email', 'proj/users')]
 
     def test_search_case_insensitive(self, uses_db: None) -> None:
         pxt.create_dir('MyDir')
@@ -216,20 +175,15 @@ class TestBridge:
         assert len(bridge.search('match', limit=3)['tables']) == 3
 
     def test_pipeline(self, uses_db: None) -> None:
-        # Test when empty
         assert bridge.get_pipeline() == {'nodes': [], 'edges': []}
 
-        # Now add some structure
         pxt.create_dir('pp')
         t = pxt.create_table('pp/t', {'c1': pxt.String})
         t.insert([{'c1': 'hello'}])
         result = bridge.get_pipeline()
         assert len(result['nodes']) == 1
         node = result['nodes'][0]
-        assert node['path'] == 'pp/t'
-        assert node['name'] == 't'
-        assert node['is_view'] is False
-        assert node['row_count'] == 1
+        assert (node['path'], node['name'], node['is_view'], node['row_count']) == ('pp/t', 't', False, 1)
         expected_keys = {
             'path',
             'name',
@@ -237,7 +191,6 @@ class TestBridge:
             'base',
             'row_count',
             'version',
-            'total_errors',
             'columns',
             'indices',
             'versions',
@@ -246,10 +199,27 @@ class TestBridge:
             'iterator_type',
         }
         assert expected_keys.issubset(node.keys())
-        # Non-computed column has no func info
         cols_by_name = {c['name']: c for c in node['columns']}
-        assert cols_by_name['c1']['func_name'] is None
-        assert cols_by_name['c1']['func_type'] is None
+        assert (cols_by_name['c1']['func_name'], cols_by_name['c1']['func_type']) == (None, None)
+
+    def test_pipeline_scoped(self, uses_db: None) -> None:
+        # Build a chain root -> mid -> leaf, plus an unrelated standalone table.
+        pxt.create_dir('sc')
+        root = pxt.create_table('sc/root', {'c': pxt.String})
+        mid = pxt.create_view('sc/mid', root)
+        pxt.create_view('sc/leaf', mid)
+        pxt.create_table('sc/other', {'c': pxt.String})
+
+        # Scoped to mid: includes ancestor (root), self (mid), descendant (leaf); excludes 'other'.
+        result = bridge.get_pipeline(tbl_path='sc/mid')
+        assert {n['path'] for n in result['nodes']} == {'sc/root', 'sc/mid', 'sc/leaf'}
+        assert {(e['source'], e['target']) for e in result['edges']} == {('sc/root', 'sc/mid'), ('sc/mid', 'sc/leaf')}
+
+        # Unknown path returns empty.
+        assert bridge.get_pipeline(tbl_path='sc/missing') == {'nodes': [], 'edges': []}
+
+        # No path returns the full catalog.
+        assert {n['path'] for n in bridge.get_pipeline()['nodes']} == {'sc/root', 'sc/mid', 'sc/leaf', 'sc/other'}
 
     def test_pipeline_view_edge(self, uses_db: None) -> None:
         pxt.create_dir('pp')
@@ -257,11 +227,7 @@ class TestBridge:
         pxt.create_view('pp/v', t)
         result = bridge.get_pipeline()
         assert len(result['nodes']) == 2
-        assert len(result['edges']) == 1
-        edge = result['edges'][0]
-        assert edge['source'] == 'pp/base'
-        assert edge['target'] == 'pp/v'
-        assert edge['type'] == 'view'
+        assert [(e['source'], e['target'], e['type']) for e in result['edges']] == [('pp/base', 'pp/v', 'view')]
 
     def test_pipeline_computed_columns(self, uses_db: None) -> None:
         pxt.create_dir('pp')
@@ -272,35 +238,91 @@ class TestBridge:
         t.add_computed_column(add3=t.c1.len() + my_udf(t.c2))
         t.add_computed_column(plus_one=my_udf(t.c1.len()))
         node = bridge.get_pipeline()['nodes'][0]
-        assert node['computed_count'] == 5
-        assert node['insertable_count'] == 2
-        cols_by_name = {c['name']: c for c in node['columns']}
-        assert cols_by_name['c1']['func_name'] is None
-        assert cols_by_name['c1']['func_type'] is None
-        assert cols_by_name['c2']['func_name'] is None
-        assert cols_by_name['c2']['func_type'] is None
-        assert cols_by_name['upper']['func_name'] == 'upper'
-        assert cols_by_name['upper']['func_type'] == 'builtin'
-        assert cols_by_name['add']['func_name'] == 'len'
-        assert cols_by_name['add']['func_type'] == 'builtin'
-        assert cols_by_name['add2']['func_name'] == 'len'
-        assert cols_by_name['add2']['func_type'] == 'builtin'
-        assert cols_by_name['add3']['func_name'] == 'len'
-        assert cols_by_name['add3']['func_type'] == 'custom_udf'
-        assert cols_by_name['plus_one']['func_name'] == 'my_udf'
-        assert cols_by_name['plus_one']['func_type'] == 'custom_udf'
+        assert (node['computed_count'], node['insertable_count']) == (5, 2)
+        funcs = {c['name']: (c['func_name'], c['func_type']) for c in node['columns']}
+        assert funcs == {
+            'c1': (None, None),
+            'c2': (None, None),
+            'upper': ('upper', 'builtin'),
+            'add': ('len', 'builtin'),
+            'add2': ('len', 'builtin'),
+            'add3': ('len', 'custom_udf'),
+            'plus_one': ('my_udf', 'custom_udf'),
+        }
 
     def test_status(self, uses_db: None) -> None:
         result = bridge.get_status()
-        assert result['version'] == pxt.__version__
-        assert result['environment'] == 'local'
+        assert (result['version'], result['environment']) == (pxt.__version__, 'local')
         assert isinstance(result['total_tables'], int)
         assert isinstance(result['total_errors'], int)
-        assert 'home' in result['config']
-        assert 'media_dir' in result['config']
+        assert {'home', 'media_dir'} <= result['config'].keys()
 
     def test_status_table_count(self, uses_db: None) -> None:
         pxt.create_dir('st')
         pxt.create_table('st/t1', {'c1': pxt.String})
         pxt.create_table('st/t2', {'c1': pxt.String})
         assert bridge.get_status()['total_tables'] == 2
+
+    def test_table_data_unstored_column(self, uses_db: None) -> None:
+        # Unstored computed columns must not be evaluated by the data view.
+        # The expression here would raise on negative inputs; the test asserts that
+        # get_table_data succeeds anyway and reports the column as is_stored=False.
+        t = pxt.create_table('udata', {'x': pxt.Int})
+        t.add_computed_column(plus_one=t.x + 1)
+        t.add_computed_column(boom=fail_on_neg(t.x), stored=False)
+        t.insert([{'x': 1}, {'x': -1}, {'x': 2}])
+
+        result = bridge.get_table_data('udata')
+        storage_by_name = {c['name']: c['is_stored'] for c in result['columns']}
+        assert storage_by_name == {'x': True, 'plus_one': True, 'boom': False}
+        assert result['rows'] == [{'x': 1, 'plus_one': 2}, {'x': -1, 'plus_one': 0}, {'x': 2, 'plus_one': 3}]
+
+        # Sorting by an unstored column is a no-op (does not raise, does not reorder).
+        sorted_result = bridge.get_table_data('udata', order_by='boom', order_desc=True)
+        assert [row['x'] for row in sorted_result['rows']] == [1, -1, 2]
+
+        # get_pipeline calls the per-column-error-count helper internally; pre-fix that helper
+        # raised on the unstored 'boom' column and the table landed in the error-stub branch.
+        node = next(n for n in bridge.get_pipeline()['nodes'] if n['path'] == 'udata')
+        assert 'error' not in node
+
+    def test_table_data_sort_gating(self, uses_db: None) -> None:
+        # Only stored, B-tree-indexed columns should be reported as sortable. Postgres has no
+        # cheap ordering for bool / json / unstored columns, so the bridge skips them.
+        pxt.create_dir('s')
+        t = pxt.create_table('s/t', {'name': pxt.String, 'flag': pxt.Bool, 'meta': pxt.Json})
+        t.add_computed_column(boom=fail_on_neg(t.name.len()), stored=False)
+        t.insert([{'name': 'b', 'flag': True, 'meta': {}}, {'name': 'a', 'flag': False, 'meta': {}}])
+
+        result = bridge.get_table_data('s/t')
+        sorted_by_name = {c['name']: c['is_sorted'] for c in result['columns']}
+        assert sorted_by_name == {'name': True, 'flag': False, 'meta': False, 'boom': False}
+
+        # Sort by an indexed column works.
+        sorted_asc = bridge.get_table_data('s/t', order_by='name')
+        assert [r['name'] for r in sorted_asc['rows']] == ['a', 'b']
+
+        # Sort by non-indexed columns is a silent no-op (does not raise, does not reorder).
+        unsorted = bridge.get_table_data('s/t', order_by='flag', order_desc=True)
+        assert [r['name'] for r in unsorted['rows']] == [r['name'] for r in result['rows']]
+
+    def test_table_data_iterator_view(self, uses_db: None) -> None:
+        video_path = get_test_video_files()[0]
+        pxt.create_dir('iv')
+        video_t = pxt.create_table('iv/videos', {'video': pxt.Video})
+        video_t.insert([{'video': video_path}])
+        pxt.create_view('iv/frames', video_t, iterator=frame_iterator(video_t.video, fps=1))
+
+        result = bridge.get_table_data('iv/frames')
+        storage_by_name = {c['name']: c['is_stored'] for c in result['columns']}
+        assert storage_by_name == {'pos': False, 'frame': False, 'frame_attrs': True, 'video': True}
+        assert all(set(row.keys()) == {'frame_attrs', 'video'} for row in result['rows'])
+
+        # Sort by an unstored column is a silent no-op (does not raise, does not reorder).
+        sorted_result = bridge.get_table_data('iv/frames', order_by='frame', order_desc=True)
+        assert [r['frame_attrs'] for r in sorted_result['rows']] == [r['frame_attrs'] for r in result['rows']]
+
+        pipeline = bridge.get_pipeline()
+        view_node = next(n for n in pipeline['nodes'] if n['path'] == 'iv/frames')
+        assert 'error' not in view_node
+        assert view_node['is_view'] is True

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -235,8 +235,16 @@ class TestPackager:
 
         # Certain metadata properties must be identical.
         metadata = t.get_metadata()
-        for property in ('indices', 'version', 'version_created', 'schema_version', 'comment', 'media_validation'):
+        for property in ('version', 'version_created', 'schema_version', 'comment', 'media_validation'):
             assert metadata[property] == bundle_info.metadata[property]
+
+        # Compare embedding indices only: btree indices aren't surfaced in a snapshot's
+        # `idxs_by_name`, but they are in a live replica's, producing a benign asymmetry
+        # we don't want to assert on. Embedding indices, on the other hand, must round-trip.
+        def embedding_indices(md: pxt.TableMetadata) -> dict[str, Any]:
+            return {k: v for k, v in md['indices'].items() if v['index_type'] == 'embedding'}
+
+        assert embedding_indices(metadata) == embedding_indices(bundle_info.metadata)
 
         # Verify that the postgres schema subsumes the original.
         # (There may be additional columns in the restored table depending on the order in which different versions are

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -238,9 +238,10 @@ class TestPackager:
         for property in ('version', 'version_created', 'schema_version', 'comment', 'media_validation'):
             assert metadata[property] == bundle_info.metadata[property]
 
-        # Compare embedding indices only: btree indices aren't surfaced in a snapshot's
-        # `idxs_by_name`, but they are in a live replica's, producing a benign asymmetry
-        # we don't want to assert on. Embedding indices, on the other hand, must round-trip.
+        # Btree indices auto-populate based on the underlying TableVersion's supports_idxs flag,
+        # which can flip across a bundle/restore boundary (e.g. a snapshot's tv has supports_idxs=False
+        # at the source, but the restored replica tv at head has supports_idxs=True). Embedding indices
+        # come from explicit user IndexMd that's preserved through the bundle, so they must round-trip.
         def embedding_indices(md: pxt.TableMetadata) -> dict[str, Any]:
             return {k: v for k, v in md['indices'].items() if v['index_type'] == 'embedding'}
 

--- a/tests/share/test_packager.py
+++ b/tests/share/test_packager.py
@@ -7,7 +7,7 @@ import tarfile
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 import pandas as pd

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -90,7 +90,7 @@ class TestDirs:
             'kind': 'snapshot',
             'version': None,
             'error_count': 0,
-            'base': 'dir1/t1',
+            'base': 'dir1/t1:0',
         }
         dir1 = {'name': 'dir1', 'path': 'dir1', 'kind': 'directory', 'entries': [snap, sub1, t1, v]}
         t2 = {'name': 't2', 'path': 't2', 'kind': 'table', 'version': 0, 'error_count': 0, 'base': None}

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -5,6 +5,13 @@ import pixeltable as pxt
 from .utils import make_tbl, pxt_raises, reload_catalog
 
 
+@pxt.udf
+def _fail_on_neg(x: int) -> int:
+    if x < 0:
+        raise ValueError('negative')
+    return x
+
+
 class TestDirs:
     def test_create(self, uses_db: None) -> None:
         dirs = ['dir1', 'dir1/sub1', 'dir1/sub1/subsub1']
@@ -63,6 +70,44 @@ class TestDirs:
         assert listing == {'dirs': ['dir1/sub1/subsub1'], 'tables': []}
         listing = pxt.get_dir_contents('dir1/sub1', recursive=False)
         assert listing == {'dirs': ['dir1/sub1/subsub1'], 'tables': []}
+
+    def test_get_dir_tree(self, uses_db: None) -> None:
+        for name in ['dir1', 'dir1/sub1', 'dir1/sub1/subsub1']:
+            pxt.create_dir(name)
+        t = make_tbl('dir1/t1')
+        make_tbl('t2')
+        pxt.create_view('dir1/v', t)
+        pxt.create_view('dir1/snap', t, is_snapshot=True)
+        reload_catalog()
+
+        subsub1 = {'name': 'subsub1', 'path': 'dir1/sub1/subsub1', 'kind': 'directory', 'entries': []}
+        sub1 = {'name': 'sub1', 'path': 'dir1/sub1', 'kind': 'directory', 'entries': [subsub1]}
+        t1 = {'name': 't1', 'path': 'dir1/t1', 'kind': 'table', 'version': 0, 'error_count': 0, 'base': None}
+        v = {'name': 'v', 'path': 'dir1/v', 'kind': 'view', 'version': 0, 'error_count': 0, 'base': 'dir1/t1'}
+        snap = {
+            'name': 'snap',
+            'path': 'dir1/snap',
+            'kind': 'snapshot',
+            'version': None,
+            'error_count': 0,
+            'base': 'dir1/t1',
+        }
+        dir1 = {'name': 'dir1', 'path': 'dir1', 'kind': 'directory', 'entries': [snap, sub1, t1, v]}
+        t2 = {'name': 't2', 'path': 't2', 'kind': 'table', 'version': 0, 'error_count': 0, 'base': None}
+        assert pxt.get_dir_tree() == [dir1, t2]
+
+    def test_get_dir_tree_error_count(self, uses_db: None) -> None:
+        t = pxt.create_table('errs', {'x': pxt.Int})
+        t.add_computed_column(y=_fail_on_neg(t.x))
+        t.insert([{'x': 1}, {'x': -1}, {'x': -2}, {'x': 3}], on_error='ignore')
+
+        # Two failing rows; pixeltable counts each error per affected column slot, so the reported
+        # count is 4 (= 2 rows x 2 slots: the computed column 'y' plus the row-level error slot).
+        tree = pxt.get_dir_tree()
+        assert len(tree) == 1
+        node = tree[0]
+        assert node['kind'] == 'table'
+        assert node['error_count'] == 4
 
     def test_create_if_exists(self, uses_db: None) -> None:
         """Test if_exists parameter of create_dir API"""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -329,7 +329,9 @@ class TestTable:
                         }
                     },
                     'comment': None,
-                    'indices': {},
+                    'indices': {
+                        'idx0': {'name': 'idx0', 'columns': ['col'], 'index_type': 'btree', 'parameters': None}
+                    },
                     'is_view': False,
                     'is_snapshot': False,
                     'is_replica': False,
@@ -624,7 +626,14 @@ class TestTable:
                 },
                 'comment': None,
                 'custom_metadata': None,
-                'indices': {},
+                'indices': {
+                    'idx0': {'name': 'idx0', 'columns': ['c1'], 'index_type': 'btree', 'parameters': None},
+                    'idx1': {'name': 'idx1', 'columns': ['c2'], 'index_type': 'btree', 'parameters': None},
+                    'idx2': {'name': 'idx2', 'columns': ['img'], 'index_type': 'btree', 'parameters': None},
+                    'idx3': {'name': 'idx3', 'columns': ['plus1'], 'index_type': 'btree', 'parameters': None},
+                    'idx4': {'name': 'idx4', 'columns': ['sum12'], 'index_type': 'btree', 'parameters': None},
+                    'idx5': {'name': 'idx5', 'columns': ['custom'], 'index_type': 'btree', 'parameters': None},
+                },
                 'is_view': False,
                 'is_snapshot': False,
                 'is_replica': False,
@@ -772,7 +781,9 @@ class TestTable:
                 },
                 'comment': None,
                 'custom_metadata': None,
-                'indices': {},
+                'indices': {
+                    'idx0': {'name': 'idx0', 'columns': ['derived'], 'index_type': 'btree', 'parameters': None}
+                },
                 'is_view': True,
                 'is_snapshot': False,
                 'is_replica': False,
@@ -812,7 +823,9 @@ class TestTable:
                 'custom_metadata': None,
                 'primary_key': None,
                 'media_validation': 'on_write',
-                'indices': {},
+                'indices': {
+                    'idx0': {'name': 'idx0', 'columns': ['derived'], 'index_type': 'btree', 'parameters': None}
+                },
                 'columns': {
                     'pos': {
                         'name': 'pos',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,9 +70,17 @@ def runs_linux_with_gpu() -> bool:
 
 @pxt.udf
 def sleep(n: float) -> float:
-    """Sleep for `n` seconds, return `n`. Used in tests to deliberately delay inserts."""
+    """Sleep for n seconds, return n. Used in tests to deliberately delay inserts."""
     time.sleep(n)
     return n
+
+
+@pxt.udf
+def error(error: bool) -> bool:
+    """Raise AssertionError if error == True"""
+    if error:
+        raise AssertionError()
+    return False
 
 
 def make_default_type(t: ts.ColumnType.Type) -> ts.ColumnType:


### PR DESCRIPTION
Performance

- /api/dirs: ~17.5s -> ~45ms on a 155-table catalog. Sidebar tree no longer instantiates Tables (which triggers transformer model loads); reads kind/version straight from the catalog.
- /api/pipeline gained a path query parameter that scopes to the connected component. TableDetailView's per-table lineage fetch went from ~20s to ~85ms.
- Per-table error counts come from a single GROUP BY over tableversions JSONB, not a per-table sweep.
- Data-table sort is restricted to B-tree-indexed columns. Avoids unbounded sorts on Bool/JSON/unstored columns.

Correctness

- Views with unstored or iterator-output columns no longer break the data tab. The bridge skips unstored columns from value/error fetches and from sort, surfacing them as a muted placeholder in the UI.
- The pipeline endpoint no longer falls into the error-stub branch on tables with unstored computed columns.

API

- New pxt.get_dir_tree() with TreeNode TypedDicts (DirectoryNode | TableNode).
- TableMetadata gained id; IndexMetadata covers B-tree indexes too; ColumnMetadata via the bridge gains is_stored / is_sorted.
- get_pipeline(tbl_path) for scoped lookups; error counts removed from its response.

Frontend

- Sidebar/main and schema/data dividers are draggable (react-resizable-panels), with persistence. Schema panel auto-fits on first table visit, then remembers per-table.
- Schema column widths are drag-resizable with min-width clamps and double-click reset.
- Long expressions open a click-to-expand modal with Python syntax highlighting.
- All error-count UI is consolidated to the sidebar tree.
- Default B-tree indexes are filtered out of the schema-panel index list.