### PR TITLE
Explicitly install pip in all conda environments in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,7 +105,7 @@ jobs:
           conda-remove-defaults: true
       - name: Install python
         run: |
-          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=${{ matrix.python-version }}
+          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=${{ matrix.python-version }} pip
           conda info
       - name: Install tools and libraries
         # cmake is needed for certain CI environments where it is not preinstalled.

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -164,7 +164,7 @@ jobs:
           conda-remove-defaults: true
       - name: Install python
         run: |
-          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=${{ matrix.python-version }}
+          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=${{ matrix.python-version }} pip
           conda info
       - name: Install tools and libraries
         # cmake is needed for certain CI environments where it is not preinstalled.

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -53,7 +53,7 @@ jobs:
           conda-remove-defaults: true
       - name: Install python
         run: |
-          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=3.10
+          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=3.10 pip
           conda info
       - name: Install uv
         run: |
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install python
         run: |
-          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=3.10
+          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=3.10 pip
           conda info
 
       - name: Install uv
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install python
         run: |
-          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=3.10
+          ./scripts/retry.sh 3 30 conda install -y -c conda-forge python=3.10 pip
           conda info
 
       - name: Install uv

--- a/scripts/run-isolated-nb-tests.sh
+++ b/scripts/run-isolated-nb-tests.sh
@@ -31,7 +31,7 @@ for nb in "$TEST_PATH"/*.ipynb; do
     echo "Testing notebook: $nb"
 
     echo "Creating conda environment $NB_CONDA_ENV ..."
-    conda create -y --name "$NB_CONDA_ENV" python="$PY_VERSION"
+    conda create -y --name "$NB_CONDA_ENV" python="$PY_VERSION" pip
 
     echo "Activating conda environment ..."
     conda activate "$NB_CONDA_ENV"


### PR DESCRIPTION
Something changed in GitHub Actions over the weekend that caused miniforge to stop installing `pip` automatically alongside `python`.

This PR adds `pip` as an explicit dependency in all conda environments in CI.