### PR TITLE
Add FAL, Jina, and Reve tests to CI

### DIFF
--- a/tests/functions/test_fal.py
+++ b/tests/functions/test_fal.py
@@ -6,6 +6,7 @@ import pixeltable as pxt
 from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 
+@pytest.mark.expensive
 @pytest.mark.remote_api
 @rerun(reruns=3, reruns_delay=8)
 class TestFal:

--- a/tests/functions/test_jina.py
+++ b/tests/functions/test_jina.py
@@ -5,6 +5,7 @@ import pixeltable as pxt
 from ..utils import rerun, skip_test_if_no_client, validate_update_status
 
 
+@pytest.mark.expensive
 @pytest.mark.remote_api
 @rerun(reruns=3, reruns_delay=8)
 class TestJina:

--- a/tests/functions/test_reve.py
+++ b/tests/functions/test_reve.py
@@ -10,9 +10,8 @@ from ..utils import rerun, skip_test_if_no_client, validate_update_status
 _logger = logging.getLogger('pixeltable')
 
 
-@pytest.mark.skip(reason='[PXT-1116] Out of credits')
-@pytest.mark.remote_api
 @pytest.mark.expensive
+@pytest.mark.remote_api
 @rerun(reruns=3, reruns_delay=8)
 class TestReve:
     @pytest.mark.parametrize('default_params', [True, False], ids=['default_params', 'nondefault_params'])


### PR DESCRIPTION
Enables Reve tests in CI.

Marks FAL and Jina tests as expensive since their keys are now in CI.