### PR TITLE
Add defensive guards to dashboard tree traversal

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -53,7 +53,7 @@ function findTreeNode(nodes: TreeNode[], path: string): TreeNode | null {
   for (const n of nodes) {
     if (n.path === path) return n
     if (n.kind === 'directory') {
-      const found = findTreeNode(n.entries, path)
+      const found = findTreeNode(n.entries ?? [], path)
       if (found) return found
     }
   }
@@ -63,7 +63,7 @@ function findTreeNode(nodes: TreeNode[], path: string): TreeNode | null {
 function flattenTables(node: TreeNode): TableNode[] {
   if (node.kind !== 'directory') return []
   const tables: TableNode[] = []
-  for (const c of node.entries) {
+  for (const c of node.entries ?? []) {
     if (c.kind === 'directory') tables.push(...flattenTables(c))
     else tables.push(c)
   }

--- a/dashboard/src/components/DirectoryTree.tsx
+++ b/dashboard/src/components/DirectoryTree.tsx
@@ -42,20 +42,23 @@ function getNodeIcon(type: string, isOpen: boolean = false) {
 }
 
 function countDescendants(node: TreeNode): number {
-  if (node.kind !== 'directory' || node.entries.length === 0) return 0
-  return node.entries.reduce((sum, child) => sum + 1 + countDescendants(child), 0)
+  if (node.kind !== 'directory') return 0
+  const entries = node.entries ?? []
+  if (entries.length === 0) return 0
+  return entries.reduce((sum, child) => sum + 1 + countDescendants(child), 0)
 }
 
 function countAllNodes(nodes: TreeNode[]): number {
+  if (!nodes) return 0
   return nodes.reduce(
-    (sum, n) => sum + 1 + (n.kind === 'directory' ? countAllNodes(n.entries) : 0),
+    (sum, n) => sum + 1 + (n.kind === 'directory' ? countAllNodes(n.entries ?? []) : 0),
     0,
   )
 }
 
 function nodeMatchesFilter(node: TreeNode, q: string): boolean {
   if (node.name.toLowerCase().includes(q)) return true
-  if (node.kind === 'directory') return node.entries.some(c => nodeMatchesFilter(c, q))
+  if (node.kind === 'directory') return (node.entries ?? []).some(c => nodeMatchesFilter(c, q))
   return false
 }
 
@@ -65,7 +68,8 @@ function TreeItem({ node, level, selectedPath, onSelect, filter, collapsedAll }:
 }) {
   const [manualOpen, setManualOpen] = useState<boolean | null>(null)
   const isDirectory = node.kind === 'directory'
-  const hasChildren = isDirectory && node.entries.length > 0
+  const entries = isDirectory ? (node.entries ?? []) : []
+  const hasChildren = isDirectory && entries.length > 0
   const descendantCount = useMemo(() => countDescendants(node), [node])
   const hasErrors = !isDirectory && node.error_count > 0
 
@@ -134,7 +138,7 @@ function TreeItem({ node, level, selectedPath, onSelect, filter, collapsedAll }:
 
       {isDirectory && hasChildren && isOpen && (
         <div>
-          {node.entries.map((child) => (
+          {entries.map((child) => (
             <TreeItem
               key={child.path}
               node={child}

--- a/dashboard/src/components/DirectoryTree.tsx
+++ b/dashboard/src/components/DirectoryTree.tsx
@@ -49,7 +49,6 @@ function countDescendants(node: TreeNode): number {
 }
 
 function countAllNodes(nodes: TreeNode[]): number {
-  if (!nodes) return 0
   return nodes.reduce(
     (sum, n) => sum + 1 + (n.kind === 'directory' ? countAllNodes(n.entries ?? []) : 0),
     0,

--- a/dashboard/src/components/PipelineInspector.tsx
+++ b/dashboard/src/components/PipelineInspector.tsx
@@ -759,7 +759,7 @@ function PipelineInspectorInner() {
     const views = pipeline.nodes.filter((n) => n.is_view).length
     const totalRows = pipeline.nodes.reduce((s, n) => s + n.row_count, 0)
     const totalComputed = pipeline.nodes.reduce((s, n) => s + n.computed_count, 0)
-    const totalIndices = pipeline.nodes.reduce((s, n) => s + (n.indices?.length ?? 0), 0)
+    const totalIndices = pipeline.nodes.reduce((s, n) => s + n.indices.length, 0)
     return { tables, views, totalRows, totalComputed, totalIndices }
   }, [pipeline])
 

--- a/dashboard/src/components/PipelineInspector.tsx
+++ b/dashboard/src/components/PipelineInspector.tsx
@@ -759,7 +759,7 @@ function PipelineInspectorInner() {
     const views = pipeline.nodes.filter((n) => n.is_view).length
     const totalRows = pipeline.nodes.reduce((s, n) => s + n.row_count, 0)
     const totalComputed = pipeline.nodes.reduce((s, n) => s + n.computed_count, 0)
-    const totalIndices = pipeline.nodes.reduce((s, n) => s + n.indices.length, 0)
+    const totalIndices = pipeline.nodes.reduce((s, n) => s + (n.indices?.length ?? 0), 0)
     return { tables, views, totalRows, totalComputed, totalIndices }
   }, [pipeline])
 


### PR DESCRIPTION
## Summary

The recursive directory-tree functions (`countAllNodes`, `countDescendants`, `nodeMatchesFilter`, etc.) call `.reduce()` / `.some()` directly on `node.entries` without null checks. If the API ever returns a directory node with a missing or undefined `entries` array — e.g. due to a version mismatch, partial response, or future schema change — the entire dashboard white-screens with a `TypeError`.