### PR TITLE
Fixing LC_CTYPE to use legacy locale on MacOS

### DIFF
--- a/pixeltable/utils/dbms.py
+++ b/pixeltable/utils/dbms.py
@@ -47,12 +47,13 @@ class PostgresqlDbms(Dbms):
         return f'DROP DATABASE {database}'
 
     def create_db_stmt(self, database: str) -> str:
-        if platform.system() == 'Windows':
-            lc_ctype = '.UTF-8'
-        elif platform.system() == 'Darwin':
-            lc_ctype = 'en_US.UTF-8'
-        else:
-            lc_ctype = 'C.UTF-8'
+        match platform.system():
+            case 'Windows':
+                lc_ctype = '.UTF-8'
+            case 'Darwin':
+                lc_ctype = 'en_US.UTF-8'
+            case _:
+                lc_ctype = 'C.UTF-8'
         return f"CREATE DATABASE {database} TEMPLATE template0 ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE '{lc_ctype}'"
 
     def default_system_db_url(self) -> str:

--- a/pixeltable/utils/dbms.py
+++ b/pixeltable/utils/dbms.py
@@ -47,7 +47,12 @@ class PostgresqlDbms(Dbms):
         return f'DROP DATABASE {database}'
 
     def create_db_stmt(self, database: str) -> str:
-        lc_ctype = '.UTF-8' if platform.system() == 'Windows' else 'C.UTF-8'
+        if platform.system() == 'Windows':
+            lc_ctype = '.UTF-8'
+        elif platform.system() == 'Darwin':
+            lc_ctype = 'en_US.UTF-8'
+        else:
+            lc_ctype = 'C.UTF-8'
         return f"CREATE DATABASE {database} TEMPLATE template0 ENCODING 'UTF8' LC_COLLATE 'C' LC_CTYPE '{lc_ctype}'"
 
     def default_system_db_url(self) -> str:


### PR DESCRIPTION
A bug was introduced in https://github.com/pixeltable/pixeltable/pull/1286, in which we assume that all MacOS systems have C.UTF-8 available as a locale option for Postgres. This was mistaken, as C.UTF-8 was a recent addition to MacOS, and the legacy locale available since MacOS 12+ is en_US.UTF-8, which is required regardless of system language. 