### PR TITLE
Thread concurrency-related bug fixes

### DIFF
--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -616,6 +616,9 @@ class Query:
         return len(self._from_clause.join_clauses) > 0
 
     def show(self, n: int = 20) -> ResultSet:
+        # See _output_row_iterator for the rationale on the defensive copy.
+        if self._origin_catalog is not get_runtime().catalog:
+            return copy.deepcopy(self).show(n)
         if self.sample_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'show() cannot be used with sample()')
         assert n is not None
@@ -636,6 +639,9 @@ class Query:
             Error: If the Query is the result of a join or
                 if the Query has an order_by clause.
         """
+        # See _output_row_iterator for the rationale on the defensive copy.
+        if self._origin_catalog is not get_runtime().catalog:
+            return copy.deepcopy(self).head(n)
         if self.order_by_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'head() cannot be used with order_by()')
         if self._has_joins():
@@ -663,6 +669,9 @@ class Query:
             Error: If the Query is the result of a join or
                 if the Query has an order_by clause.
         """
+        # See _output_row_iterator for the rationale on the defensive copy.
+        if self._origin_catalog is not get_runtime().catalog:
+            return copy.deepcopy(self).tail(n)
         if self.order_by_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'tail() cannot be used with order_by()')
         if self._has_joins():
@@ -860,6 +869,9 @@ class Query:
         Returns:
             The number of rows in the Query.
         """
+        # See _output_row_iterator for the rationale on the defensive copy.
+        if self._origin_catalog is not get_runtime().catalog:
+            return copy.deepcopy(self).count()
         if self.limit_val is not None and self.limit_val.val == 0:
             return 0
         with get_runtime().catalog.begin_xact(read_tbl_ids=self.referenced_tbl_ids()) as conn:

--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -716,7 +716,11 @@ class Query:
                 )
 
         return Query(
-            from_clause=self._from_clause,
+            # Deepcopy from_clause so its TableVersionHandles get their _tbl_version cache
+            # reset (via TableVersionHandle.__deepcopy__). Without this, a worker thread
+            # executing a bound Query would render FROM via the importing thread's sa_tbl
+            # while WHERE references its own sa_tbl, producing a duplicate-FROM error.
+            from_clause=copy.deepcopy(self._from_clause),
             select_list=select_list,
             where_clause=where_clause,
             group_by_clause=group_by_clause,

--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -357,7 +357,11 @@ class ResultCursor(Iterable[Row]):
 
 
 class Query:
-    """Represents a query for retrieving and transforming data from Pixeltable tables."""
+    """
+    Represents a query for retrieving and transforming data from Pixeltable tables.
+
+    Thread-safe.
+    """
 
     _from_clause: plan.FromClause
     _select_list_exprs: list[exprs.Expr]
@@ -365,19 +369,14 @@ class Query:
     select_list: list[tuple[exprs.Expr, str | None]] | None
     where_clause: exprs.Expr | None
     group_by_clause: list[exprs.Expr] | None
-    # Stored as a TableVersionHandle (identity-only) rather than a TableVersion so the Query
-    # is shareable across thread/transaction boundaries: every read goes through the catalog's
-    # is_validated-gated machinery on the calling thread.
+    # TVH: we need to avoid inadvertently caching catalog objects, which get invalidated across thread/xact boundaries
     grouping_tbl: catalog.TableVersionHandle | None
     order_by_clause: list[tuple[exprs.Expr, bool]] | None
     limit_val: exprs.Expr | None
     offset_val: exprs.Expr | None
     sample_clause: SampleClause | None
-    # The Catalog instance this Query was constructed against. Used by _exec / _aexec to
-    # defensively deepcopy when the Query is invoked under a different Catalog (e.g., a
-    # global Query held by user code and called from FastAPI worker threads, or a Query
-    # held across reset_runtime). Set in __init__ from get_runtime().catalog and re-set
-    # by __deepcopy__.
+
+    # Catalog instance against which this Query was constructed
     _origin_catalog: 'catalog.Catalog'
 
     def __init__(
@@ -415,15 +414,12 @@ class Query:
         self._origin_catalog = get_runtime().catalog
 
     def __deepcopy__(self, memo: dict[int, Any]) -> 'Query':
-        # Default-deep traversal across all fields (which reaches into FromClause to
-        # TableVersionPath to TableVersionHandle, and into Exprs whose own copy() overrides
-        # take care of resetting the per-(thread, xact) caches), then re-tag _origin_catalog
-        # to the calling thread's catalog. See _exec / _aexec for the defensive use-site.
         cls = type(self)
         new = cls.__new__(cls)
         memo[id(self)] = new
         for k, v in self.__dict__.items():
             new.__dict__[k] = copy.deepcopy(v, memo)
+        # make sure to record the current catalog
         new._origin_catalog = get_runtime().catalog
         return new
 
@@ -616,7 +612,6 @@ class Query:
         return len(self._from_clause.join_clauses) > 0
 
     def show(self, n: int = 20) -> ResultSet:
-        # See _output_row_iterator for the rationale on the defensive copy.
         if self._origin_catalog is not get_runtime().catalog:
             return copy.deepcopy(self).show(n)
         if self.sample_clause is not None:
@@ -639,7 +634,6 @@ class Query:
             Error: If the Query is the result of a join or
                 if the Query has an order_by clause.
         """
-        # See _output_row_iterator for the rationale on the defensive copy.
         if self._origin_catalog is not get_runtime().catalog:
             return copy.deepcopy(self).head(n)
         if self.order_by_clause is not None:
@@ -669,7 +663,6 @@ class Query:
             Error: If the Query is the result of a join or
                 if the Query has an order_by clause.
         """
-        # See _output_row_iterator for the rationale on the defensive copy.
         if self._origin_catalog is not get_runtime().catalog:
             return copy.deepcopy(self).tail(n)
         if self.order_by_clause is not None:
@@ -846,7 +839,6 @@ class Query:
         return ResultCursor(self)
 
     async def _acollect(self) -> ResultSet:
-        # See _output_row_iterator for the rationale on the defensive copy.
         if self._origin_catalog is not get_runtime().catalog:
             return await copy.deepcopy(self)._acollect()
         single_tbl = self._first_tbl if len(self._from_clause.tbls) == 1 else None
@@ -869,7 +861,6 @@ class Query:
         Returns:
             The number of rows in the Query.
         """
-        # See _output_row_iterator for the rationale on the defensive copy.
         if self._origin_catalog is not get_runtime().catalog:
             return copy.deepcopy(self).count()
         if self.limit_val is not None and self.limit_val.val == 0:

--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -376,7 +376,7 @@ class Query:
     # The Catalog instance this Query was constructed against. Used by _exec / _aexec to
     # defensively deepcopy when the Query is invoked under a different Catalog (e.g., a
     # global Query held by user code and called from FastAPI worker threads, or a Query
-    # held across reset_runtime). Set in __init__ from `get_runtime().catalog` and re-set
+    # held across reset_runtime). Set in __init__ from get_runtime().catalog and re-set
     # by __deepcopy__.
     _origin_catalog: 'catalog.Catalog'
 
@@ -987,7 +987,7 @@ class Query:
                 raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, f'Invalid type: {raw_expr}')
             if len(self._from_clause.tbls) == 1:
                 # Select expressions need to be retargeted in order to handle snapshots correctly, as in expressions
-                # such as `snapshot.select(base_tbl.col)`
+                # such as snapshot.select(base_tbl.col)
                 # TODO: For joins involving snapshots, we need a more sophisticated retarget() that can handle
                 #     multiple TableVersionPaths.
                 expr = expr.copy()

--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -990,7 +990,7 @@ class Query:
                 raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, f'Invalid type: {raw_expr}')
             if len(self._from_clause.tbls) == 1:
                 # Select expressions need to be retargeted in order to handle snapshots correctly, as in expressions
-                # such as snapshot.select(base_tbl.col)
+                # such as `snapshot.select(base_tbl.col)`
                 # TODO: For joins involving snapshots, we need a more sophisticated retarget() that can handle
                 #     multiple TableVersionPaths.
                 expr = expr.copy()

--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -365,11 +365,20 @@ class Query:
     select_list: list[tuple[exprs.Expr, str | None]] | None
     where_clause: exprs.Expr | None
     group_by_clause: list[exprs.Expr] | None
-    grouping_tbl: catalog.TableVersion | None
+    # Stored as a TableVersionHandle (identity-only) rather than a TableVersion so the Query
+    # is shareable across thread/transaction boundaries: every read goes through the catalog's
+    # is_validated-gated machinery on the calling thread.
+    grouping_tbl: catalog.TableVersionHandle | None
     order_by_clause: list[tuple[exprs.Expr, bool]] | None
     limit_val: exprs.Expr | None
     offset_val: exprs.Expr | None
     sample_clause: SampleClause | None
+    # The Catalog instance this Query was constructed against. Used by _exec / _aexec to
+    # defensively deepcopy when the Query is invoked under a different Catalog (e.g., a
+    # global Query held by user code and called from FastAPI worker threads, or a Query
+    # held across reset_runtime). Set in __init__ from `get_runtime().catalog` and re-set
+    # by __deepcopy__.
+    _origin_catalog: 'catalog.Catalog'
 
     def __init__(
         self,
@@ -377,7 +386,7 @@ class Query:
         select_list: list[tuple[exprs.Expr, str | None]] | None = None,
         where_clause: exprs.Expr | None = None,
         group_by_clause: list[exprs.Expr] | None = None,
-        grouping_tbl: catalog.TableVersion | None = None,
+        grouping_tbl: catalog.TableVersionHandle | None = None,
         order_by_clause: list[tuple[exprs.Expr, bool]] | None = None,  # list[(expr, asc)]
         limit: exprs.Expr | None = None,
         offset: exprs.Expr | None = None,
@@ -403,6 +412,20 @@ class Query:
         self.limit_val = limit
         self.offset_val = offset
         self.sample_clause = sample_clause
+        self._origin_catalog = get_runtime().catalog
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> 'Query':
+        # Default-deep traversal across all fields (which reaches into FromClause to
+        # TableVersionPath to TableVersionHandle, and into Exprs whose own copy() overrides
+        # take care of resetting the per-(thread, xact) caches), then re-tag _origin_catalog
+        # to the calling thread's catalog. See _exec / _aexec for the defensive use-site.
+        cls = type(self)
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        for k, v in self.__dict__.items():
+            new.__dict__[k] = copy.deepcopy(v, memo)
+        new._origin_catalog = get_runtime().catalog
+        return new
 
     @classmethod
     def _normalize_select_list(
@@ -564,7 +587,7 @@ class Query:
         group_by_clause: list[exprs.Expr] | None = None
         if self.grouping_tbl is not None:
             assert self.group_by_clause is None
-            num_rowid_cols = len(self.grouping_tbl.store_tbl.rowid_columns())
+            num_rowid_cols = len(self.grouping_tbl.get().store_tbl.rowid_columns())
             # the grouping table must be a base of self.tbl
             assert num_rowid_cols <= len(self._first_tbl.tbl_version.get().store_tbl.rowid_columns())
             group_by_clause = self.__rowid_columns(num_rowid_cols)
@@ -782,6 +805,15 @@ class Query:
         return tbl_ids
 
     def _output_row_iterator(self) -> Generator[list, None, None]:
+        # Defensive thread-local copy: if this Query was constructed under a different
+        # Catalog than the one we're now running under (e.g., a user-built global held
+        # across FastAPI worker threads, or a Query held across reset_runtime), produce a
+        # thread-local copy whose embedded TVHs/TVPs/Exprs all have their per-(thread, xact)
+        # caches reset, and run the entire iteration (including the slot_idx extraction
+        # below) against the copy.
+        if self._origin_catalog is not get_runtime().catalog:
+            yield from copy.deepcopy(self)._output_row_iterator()
+            return
         tbl_ids = self.referenced_tbl_ids()
         with get_runtime().catalog.begin_xact(for_write=False, read_tbl_ids=tbl_ids):
             try:
@@ -805,6 +837,9 @@ class Query:
         return ResultCursor(self)
 
     async def _acollect(self) -> ResultSet:
+        # See _output_row_iterator for the rationale on the defensive copy.
+        if self._origin_catalog is not get_runtime().catalog:
+            return await copy.deepcopy(self)._acollect()
         single_tbl = self._first_tbl if len(self._from_clause.tbls) == 1 else None
         columns = {name: i for i, name in enumerate(self.schema)}
         try:
@@ -1258,7 +1293,7 @@ class Query:
         if self.sample_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'group_by() cannot be used with sample()')
 
-        grouping_tbl: catalog.TableVersion | None = None
+        grouping_tbl: catalog.TableVersionHandle | None = None
         group_by_clause: list[exprs.Expr] | None = None
         for item in grouping_items:
             if isinstance(item, (catalog.Table, catalog.TableVersion)):
@@ -1270,13 +1305,16 @@ class Query:
                     raise excs.RequestError(
                         excs.ErrorCode.UNSUPPORTED_OPERATION, 'group_by() with Table not supported for joins'
                     )
-                grouping_tbl = item if isinstance(item, catalog.TableVersion) else item._tbl_version.get()
+                # Take a handle (identity), not a TV instance: the Query may be invoked from a
+                # different thread/xact than the one that built it.
+                grouping_tv = item if isinstance(item, catalog.TableVersion) else item._tbl_version.get()
+                grouping_tbl = grouping_tv.handle
                 # we need to make sure that the grouping table is a base of self.tbl
                 base = self._first_tbl.find_tbl_version(grouping_tbl.id)
                 if base is None or base.id == self._first_tbl.tbl_id:
                     raise excs.RequestError(
                         excs.ErrorCode.UNSUPPORTED_OPERATION,
-                        f'group_by(): {grouping_tbl.name!r} is not a base table of {self._first_tbl.tbl_name()!r}',
+                        f'group_by(): {grouping_tv.name!r} is not a base table of {self._first_tbl.tbl_name()!r}',
                     )
                 break
             if not isinstance(item, exprs.Expr):
@@ -1693,7 +1731,9 @@ class Query:
         group_by_clause = (
             [exprs.Expr.from_dict(e) for e in d['group_by_clause']] if d['group_by_clause'] is not None else None
         )
-        grouping_tbl = catalog.TableVersion.from_dict(d['grouping_tbl']) if d['grouping_tbl'] is not None else None
+        grouping_tbl = (
+            catalog.TableVersionHandle.from_dict(d['grouping_tbl']) if d['grouping_tbl'] is not None else None
+        )
         order_by_clause = (
             [(exprs.Expr.from_dict(e), asc) for e, asc in d['order_by_clause']]
             if d['order_by_clause'] is not None

--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -1214,6 +1214,7 @@ class Query:
 
             >>> query = t.join(d, on=(t.d1 == d.pk1) & (t.d2 == d.pk2), how='left')
         """
+        other._validate_thread()
         assert len(self._from_clause.tbls) > 0
         if self._from_clause.tbls[0].is_versioned() != other._is_versioned():
             raise excs.RequestError(

--- a/pixeltable/_query.py
+++ b/pixeltable/_query.py
@@ -423,6 +423,17 @@ class Query:
         new._origin_catalog = get_runtime().catalog
         return new
 
+    def _rebind(self) -> 'Query':
+        """Return self if its origin matches the current runtime's catalog, else a deepcopy re-rooted to it.
+
+        Catalog instances are per-thread, so this also covers the cross-thread case: a Query built on one thread
+        and used to chain a builder method on another thread will be deepcopied here, resetting the origin/thread
+        state of all embedded TVHs/TVPs/Exprs.
+        """
+        if self._origin_catalog is get_runtime().catalog:
+            return self
+        return copy.deepcopy(self)
+
     @classmethod
     def _normalize_select_list(
         cls, tbls: list[catalog.TableVersionPath], select_list: list[tuple[exprs.Expr, str | None]] | None
@@ -612,8 +623,7 @@ class Query:
         return len(self._from_clause.join_clauses) > 0
 
     def show(self, n: int = 20) -> ResultSet:
-        if self._origin_catalog is not get_runtime().catalog:
-            return copy.deepcopy(self).show(n)
+        self = self._rebind()  # noqa: PLW0642
         if self.sample_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'show() cannot be used with sample()')
         assert n is not None
@@ -634,8 +644,7 @@ class Query:
             Error: If the Query is the result of a join or
                 if the Query has an order_by clause.
         """
-        if self._origin_catalog is not get_runtime().catalog:
-            return copy.deepcopy(self).head(n)
+        self = self._rebind()  # noqa: PLW0642
         if self.order_by_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'head() cannot be used with order_by()')
         if self._has_joins():
@@ -663,8 +672,7 @@ class Query:
             Error: If the Query is the result of a join or
                 if the Query has an order_by clause.
         """
-        if self._origin_catalog is not get_runtime().catalog:
-            return copy.deepcopy(self).tail(n)
+        self = self._rebind()  # noqa: PLW0642
         if self.order_by_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'tail() cannot be used with order_by()')
         if self._has_joins():
@@ -807,15 +815,7 @@ class Query:
         return tbl_ids
 
     def _output_row_iterator(self) -> Generator[list, None, None]:
-        # Defensive thread-local copy: if this Query was constructed under a different
-        # Catalog than the one we're now running under (e.g., a user-built global held
-        # across FastAPI worker threads, or a Query held across reset_runtime), produce a
-        # thread-local copy whose embedded TVHs/TVPs/Exprs all have their per-(thread, xact)
-        # caches reset, and run the entire iteration (including the slot_idx extraction
-        # below) against the copy.
-        if self._origin_catalog is not get_runtime().catalog:
-            yield from copy.deepcopy(self)._output_row_iterator()
-            return
+        self = self._rebind()  # noqa: PLW0642
         tbl_ids = self.referenced_tbl_ids()
         with get_runtime().catalog.begin_xact(for_write=False, read_tbl_ids=tbl_ids):
             try:
@@ -839,8 +839,7 @@ class Query:
         return ResultCursor(self)
 
     async def _acollect(self) -> ResultSet:
-        if self._origin_catalog is not get_runtime().catalog:
-            return await copy.deepcopy(self)._acollect()
+        self = self._rebind()  # noqa: PLW0642
         single_tbl = self._first_tbl if len(self._from_clause.tbls) == 1 else None
         columns = {name: i for i, name in enumerate(self.schema)}
         try:
@@ -971,6 +970,7 @@ class Query:
             >>> query = person.select(t.name, is_adult=(t.age >= 18))
 
         """
+        self = self._rebind()  # noqa: PLW0642
         if self.select_list is not None:
             raise excs.RequestError(excs.ErrorCode.INVALID_STATE, 'Select list already specified')
         for name, _ in named_items.items():
@@ -1055,6 +1055,7 @@ class Query:
 
             >>> query = person.where(t.age > 30)
         """
+        self = self._rebind()  # noqa: PLW0642
         if self.where_clause is not None:
             raise excs.RequestError(excs.ErrorCode.INVALID_STATE, 'where() clause already specified')
         if self.sample_clause is not None:
@@ -1215,6 +1216,7 @@ class Query:
             >>> query = t.join(d, on=(t.d1 == d.pk1) & (t.d2 == d.pk2), how='left')
         """
         other._validate_thread()
+        self = self._rebind()  # noqa: PLW0642
         assert len(self._from_clause.tbls) > 0
         if self._from_clause.tbls[0].is_versioned() != other._is_versioned():
             raise excs.RequestError(
@@ -1292,6 +1294,7 @@ class Query:
 
             >>> query = book.group_by(t.genre).select(t.genre, total=sum(t.price)).show()
         """
+        self = self._rebind()  # noqa: PLW0642
         if self.group_by_clause is not None:
             raise excs.RequestError(excs.ErrorCode.INVALID_STATE, 'group_by() already specified')
         if self.sample_clause is not None:
@@ -1360,6 +1363,7 @@ class Query:
             ...     .distinct()
             ... )
         """
+        self = self._rebind()  # noqa: PLW0642
         exps, _ = self._normalize_select_list(self._from_clause.tbls, self.select_list)
         return self.group_by(*exps)
 
@@ -1393,6 +1397,7 @@ class Query:
 
             >>> query = book.order_by(t.price, asc=False).order_by(t.pages)
         """
+        self = self._rebind()  # noqa: PLW0642
         if self.sample_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'order_by() cannot be used with sample()')
         for e in expr_list:
@@ -1432,6 +1437,7 @@ class Query:
 
             >>> query.limit(10, offset=20).collect()
         """
+        self = self._rebind()  # noqa: PLW0642
         if self.sample_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'limit() cannot be used with sample()')
 
@@ -1516,6 +1522,7 @@ class Query:
 
             >>> query = person.where(t.age > 30).sample(n=100)
         """
+        self = self._rebind()  # noqa: PLW0642
         # Check context of usage
         if self.sample_clause is not None:
             raise excs.RequestError(excs.ErrorCode.UNSUPPORTED_OPERATION, 'Multiple sample() clauses not allowed')

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1127,8 +1127,8 @@ class Catalog:
         assert dest_obj is None or if_exists == IfExistsParam.IGNORE
         assert src_obj is not None or if_not_exists == IfNotExistsParam.IGNORE
         if dest_obj is None and src_obj is not None:
-            # If dest_obj is not None, it means if_exists='ignore' and the destination already exists.
-            # If src_obj is None, it means if_not_exists='ignore' and the source doesn't exist.
+            # If dest_obj is not None, it means `if_exists='ignore'` and the destination already exists.
+            # If src_obj is None, it means `if_not_exists='ignore'` and the source doesn't exist.
             # If dest_obj is None and src_obj is not None, then we can proceed with the move.
             src_obj._move(new_path.name, dest_dir._id)
 
@@ -1541,7 +1541,7 @@ class Catalog:
         # Finally, it's possible that the table already exists in the catalog, but as an anonymous system table that
         # was hidden the last time we checked (and that just became visible when the replica was imported). In this
         # case, we need to make the existing table visible by moving it to the specified path.
-        # We need to do this at the end, since existing_path needs to first have a non-fragment table version in
+        # We need to do this at the end, since `existing_path` needs to first have a non-fragment table version in
         # order to be instantiated as a schema object.
         existing = self.get_table_by_id(tbl_id)
         assert existing is not None
@@ -1861,7 +1861,7 @@ class Catalog:
             ):
                 # then drop the base table as well (possibly recursively).
                 _logger.debug(f'Dropping hidden base table {tvp.base.tbl_id} of dropped replica {tbl_id}.')
-                # we just dropped the anchor on tvp.base; we need to clear the anchor so that we can actually
+                # we just dropped the anchor on `tvp.base`; we need to clear the anchor so that we can actually
                 # load the TableVersion instance in order to drop it
                 self._drop_tbl(tvp.base.anchor_to(None), force=False, is_replace=False)
 
@@ -2336,7 +2336,7 @@ class Catalog:
         anchor_timestamp: float | None = None
         if key.anchor_tbl_id is not None:
             anchored_version_md = self.head_version_md(key.anchor_tbl_id)
-            # anchor_tbl_id must exist and have at least one non-fragment version, or else this isn't
+            # `anchor_tbl_id` must exist and have at least one non-fragment version, or else this isn't
             # a valid TableVersion specification.
             assert anchored_version_md is not None
             anchor_timestamp = anchored_version_md.created_at
@@ -2613,17 +2613,17 @@ class Catalog:
         # TODO: First acquire X-locks for all relevant metadata entries
         # TODO: handle concurrent drop()
 
-        # Load metadata for every table in the TableVersionPath for tbl.
+        # Load metadata for every table in the TableVersionPath for `tbl`.
         md = [self.load_tbl_md(tv.key) for tv in tbl._tbl_version_path.get_tbl_versions()]
 
-        # If tbl is a named pure snapshot, we're not quite done, since the snapshot metadata won't appear in the
+        # If `tbl` is a named pure snapshot, we're not quite done, since the snapshot metadata won't appear in the
         # TableVersionPath. We need to prepend it separately.
         if isinstance(tbl, View) and tbl._is_named_pure_snapshot():
             snapshot_md = self.load_tbl_md(TableVersionKey(tbl._id, 0, None))
             md = [snapshot_md, *md]
 
         for ancestor_md in md:
-            # Set the is_replica flag on every ancestor's TableMd.
+            # Set the `is_replica` flag on every ancestor's TableMd.
             ancestor_md.tbl_md.is_replica = True
             # For replica metadata, we guarantee that the current_version and current_schema_version of TableMd
             # match the corresponding values in TableVersionMd and TableSchemaVersionMd. This is to ensure that,

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -238,10 +238,7 @@ class Catalog:
         self._init_store()
 
     def __deepcopy__(self, memo: dict[int, object]) -> 'Catalog':
-        # Catalog instances are owned by Runtime and never duplicated. Return self so that
-        # any deepcopy traversal that reaches a Catalog reference (e.g., the _origin_catalog
-        # field on TableVersionHandle, TableVersionPath, or Query) terminates here rather
-        # than walking the entire catalog state graph.
+        # Catalog instances are owned by Runtime and never duplicated. Return self here to prevent deepcopies.
         memo[id(self)] = self
         return self
 

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -281,9 +281,7 @@ class Catalog:
                     base_tv = self._tbl_versions.get(key, None)
                     if base_tv is not None and base_tv.is_validated and tbl_version.handle not in base_tv.mutable_views:
                         mutable_view_ids = ', '.join(str(tv.id) for tv in base_tv.mutable_views)
-                        mutable_view_names = ', '.join(
-                            tv._tbl_version.name for tv in base_tv.mutable_views if tv._tbl_version is not None
-                        )
+                        mutable_view_names = ', '.join(tv.get().name for tv in base_tv.mutable_views)
                         raise AssertionError(
                             f'{tbl_version.name} ({tbl_version.id}) missing in '
                             f'{mutable_view_ids} ({mutable_view_names})'

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -237,6 +237,14 @@ class Catalog:
         self._column_dependents = None
         self._init_store()
 
+    def __deepcopy__(self, memo: dict[int, object]) -> 'Catalog':
+        # Catalog instances are owned by Runtime and never duplicated. Return self so that
+        # any deepcopy traversal that reaches a Catalog reference (e.g., the _origin_catalog
+        # field on TableVersionHandle, TableVersionPath, or Query) terminates here rather
+        # than walking the entire catalog state graph.
+        memo[id(self)] = self
+        return self
+
     def _active_tbl_clause(
         self, *, tbl_id: UUID | None = None, dir_id: UUID | None = None, tbl_name: str | None = None
     ) -> sql.ColumnElement[bool]:

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1130,8 +1130,8 @@ class Catalog:
         assert dest_obj is None or if_exists == IfExistsParam.IGNORE
         assert src_obj is not None or if_not_exists == IfNotExistsParam.IGNORE
         if dest_obj is None and src_obj is not None:
-            # If dest_obj is not None, it means `if_exists='ignore'` and the destination already exists.
-            # If src_obj is None, it means `if_not_exists='ignore'` and the source doesn't exist.
+            # If dest_obj is not None, it means if_exists='ignore' and the destination already exists.
+            # If src_obj is None, it means if_not_exists='ignore' and the source doesn't exist.
             # If dest_obj is None and src_obj is not None, then we can proceed with the move.
             src_obj._move(new_path.name, dest_dir._id)
 
@@ -1544,7 +1544,7 @@ class Catalog:
         # Finally, it's possible that the table already exists in the catalog, but as an anonymous system table that
         # was hidden the last time we checked (and that just became visible when the replica was imported). In this
         # case, we need to make the existing table visible by moving it to the specified path.
-        # We need to do this at the end, since `existing_path` needs to first have a non-fragment table version in
+        # We need to do this at the end, since existing_path needs to first have a non-fragment table version in
         # order to be instantiated as a schema object.
         existing = self.get_table_by_id(tbl_id)
         assert existing is not None
@@ -1864,7 +1864,7 @@ class Catalog:
             ):
                 # then drop the base table as well (possibly recursively).
                 _logger.debug(f'Dropping hidden base table {tvp.base.tbl_id} of dropped replica {tbl_id}.')
-                # we just dropped the anchor on `tvp.base`; we need to clear the anchor so that we can actually
+                # we just dropped the anchor on tvp.base; we need to clear the anchor so that we can actually
                 # load the TableVersion instance in order to drop it
                 self._drop_tbl(tvp.base.anchor_to(None), force=False, is_replace=False)
 
@@ -2339,7 +2339,7 @@ class Catalog:
         anchor_timestamp: float | None = None
         if key.anchor_tbl_id is not None:
             anchored_version_md = self.head_version_md(key.anchor_tbl_id)
-            # `anchor_tbl_id` must exist and have at least one non-fragment version, or else this isn't
+            # anchor_tbl_id must exist and have at least one non-fragment version, or else this isn't
             # a valid TableVersion specification.
             assert anchored_version_md is not None
             anchor_timestamp = anchored_version_md.created_at
@@ -2616,17 +2616,17 @@ class Catalog:
         # TODO: First acquire X-locks for all relevant metadata entries
         # TODO: handle concurrent drop()
 
-        # Load metadata for every table in the TableVersionPath for `tbl`.
+        # Load metadata for every table in the TableVersionPath for tbl.
         md = [self.load_tbl_md(tv.key) for tv in tbl._tbl_version_path.get_tbl_versions()]
 
-        # If `tbl` is a named pure snapshot, we're not quite done, since the snapshot metadata won't appear in the
+        # If tbl is a named pure snapshot, we're not quite done, since the snapshot metadata won't appear in the
         # TableVersionPath. We need to prepend it separately.
         if isinstance(tbl, View) and tbl._is_named_pure_snapshot():
             snapshot_md = self.load_tbl_md(TableVersionKey(tbl._id, 0, None))
             md = [snapshot_md, *md]
 
         for ancestor_md in md:
-            # Set the `is_replica` flag on every ancestor's TableMd.
+            # Set the is_replica flag on every ancestor's TableMd.
             ancestor_md.tbl_md.is_replica = True
             # For replica metadata, we guarantee that the current_version and current_schema_version of TableMd
             # match the corresponding values in TableVersionMd and TableSchemaVersionMd. This is to ensure that,

--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -146,7 +146,7 @@ class InsertableTable(Table):
         return_rows: bool = False,
         **kwargs: Any,
     ) -> UpdateStatus:
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.io.table_data_conduit import TableDataConduit
 
         if source is not None and isinstance(source, Sequence) and len(source) == 0:
@@ -221,7 +221,7 @@ class InsertableTable(Table):
 
             >>> tbl.delete(tbl.a > 5)
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):

--- a/pixeltable/catalog/insertable_table.py
+++ b/pixeltable/catalog/insertable_table.py
@@ -146,6 +146,7 @@ class InsertableTable(Table):
         return_rows: bool = False,
         **kwargs: Any,
     ) -> UpdateStatus:
+        self._check_thread()
         from pixeltable.io.table_data_conduit import TableDataConduit
 
         if source is not None and isinstance(source, Sequence) and len(source) == 0:
@@ -220,6 +221,7 @@ class InsertableTable(Table):
 
             >>> tbl.delete(tbl.a > 5)
         """
+        self._check_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -5,6 +5,7 @@ import builtins
 import datetime
 import json
 import logging
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping
 from uuid import UUID
@@ -66,10 +67,32 @@ class Table(SchemaObject):
     # the physical TableVersion backing this Table; None for pure snapshots
     _tbl_version: TableVersionHandle | None
 
+    # The thread that constructed this Table. Tables are not thread-safe: their
+    # _tbl_version_path holds a per-instance metadata cache, and the Catalog they
+    # resolve through is itself thread-local. Cross-thread sharing would require a
+    # deepcopy + per-thread Catalog rebind that the user can't reasonably do; the
+    # supported pattern is to call pxt.get_table() on the thread that needs it.
+    # Public methods call _check_thread() at entry to surface a clear error rather
+    # than a deeper, harder-to-diagnose failure later in the call chain.
+    _origin_thread_id: int
+
     def __init__(self, id: UUID, dir_id: UUID, name: str, tbl_version_path: TableVersionPath):
         super().__init__(id, name, dir_id)
         self._tbl_version_path = tbl_version_path
         self._tbl_version = None
+        self._origin_thread_id = threading.get_ident()
+
+    def _check_thread(self) -> None:
+        """Raise if accessed from a thread other than the one that constructed this Table."""
+        if self._origin_thread_id != threading.get_ident():
+            # Use self._name (a plain attribute) rather than self._path() so the error
+            # construction itself doesn't go through the catalog from the wrong thread.
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_STATE,
+                f'Table {self._name!r} was accessed from a thread other than the one that constructed it. '
+                f'Tables are not thread-safe; call pxt.get_table(...) on this thread to obtain a thread-local '
+                f'instance.',
+            )
 
     def _move(self, new_name: str, new_dir_id: UUID) -> None:
         old_name = self._name
@@ -103,6 +126,7 @@ class Table(SchemaObject):
         Returns:
             A [TableMetadata][pixeltable.TableMetadata] instance containing this table's metadata.
         """
+        self._check_thread()
         from pixeltable.catalog import retry_loop
 
         @retry_loop(for_write=False)
@@ -208,6 +232,17 @@ class Table(SchemaObject):
 
     def __getattr__(self, name: str) -> 'exprs.ColumnRef':
         """Return a ColumnRef for the given name."""
+        # __getattr__ is called when normal attribute lookup fails. Avoid recursion by reading
+        # _origin_thread_id from the instance dict directly. If it's missing (Table not fully
+        # constructed yet), skip the check.
+        origin = self.__dict__.get('_origin_thread_id')
+        if origin is not None and origin != threading.get_ident():
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_STATE,
+                f'Table {self.__dict__.get("_name")!r} was accessed from a thread other than the one that '
+                f'constructed it. Tables are not thread-safe; call pxt.get_table(...) on this thread to obtain '
+                f'a thread-local instance.',
+            )
         col = self._tbl_version_path.get_column(name)
         if col is None:
             raise AttributeError(f'Unknown column: {name}')
@@ -228,6 +263,7 @@ class Table(SchemaObject):
         Returns:
             A list of view paths.
         """
+        self._check_thread()
         from pixeltable.catalog import retry_loop
 
         # we need retry_loop() here, because we end up loading Tables for the views
@@ -252,6 +288,7 @@ class Table(SchemaObject):
 
         See [`Query.select`][pixeltable.Query.select] for more details.
         """
+        self._check_thread()
         from pixeltable.plan import FromClause
 
         query = pxt.Query(FromClause(tbls=[self._tbl_version_path]))
@@ -266,7 +303,7 @@ class Table(SchemaObject):
 
         See [`Query.where`][pixeltable.Query.where] for more details.
         """
-
+        self._check_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().where(pred)
 
@@ -274,7 +311,7 @@ class Table(SchemaObject):
         self, other: 'Table', *, on: 'exprs.Expr' | None = None, how: 'pixeltable.plan.JoinType.LiteralType' = 'inner'
     ) -> 'pxt.Query':
         """Join this table with another table."""
-
+        self._check_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().join(other, on=on, how=how)
 
@@ -283,7 +320,7 @@ class Table(SchemaObject):
 
         See [`Query.order_by`][pixeltable.Query.order_by] for more details.
         """
-
+        self._check_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().order_by(*items, asc=asc)
 
@@ -292,12 +329,13 @@ class Table(SchemaObject):
 
         See [`Query.group_by`][pixeltable.Query.group_by] for more details.
         """
-
+        self._check_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().group_by(*items)
 
     def distinct(self) -> 'pxt.Query':
         """Remove duplicate rows from table."""
+        self._check_thread()
         return self.select().distinct()
 
     def limit(self, n: int, offset: int | None = None) -> 'pxt.Query':
@@ -319,6 +357,7 @@ class Table(SchemaObject):
 
             >>> t.limit(10, offset=20).collect()
         """
+        self._check_thread()
         return self.select().limit(n, offset=offset)
 
     def sample(
@@ -333,12 +372,14 @@ class Table(SchemaObject):
 
         See [`Query.sample`][pixeltable.Query.sample] for more details.
         """
+        self._check_thread()
         return self.select().sample(
             n=n, n_per_stratum=n_per_stratum, fraction=fraction, seed=seed, stratify_by=stratify_by
         )
 
     def collect(self) -> 'pxt._query.ResultSet':
         """Return rows from this table."""
+        self._check_thread()
         return self.select().collect()
 
     def cursor(self) -> 'pxt._query.ResultCursor':
@@ -346,26 +387,32 @@ class Table(SchemaObject):
 
         See [`ResultCursor`][pixeltable.ResultCursor] for usage examples and lifecycle details.
         """
+        self._check_thread()
         return self.select().cursor()
 
     def show(self, *args: Any, **kwargs: Any) -> 'pxt._query.ResultSet':
         """Return rows from this table."""
+        self._check_thread()
         return self.select().show(*args, **kwargs)
 
     def head(self, *args: Any, **kwargs: Any) -> 'pxt._query.ResultSet':
         """Return the first n rows inserted into this table."""
+        self._check_thread()
         return self.select().head(*args, **kwargs)
 
     def tail(self, *args: Any, **kwargs: Any) -> 'pxt._query.ResultSet':
         """Return the last n rows inserted into this table."""
+        self._check_thread()
         return self.select().tail(*args, **kwargs)
 
     def count(self) -> int:
         """Return the number of rows in this table."""
+        self._check_thread()
         return self.select().count()
 
     def columns(self) -> list[str]:
         """Return the names of the columns in this table."""
+        self._check_thread()
         cols = self._tbl_version_path.columns()
         return [c.name for c in cols]
 
@@ -374,6 +421,7 @@ class Table(SchemaObject):
         return {c.name: c.col_type for c in self._tbl_version_path.columns()}
 
     def get_base_table(self) -> 'Table' | None:
+        self._check_thread()
         return self._get_base_table()
 
     @abc.abstractmethod
@@ -507,6 +555,7 @@ class Table(SchemaObject):
         """
         Print the table schema.
         """
+        self._check_thread()
         if getattr(builtins, '__IPYTHON__', False):
             from IPython.display import Markdown, display
 
@@ -520,12 +569,14 @@ class Table(SchemaObject):
         """Return a PyTorch Dataset for this table.
         See Query.to_pytorch_dataset()
         """
+        self._check_thread()
         return self.select().to_pytorch_dataset(image_format=image_format)
 
     def to_coco_dataset(self) -> Path:
         """Return the path to a COCO json file for this table.
         See Query.to_coco_dataset()
         """
+        self._check_thread()
         return self.select().to_coco_dataset()
 
     def _column_has_dependents(self, col: Column) -> bool:
@@ -631,7 +682,7 @@ class Table(SchemaObject):
             ... }
             ... tbl.add_columns(schema)
         """
-
+        self._check_thread()
         from pixeltable.catalog import retry_loop
 
         # a retry loop is necessary because drop column needs it
@@ -726,6 +777,7 @@ class Table(SchemaObject):
             ...     }
             ... )
         """
+        self._check_thread()
         # verify kwargs and construct column schema dict
         if len(kwargs) != 1:
             raise excs.RequestError(
@@ -790,6 +842,7 @@ class Table(SchemaObject):
 
             >>> tbl.add_computed_column(rotated=tbl.frame.rotate(90), stored=False)
         """
+        self._check_thread()
         from pixeltable.catalog import retry_loop
 
         # a retry loop is necessary because drop column needs it.
@@ -884,6 +937,7 @@ class Table(SchemaObject):
             >>> tbl = pxt.get_table('my_table')
             ... tbl.drop_col(tbl.col, if_not_exists='ignore')
         """
+        self._check_thread()
         from pixeltable.catalog import retry_loop
 
         cat = get_runtime().catalog
@@ -1000,7 +1054,7 @@ class Table(SchemaObject):
             >>> tbl = pxt.get_table('my_table')
             ... tbl.rename_column('col1', 'col2')
         """
-
+        self._check_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=False
         ):
@@ -1114,6 +1168,7 @@ class Table(SchemaObject):
             ...     image_embed=image_embedding_fn,
             ... )
         """
+        self._check_thread()
         assert self._tbl_version is None or self._tbl_version.get().is_versioned, (
             'TODO: implement for unversioned tables [PXT-1101]'
         )
@@ -1212,7 +1267,7 @@ class Table(SchemaObject):
             >>> tbl = pxt.get_table('my_table')
             ... tbl.drop_embedding_index(idx_name='idx1', if_not_exists='ignore')
         """
-
+        self._check_thread()
         if (column is None) == (idx_name is None):
             raise excs.RequestError(
                 excs.ErrorCode.MISSING_REQUIRED, "Exactly one of 'column' or 'idx_name' must be provided"
@@ -1296,7 +1351,7 @@ class Table(SchemaObject):
             ... tbl.drop_index(idx_name='idx1', if_not_exists='ignore')
 
         """
-
+        self._check_thread()
         if (column is None) == (idx_name is None):
             raise excs.RequestError(
                 excs.ErrorCode.MISSING_REQUIRED, "Exactly one of 'column' or 'idx_name' must be provided"
@@ -1498,6 +1553,7 @@ class Table(SchemaObject):
             ... models = [MyModel(a=1, b=2), MyModel(a=3, b=4)]
             ... tbl.insert(models)
         """
+        self._check_thread()
         raise NotImplementedError
 
     def update(
@@ -1536,7 +1592,7 @@ class Table(SchemaObject):
 
             >>> tbl.update({'int_col': tbl.int_col + 1}, where=tbl.int_col == 0)
         """
-
+        self._check_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):
@@ -1590,7 +1646,7 @@ class Table(SchemaObject):
             ...     if_not_exists='insert',
             ... )
         """
-
+        self._check_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):
@@ -1670,7 +1726,7 @@ class Table(SchemaObject):
 
             >>> tbl.recompute_columns('c1', errors_only=True)
         """
-
+        self._check_thread()
         cat = get_runtime().catalog
         # lock_mutable_tree=True: we need to be able to see whether any transitive view has column dependents
         with cat.begin_xact(for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True):
@@ -1736,6 +1792,7 @@ class Table(SchemaObject):
 
             >>> tbl.delete(tbl.a > 5)
         """
+        self._check_thread()
         raise NotImplementedError
 
     def revert(self) -> None:
@@ -1744,6 +1801,7 @@ class Table(SchemaObject):
         .. warning::
             This operation is irreversible.
         """
+        self._check_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):
@@ -1758,6 +1816,7 @@ class Table(SchemaObject):
             self._tbl_version_path.clear_cached_md()
 
     def push(self) -> None:
+        self._check_thread()
         from pixeltable.share import push_replica
         from pixeltable.share.protocol import PxtUri
 
@@ -1798,6 +1857,7 @@ class Table(SchemaObject):
         push_replica(uuid_uri_obj, self)
 
     def pull(self) -> None:
+        self._check_thread()
         from pixeltable.share import pull_replica
         from pixeltable.share.protocol import PxtUri
 
@@ -1826,6 +1886,7 @@ class Table(SchemaObject):
         pull_replica(self._path(), uuid_uri_obj)
 
     def external_stores(self) -> list[str]:
+        self._check_thread()
         return list(self._tbl_version.get().external_stores.keys())
 
     def _link_external_store(self, store: 'pxt.io.ExternalStore') -> None:
@@ -1860,7 +1921,7 @@ class Table(SchemaObject):
             delete_external_data (bool): If `True`, then the external data store will also be deleted. WARNING: This
                 is a destructive operation that will delete data outside Pixeltable, and cannot be undone.
         """
-
+        self._check_thread()
         if not self._tbl_version_path.is_mutable():
             return
         with get_runtime().catalog.begin_xact(for_write=True, write_tvps=[self._tbl_version_path]):
@@ -1902,7 +1963,7 @@ class Table(SchemaObject):
             export_data: If `True`, data from this table will be exported to the external stores during synchronization.
             import_data: If `True`, data from the external stores will be imported to this table during synchronization.
         """
-
+        self._check_thread()
         if not self._tbl_version_path.is_mutable():
             return UpdateStatus()
         # we lock the entire tree starting at the root base table in order to ensure that all synced columns can
@@ -1962,7 +2023,7 @@ class Table(SchemaObject):
 
             >>> tbl.get_versions(n=5)
         """
-
+        self._check_thread()
         if n is None:
             n = 1_000_000_000
         if not isinstance(n, int) or n < 1:
@@ -2032,6 +2093,7 @@ class Table(SchemaObject):
 
             >>> tbl.history(n=5)
         """
+        self._check_thread()
         versions = self.get_versions(n)
         assert len(versions) > 0
         return pd.DataFrame([list(v.values()) for v in versions], columns=list(versions[0].keys()))

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -56,10 +56,15 @@ class Table(SchemaObject):
     """
     A handle to a table, view, or snapshot. This class is the primary interface through which table operations
     (queries, insertions, updates, etc.) are performed in Pixeltable.
+
+    Table instances are not thread-safe. A thread that needs to perform table operations must get its own handle
+    (e.g., via get_table)
     """
 
     # Every user-invoked operation that runs an ExecNode tree (directly or indirectly) needs to call
     # FileCache.emit_eviction_warnings() at the end of the operation.
+    #
+    # Every public method needs to call _validate_thread() at the beginning.
 
     # the chain of TableVersions needed to run queries and supply metadata (eg, schema)
     _tbl_version_path: TableVersionPath
@@ -67,13 +72,7 @@ class Table(SchemaObject):
     # the physical TableVersion backing this Table; None for pure snapshots
     _tbl_version: TableVersionHandle | None
 
-    # The thread that constructed this Table. Tables are not thread-safe: their
-    # _tbl_version_path holds a per-instance metadata cache, and the Catalog they
-    # resolve through is itself thread-local. Cross-thread sharing would require a
-    # deepcopy + per-thread Catalog rebind that the user can't reasonably do; the
-    # supported pattern is to call pxt.get_table() on the thread that needs it.
-    # Public methods call _check_thread() at entry to surface a clear error rather
-    # than a deeper, harder-to-diagnose failure later in the call chain.
+    # the thread that constructed this Table; used to guard against cross-thread access
     _origin_thread_id: int
 
     def __init__(self, id: UUID, dir_id: UUID, name: str, tbl_version_path: TableVersionPath):
@@ -82,7 +81,7 @@ class Table(SchemaObject):
         self._tbl_version = None
         self._origin_thread_id = threading.get_ident()
 
-    def _check_thread(self) -> None:
+    def _validate_thread(self) -> None:
         """Raise if accessed from a thread other than the one that constructed this Table."""
         if self._origin_thread_id != threading.get_ident():
             # Use self._name (a plain attribute) rather than self._path() so the error
@@ -126,7 +125,7 @@ class Table(SchemaObject):
         Returns:
             A [TableMetadata][pixeltable.TableMetadata] instance containing this table's metadata.
         """
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.catalog import retry_loop
 
         @retry_loop(for_write=False)
@@ -263,7 +262,7 @@ class Table(SchemaObject):
         Returns:
             A list of view paths.
         """
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.catalog import retry_loop
 
         # we need retry_loop() here, because we end up loading Tables for the views
@@ -288,7 +287,7 @@ class Table(SchemaObject):
 
         See [`Query.select`][pixeltable.Query.select] for more details.
         """
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.plan import FromClause
 
         query = pxt.Query(FromClause(tbls=[self._tbl_version_path]))
@@ -303,7 +302,7 @@ class Table(SchemaObject):
 
         See [`Query.where`][pixeltable.Query.where] for more details.
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().where(pred)
 
@@ -311,7 +310,7 @@ class Table(SchemaObject):
         self, other: 'Table', *, on: 'exprs.Expr' | None = None, how: 'pixeltable.plan.JoinType.LiteralType' = 'inner'
     ) -> 'pxt.Query':
         """Join this table with another table."""
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().join(other, on=on, how=how)
 
@@ -320,7 +319,7 @@ class Table(SchemaObject):
 
         See [`Query.order_by`][pixeltable.Query.order_by] for more details.
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().order_by(*items, asc=asc)
 
@@ -329,13 +328,13 @@ class Table(SchemaObject):
 
         See [`Query.group_by`][pixeltable.Query.group_by] for more details.
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().group_by(*items)
 
     def distinct(self) -> 'pxt.Query':
         """Remove duplicate rows from table."""
-        self._check_thread()
+        self._validate_thread()
         return self.select().distinct()
 
     def limit(self, n: int, offset: int | None = None) -> 'pxt.Query':
@@ -357,7 +356,7 @@ class Table(SchemaObject):
 
             >>> t.limit(10, offset=20).collect()
         """
-        self._check_thread()
+        self._validate_thread()
         return self.select().limit(n, offset=offset)
 
     def sample(
@@ -372,14 +371,14 @@ class Table(SchemaObject):
 
         See [`Query.sample`][pixeltable.Query.sample] for more details.
         """
-        self._check_thread()
+        self._validate_thread()
         return self.select().sample(
             n=n, n_per_stratum=n_per_stratum, fraction=fraction, seed=seed, stratify_by=stratify_by
         )
 
     def collect(self) -> 'pxt._query.ResultSet':
         """Return rows from this table."""
-        self._check_thread()
+        self._validate_thread()
         return self.select().collect()
 
     def cursor(self) -> 'pxt._query.ResultCursor':
@@ -387,32 +386,32 @@ class Table(SchemaObject):
 
         See [`ResultCursor`][pixeltable.ResultCursor] for usage examples and lifecycle details.
         """
-        self._check_thread()
+        self._validate_thread()
         return self.select().cursor()
 
     def show(self, *args: Any, **kwargs: Any) -> 'pxt._query.ResultSet':
         """Return rows from this table."""
-        self._check_thread()
+        self._validate_thread()
         return self.select().show(*args, **kwargs)
 
     def head(self, *args: Any, **kwargs: Any) -> 'pxt._query.ResultSet':
         """Return the first n rows inserted into this table."""
-        self._check_thread()
+        self._validate_thread()
         return self.select().head(*args, **kwargs)
 
     def tail(self, *args: Any, **kwargs: Any) -> 'pxt._query.ResultSet':
         """Return the last n rows inserted into this table."""
-        self._check_thread()
+        self._validate_thread()
         return self.select().tail(*args, **kwargs)
 
     def count(self) -> int:
         """Return the number of rows in this table."""
-        self._check_thread()
+        self._validate_thread()
         return self.select().count()
 
     def columns(self) -> list[str]:
         """Return the names of the columns in this table."""
-        self._check_thread()
+        self._validate_thread()
         cols = self._tbl_version_path.columns()
         return [c.name for c in cols]
 
@@ -421,7 +420,7 @@ class Table(SchemaObject):
         return {c.name: c.col_type for c in self._tbl_version_path.columns()}
 
     def get_base_table(self) -> 'Table' | None:
-        self._check_thread()
+        self._validate_thread()
         return self._get_base_table()
 
     @abc.abstractmethod
@@ -555,7 +554,7 @@ class Table(SchemaObject):
         """
         Print the table schema.
         """
-        self._check_thread()
+        self._validate_thread()
         if getattr(builtins, '__IPYTHON__', False):
             from IPython.display import Markdown, display
 
@@ -569,14 +568,14 @@ class Table(SchemaObject):
         """Return a PyTorch Dataset for this table.
         See Query.to_pytorch_dataset()
         """
-        self._check_thread()
+        self._validate_thread()
         return self.select().to_pytorch_dataset(image_format=image_format)
 
     def to_coco_dataset(self) -> Path:
         """Return the path to a COCO json file for this table.
         See Query.to_coco_dataset()
         """
-        self._check_thread()
+        self._validate_thread()
         return self.select().to_coco_dataset()
 
     def _column_has_dependents(self, col: Column) -> bool:
@@ -682,7 +681,7 @@ class Table(SchemaObject):
             ... }
             ... tbl.add_columns(schema)
         """
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.catalog import retry_loop
 
         # a retry loop is necessary because drop column needs it
@@ -777,7 +776,7 @@ class Table(SchemaObject):
             ...     }
             ... )
         """
-        self._check_thread()
+        self._validate_thread()
         # verify kwargs and construct column schema dict
         if len(kwargs) != 1:
             raise excs.RequestError(
@@ -842,7 +841,7 @@ class Table(SchemaObject):
 
             >>> tbl.add_computed_column(rotated=tbl.frame.rotate(90), stored=False)
         """
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.catalog import retry_loop
 
         # a retry loop is necessary because drop column needs it.
@@ -937,7 +936,7 @@ class Table(SchemaObject):
             >>> tbl = pxt.get_table('my_table')
             ... tbl.drop_col(tbl.col, if_not_exists='ignore')
         """
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.catalog import retry_loop
 
         cat = get_runtime().catalog
@@ -1054,7 +1053,7 @@ class Table(SchemaObject):
             >>> tbl = pxt.get_table('my_table')
             ... tbl.rename_column('col1', 'col2')
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=False
         ):
@@ -1168,7 +1167,7 @@ class Table(SchemaObject):
             ...     image_embed=image_embedding_fn,
             ... )
         """
-        self._check_thread()
+        self._validate_thread()
         assert self._tbl_version is None or self._tbl_version.get().is_versioned, (
             'TODO: implement for unversioned tables [PXT-1101]'
         )
@@ -1267,7 +1266,7 @@ class Table(SchemaObject):
             >>> tbl = pxt.get_table('my_table')
             ... tbl.drop_embedding_index(idx_name='idx1', if_not_exists='ignore')
         """
-        self._check_thread()
+        self._validate_thread()
         if (column is None) == (idx_name is None):
             raise excs.RequestError(
                 excs.ErrorCode.MISSING_REQUIRED, "Exactly one of 'column' or 'idx_name' must be provided"
@@ -1351,7 +1350,7 @@ class Table(SchemaObject):
             ... tbl.drop_index(idx_name='idx1', if_not_exists='ignore')
 
         """
-        self._check_thread()
+        self._validate_thread()
         if (column is None) == (idx_name is None):
             raise excs.RequestError(
                 excs.ErrorCode.MISSING_REQUIRED, "Exactly one of 'column' or 'idx_name' must be provided"
@@ -1553,7 +1552,7 @@ class Table(SchemaObject):
             ... models = [MyModel(a=1, b=2), MyModel(a=3, b=4)]
             ... tbl.insert(models)
         """
-        self._check_thread()
+        self._validate_thread()
         raise NotImplementedError
 
     def update(
@@ -1592,7 +1591,7 @@ class Table(SchemaObject):
 
             >>> tbl.update({'int_col': tbl.int_col + 1}, where=tbl.int_col == 0)
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):
@@ -1646,7 +1645,7 @@ class Table(SchemaObject):
             ...     if_not_exists='insert',
             ... )
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):
@@ -1726,7 +1725,7 @@ class Table(SchemaObject):
 
             >>> tbl.recompute_columns('c1', errors_only=True)
         """
-        self._check_thread()
+        self._validate_thread()
         cat = get_runtime().catalog
         # lock_mutable_tree=True: we need to be able to see whether any transitive view has column dependents
         with cat.begin_xact(for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True):
@@ -1792,7 +1791,7 @@ class Table(SchemaObject):
 
             >>> tbl.delete(tbl.a > 5)
         """
-        self._check_thread()
+        self._validate_thread()
         raise NotImplementedError
 
     def revert(self) -> None:
@@ -1801,7 +1800,7 @@ class Table(SchemaObject):
         .. warning::
             This operation is irreversible.
         """
-        self._check_thread()
+        self._validate_thread()
         with get_runtime().catalog.begin_xact(
             for_write=True, write_tvps=[self._tbl_version_path], lock_mutable_tree=True
         ):
@@ -1816,7 +1815,7 @@ class Table(SchemaObject):
             self._tbl_version_path.clear_cached_md()
 
     def push(self) -> None:
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.share import push_replica
         from pixeltable.share.protocol import PxtUri
 
@@ -1857,7 +1856,7 @@ class Table(SchemaObject):
         push_replica(uuid_uri_obj, self)
 
     def pull(self) -> None:
-        self._check_thread()
+        self._validate_thread()
         from pixeltable.share import pull_replica
         from pixeltable.share.protocol import PxtUri
 
@@ -1886,7 +1885,7 @@ class Table(SchemaObject):
         pull_replica(self._path(), uuid_uri_obj)
 
     def external_stores(self) -> list[str]:
-        self._check_thread()
+        self._validate_thread()
         return list(self._tbl_version.get().external_stores.keys())
 
     def _link_external_store(self, store: 'pxt.io.ExternalStore') -> None:
@@ -1921,7 +1920,7 @@ class Table(SchemaObject):
             delete_external_data (bool): If `True`, then the external data store will also be deleted. WARNING: This
                 is a destructive operation that will delete data outside Pixeltable, and cannot be undone.
         """
-        self._check_thread()
+        self._validate_thread()
         if not self._tbl_version_path.is_mutable():
             return
         with get_runtime().catalog.begin_xact(for_write=True, write_tvps=[self._tbl_version_path]):
@@ -1963,7 +1962,7 @@ class Table(SchemaObject):
             export_data: If `True`, data from this table will be exported to the external stores during synchronization.
             import_data: If `True`, data from the external stores will be imported to this table during synchronization.
         """
-        self._check_thread()
+        self._validate_thread()
         if not self._tbl_version_path.is_mutable():
             return UpdateStatus()
         # we lock the entire tree starting at the root base table in order to ensure that all synced columns can
@@ -2023,7 +2022,7 @@ class Table(SchemaObject):
 
             >>> tbl.get_versions(n=5)
         """
-        self._check_thread()
+        self._validate_thread()
         if n is None:
             n = 1_000_000_000
         if not isinstance(n, int) or n < 1:
@@ -2093,7 +2092,7 @@ class Table(SchemaObject):
 
             >>> tbl.history(n=5)
         """
-        self._check_thread()
+        self._validate_thread()
         versions = self.get_versions(n)
         assert len(versions) > 0
         return pd.DataFrame([list(v.values()) for v in versions], columns=list(versions[0].keys()))

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -238,7 +238,7 @@ class Table(SchemaObject):
         if origin is not None and origin != threading.get_ident():
             raise excs.RequestError(
                 excs.ErrorCode.INVALID_STATE,
-                f'Table {self.__dict__.get("_name")!r} was accessed from a thread other than the one that '
+                f'Table {self._name} was accessed from a thread other than the one that '
                 f'constructed it. Tables are not thread-safe; call pxt.get_table(...) on this thread to obtain '
                 f'a thread-local instance.',
             )

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -311,6 +311,7 @@ class Table(SchemaObject):
     ) -> 'pxt.Query':
         """Join this table with another table."""
         self._validate_thread()
+        other._validate_thread()
         with get_runtime().catalog.begin_xact(read_tvps=[self._tbl_version_path]):
             return self.select().join(other, on=on, how=how)
 

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -13,6 +13,8 @@ from .table_version import TableVersion, TableVersionKey
 if TYPE_CHECKING:
     from pixeltable.catalog import Column
 
+    from .catalog import Catalog
+
 _logger = logging.getLogger('pixeltable')
 
 
@@ -26,19 +28,29 @@ class TableVersionHandle:
     """
 
     key: TableVersionKey
+    # Per-(thread, xact) cache of the resolved TableVersion. Reset on __deepcopy__ when the
+    # handle crosses a thread/transaction boundary (e.g., a Query template captured at
+    # module-import time being executed in a worker thread, or a Query held across xacts in
+    # the face of a schema change from another process). Re-validation happens on the next
+    # get() through the catalog's is_validated machinery.
     _tbl_version: TableVersion | None
+    # The Catalog instance this handle was last resolved against. Set in __init__ from
+    # `get_runtime().catalog`, re-set by __deepcopy__, and updated by get() whenever it
+    # detects a mismatch with the calling thread's catalog (which can happen across worker
+    # threads or after reset_runtime). On mismatch get() drops the cached TableVersion and
+    # re-resolves through the current catalog, so consumers always observe metadata from the
+    # catalog they're running against.
+    _origin_catalog: Catalog
 
     def __init__(self, key: TableVersionKey, *, tbl_version: TableVersion | None = None):
         self.key = key
         self._tbl_version = tbl_version
+        self._origin_catalog = get_runtime().catalog
 
     def __deepcopy__(self, memo: dict[int, object] | None = None) -> TableVersionHandle:
-        # Drop the per-instance _tbl_version cache on deepcopy: it points to whichever thread's
-        # TV was current when this handle was constructed (e.g., the importing thread for a
-        # Query template). The copy will lazily resolve via the current thread's catalog on
-        # the next get(). Without this, a worker thread executing a copied Query would render
-        # FROM via the importing thread's sa_tbl while WHERE references its own sa_tbl,
-        # producing a duplicate-FROM SQL error.
+        # Returning a fresh handle resets _tbl_version (so the next get() re-resolves via the
+        # current thread's catalog) and re-tags _origin_catalog to the calling thread's
+        # catalog via __init__.
         return TableVersionHandle(self.key)
 
     def __eq__(self, other: object) -> bool:
@@ -72,19 +84,32 @@ class TableVersionHandle:
         return self.effective_version is not None
 
     def get(self) -> TableVersion:
-        if self._tbl_version is None or not self._tbl_version.is_validated:
-            cat = get_runtime().catalog
-            if self.effective_version is not None and self._tbl_version is not None:
-                # this is a snapshot version; we need to make sure we refer to the instance cached
-                # in Catalog, in order to avoid mixing sa_tbl instances in the same transaction
-                # (which will lead to duplicates in the From clause generated in SqlNode.create_from_clause())
-                assert self.key in cat._tbl_versions
-                self._tbl_version = cat._tbl_versions[self.key]
-                self._tbl_version.is_validated = True
-            else:
-                self._tbl_version = cat.get_tbl_version(self.key)
-                assert self._tbl_version.key == self.key
-        return self._tbl_version
+        # Snapshot the cache once, decide whether to refresh, and atomically replace at the
+        # end — never reset to None mid-method, so that concurrent readers (this handle can
+        # be shared across threads via Table._tbl_version_path or Column.tbl_handle) always
+        # observe a complete TableVersion. The mismatch case happens when the handle is used
+        # in a different catalog context than it was built against (worker thread with its
+        # own Catalog, or after reset_runtime); we re-resolve so sa_tbl etc. come from the
+        # current catalog's metadata.
+        cat = get_runtime().catalog
+        cached = self._tbl_version
+        needs_refresh = self._origin_catalog is not cat or cached is None or not cached.is_validated
+        if not needs_refresh:
+            return cached
+
+        if self.effective_version is not None and cached is not None:
+            # Snapshot version; refer to the instance cached in Catalog, in order to avoid
+            # mixing sa_tbl instances in the same transaction (which would generate
+            # duplicates in the From clause produced by SqlNode.create_from_clause()).
+            assert self.key in cat._tbl_versions
+            new_tv = cat._tbl_versions[self.key]
+            new_tv.is_validated = True
+        else:
+            new_tv = cat.get_tbl_version(self.key)
+            assert new_tv.key == self.key
+        self._tbl_version = new_tv
+        self._origin_catalog = cat
+        return new_tv
 
     def as_dict(self) -> dict:
         return self.key.as_dict()

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -88,13 +88,14 @@ class TableVersionHandle:
         if not needs_refresh:
             return cached
 
-        if self.effective_version is not None and cached is not None:
-            # This is a snapshot version. We need to reuse the instance cached in Catalog, to avoid mixing sa_tbl
+        if self.effective_version is not None and cached is not None and self._origin_catalog is cat:
+            # Snapshot version, same catalog as before: reuse the instance cached in Catalog to avoid mixing sa_tbl
             # instances in the same transaction (which would produce duplicates in the From clause).
             assert self.key in cat._tbl_versions
             new_tv = cat._tbl_versions[self.key]
             new_tv.is_validated = True
         else:
+            # either no cached instance, or the catalog changed
             new_tv = cat.get_tbl_version(self.key)
             assert new_tv.key == self.key
         self._tbl_version = new_tv

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from pixeltable import exceptions as excs
 from pixeltable.runtime import get_runtime
+
 from .table_version import TableVersion, TableVersionKey
 
 if TYPE_CHECKING:
@@ -40,6 +41,7 @@ class TableVersionHandle:
     def __init__(self, key: TableVersionKey, *, tbl_version: TableVersion | None = None):
         self.key = key
         self._tbl_version = tbl_version
+        self._origin_thread_id = threading.get_ident()
         self._origin_catalog = get_runtime().catalog
 
     def __deepcopy__(self, memo: dict[int, object] | None = None) -> TableVersionHandle:
@@ -109,18 +111,25 @@ class TableVersionHandle:
 
 @dataclass(frozen=True)
 class ColumnHandle:
+    """
+    Indirection mechanism for Column instances, which get resolved against the catalog at runtime.
+
+    Not thread-safe.
+    """
+
     tbl_version: TableVersionHandle
     col_id: int
 
     def get(self) -> 'Column':
-        if self.col_id not in self.tbl_version.get().cols_by_id:
-            schema_version_drop = self.tbl_version.get()._tbl_md.column_md[self.col_id].schema_version_drop
+        tv = self.tbl_version.get()
+        if self.col_id not in tv.cols_by_id:
+            schema_version_drop = tv._tbl_md.column_md[self.col_id].schema_version_drop
             raise excs.NotFoundError(
                 excs.ErrorCode.COLUMN_NOT_FOUND,
                 f'Column was dropped (no record for column ID {self.col_id} in table '
-                f'{self.tbl_version.get().versioned_name!r}; it was dropped in table version {schema_version_drop})',
+                f'{tv.versioned_name!r}; it was dropped in table version {schema_version_drop})',
             )
-        return self.tbl_version.get().cols_by_id[self.col_id]
+        return tv.cols_by_id[self.col_id]
 
     def as_dict(self) -> dict:
         return {'tbl_version': self.tbl_version.as_dict(), 'col_id': self.col_id}

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -20,26 +20,18 @@ _logger = logging.getLogger('pixeltable')
 
 class TableVersionHandle:
     """
-    Indirection mechanism for TableVersion instances, which get resolved against the (thread-local) catalog at runtime.
-    Each get() call needs to resolve against the current thread's catalog in order to avoid picking up catalog
-    elements (eg, Column.sa_column) created in a different thread.
+    Indirection mechanism for TableVersion instances, which get resolved against the catalog at runtime.
 
-    See the TableVersion docstring for details on the semantics of effective_version and anchor_tbl_id.
+    Not thread-safe.
     """
 
     key: TableVersionKey
-    # Per-(thread, xact) cache of the resolved TableVersion. Reset on __deepcopy__ when the
-    # handle crosses a thread/transaction boundary (e.g., a Query template captured at
-    # module-import time being executed in a worker thread, or a Query held across xacts in
-    # the face of a schema change from another process). Re-validation happens on the next
-    # get() through the catalog's is_validated machinery.
+
+    # cache of the resolved TableVersion; needs to be cleared whenever we cross a transaction
+    # or Catalog instance boundary
     _tbl_version: TableVersion | None
-    # The Catalog instance this handle was last resolved against. Set in __init__ from
-    # get_runtime().catalog, re-set by __deepcopy__, and updated by get() whenever it
-    # detects a mismatch with the calling thread's catalog (which can happen across worker
-    # threads or after reset_runtime). On mismatch get() drops the cached TableVersion and
-    # re-resolves through the current catalog, so consumers always observe metadata from the
-    # catalog they're running against.
+
+    # Catalog instance against which this handle was last resolved
     _origin_catalog: Catalog
 
     def __init__(self, key: TableVersionKey, *, tbl_version: TableVersion | None = None):
@@ -48,9 +40,7 @@ class TableVersionHandle:
         self._origin_catalog = get_runtime().catalog
 
     def __deepcopy__(self, memo: dict[int, object] | None = None) -> TableVersionHandle:
-        # Returning a fresh handle resets _tbl_version (so the next get() re-resolves via the
-        # current thread's catalog) and re-tags _origin_catalog to the calling thread's
-        # catalog via __init__.
+        # reset _tbl_version, we might end up in a different thread
         return TableVersionHandle(self.key)
 
     def __eq__(self, other: object) -> bool:

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 from pixeltable import exceptions as excs
 from pixeltable.runtime import get_runtime
-
 from .table_version import TableVersion, TableVersionKey
 
 if TYPE_CHECKING:
@@ -30,6 +30,9 @@ class TableVersionHandle:
     # cache of the resolved TableVersion; needs to be cleared whenever we cross a transaction
     # or Catalog instance boundary
     _tbl_version: TableVersion | None
+
+    # id of the constructing thread; used to guard against cross-thread access
+    _origin_thread_id: int
 
     # Catalog instance against which this handle was last resolved
     _origin_catalog: Catalog
@@ -74,13 +77,9 @@ class TableVersionHandle:
         return self.effective_version is not None
 
     def get(self) -> TableVersion:
-        # Snapshot the cache once, decide whether to refresh, and atomically replace at the
-        # end - never reset to None mid-method, so that concurrent readers (this handle can
-        # be shared across threads via Table._tbl_version_path or Column.tbl_handle) always
-        # observe a complete TableVersion. The mismatch case happens when the handle is used
-        # in a different catalog context than it was built against (worker thread with its
-        # own Catalog, or after reset_runtime); we re-resolve so sa_tbl etc. come from the
-        # current catalog's metadata.
+        # guard against cross-thread access
+        assert self._origin_thread_id == threading.get_ident()
+
         cat = get_runtime().catalog
         cached = self._tbl_version
         needs_refresh = self._origin_catalog is not cat or cached is None or not cached.is_validated
@@ -88,9 +87,8 @@ class TableVersionHandle:
             return cached
 
         if self.effective_version is not None and cached is not None:
-            # Snapshot version; refer to the instance cached in Catalog, in order to avoid
-            # mixing sa_tbl instances in the same transaction (which would generate
-            # duplicates in the From clause produced by SqlNode.create_from_clause()).
+            # This is a snapshot version. We need to reuse the instance cached in Catalog, to avoid mixing sa_tbl
+            # instances in the same transaction (which would produce duplicates in the From clause).
             assert self.key in cat._tbl_versions
             new_tv = cat._tbl_versions[self.key]
             new_tv.is_validated = True

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -18,9 +18,11 @@ _logger = logging.getLogger('pixeltable')
 
 class TableVersionHandle:
     """
-    Indirection mechanism for TableVersion instances, which get resolved against the catalog at runtime.
+    Indirection mechanism for TableVersion instances, which get resolved against the (thread-local) catalog at runtime.
+    Each get() call needs to resolve against the current thread's catalog in order to avoid picking up catalog
+    elements (eg, Column.sa_column) created in a different thread.
 
-    See the TableVersion docstring for details on the semantics of `effective_version` and `anchor_tbl_id`.
+    See the TableVersion docstring for details on the semantics of effective_version and anchor_tbl_id.
     """
 
     key: TableVersionKey
@@ -29,6 +31,15 @@ class TableVersionHandle:
     def __init__(self, key: TableVersionKey, *, tbl_version: TableVersion | None = None):
         self.key = key
         self._tbl_version = tbl_version
+
+    def __deepcopy__(self, memo: dict[int, object] | None = None) -> TableVersionHandle:
+        # Drop the per-instance _tbl_version cache on deepcopy: it points to whichever thread's
+        # TV was current when this handle was constructed (e.g., the importing thread for a
+        # Query template). The copy will lazily resolve via the current thread's catalog on
+        # the next get(). Without this, a worker thread executing a copied Query would render
+        # FROM via the importing thread's sa_tbl while WHERE references its own sa_tbl,
+        # producing a duplicate-FROM SQL error.
+        return TableVersionHandle(self.key)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TableVersionHandle):

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -12,9 +12,7 @@ from pixeltable.runtime import get_runtime
 from .table_version import TableVersion, TableVersionKey
 
 if TYPE_CHECKING:
-    from pixeltable.catalog import Column
-
-    from .catalog import Catalog
+    from pixeltable.catalog import Catalog, Column
 
 _logger = logging.getLogger('pixeltable')
 

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -79,8 +79,8 @@ class TableVersionHandle:
         return self.effective_version is not None
 
     def get(self) -> TableVersion:
-        # guard against cross-thread access
-        assert self._origin_thread_id == threading.get_ident()
+        # guard against incorrect cross-thread access; inherited-context threads are allowed
+        assert self._origin_thread_id == threading.get_ident() or get_runtime().context_inherited
 
         cat = get_runtime().catalog
         cached = self._tbl_version

--- a/pixeltable/catalog/table_version_handle.py
+++ b/pixeltable/catalog/table_version_handle.py
@@ -35,7 +35,7 @@ class TableVersionHandle:
     # get() through the catalog's is_validated machinery.
     _tbl_version: TableVersion | None
     # The Catalog instance this handle was last resolved against. Set in __init__ from
-    # `get_runtime().catalog`, re-set by __deepcopy__, and updated by get() whenever it
+    # get_runtime().catalog, re-set by __deepcopy__, and updated by get() whenever it
     # detects a mismatch with the calling thread's catalog (which can happen across worker
     # threads or after reset_runtime). On mismatch get() drops the cached TableVersion and
     # re-resolves through the current catalog, so consumers always observe metadata from the
@@ -85,7 +85,7 @@ class TableVersionHandle:
 
     def get(self) -> TableVersion:
         # Snapshot the cache once, decide whether to refresh, and atomically replace at the
-        # end — never reset to None mid-method, so that concurrent readers (this handle can
+        # end - never reset to None mid-method, so that concurrent readers (this handle can
         # be shared across threads via Table._tbl_version_path or Column.tbl_handle) always
         # observe a complete TableVersion. The mismatch case happens when the handle is used
         # in a different catalog context than it was built against (worker thread with its

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -5,9 +5,9 @@ import threading
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from pixeltable import exceptions as excs
 from pixeltable.metadata import schema
 from pixeltable.runtime import get_runtime
+
 from .column import Column
 from .globals import MediaValidation, QColumnId
 from .table_version import TableVersion, TableVersionKey
@@ -92,13 +92,7 @@ class TableVersionPath:
 
     def refresh_cached_md(self) -> None:
         # guard against cross-thread access
-        if self._origin_thread_id != threading.get_ident():
-            raise excs.RequestError(
-                excs.ErrorCode.INVALID_STATE,
-                f'Table {self.tbl_version.id} was accessed from a thread other than the one that constructed it. '
-                f'Tables are not thread-safe; call pxt.get_table(...) on this thread to obtain a thread-local '
-                f'instance.',
-            )
+        assert self._origin_thread_id == threading.get_ident()
 
         # re-resolve if the Catalog instance changed
         cat = get_runtime().catalog

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import copy
+import threading
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from pixeltable import exceptions as excs
 from pixeltable.metadata import schema
 
 from .column import Column
@@ -41,13 +43,21 @@ class TableVersionPath:
     tbl_version: TableVersionHandle
     base: TableVersionPath | None
     # Per-(thread, xact) cache of the resolved TableVersion. Reset on __deepcopy__ when the
-    # TVP crosses a thread/transaction boundary (e.g., a Query template captured at
-    # module-import time being executed in a worker thread, or a Query held across xacts in
-    # the face of a schema change from another process). Re-validation happens on the next
+    # TVP crosses a thread boundary (e.g., a Query template captured at module-import time
+    # being executed in a worker thread, or a Query held across xacts in the face of a
+    # schema change from another process). Re-validation happens on the next
     # tbl_version.get() through the catalog's is_validated machinery.
     _cached_tbl_version: TableVersion | None
-    # The Catalog instance this path was last resolved against. See the corresponding
-    # comment on TableVersionHandle._origin_catalog.
+    # The thread that constructed (or most recently deepcopied) this TVP. Tables hold a TVP
+    # via Table._tbl_version_path; cross-thread access through a Table is rejected at
+    # refresh_cached_md() with a clear error pointing the user at pxt.get_table(). Queries,
+    # by contrast, defensively deepcopy at collect-time, so the per-Query TVPs end up tagged
+    # to the executing thread.
+    _origin_thread_id: int
+    # The Catalog instance this path was last resolved against. Used for the same-thread
+    # cross-Catalog case (reset_runtime in tests): we self-heal by dropping the cache and
+    # re-resolving via the new Catalog. See the corresponding comment on
+    # TableVersionHandle._origin_catalog.
     _origin_catalog: Catalog
 
     def __init__(self, tbl_version: TableVersionHandle, base: TableVersionPath | None = None):
@@ -57,6 +67,7 @@ class TableVersionPath:
         self.tbl_version = tbl_version
         self.base = base
         self._cached_tbl_version = None
+        self._origin_thread_id = threading.get_ident()
         self._origin_catalog = get_runtime().catalog
 
         if self.base is not None and tbl_version.anchor_tbl_id is not None:
@@ -92,13 +103,25 @@ class TableVersionPath:
     def refresh_cached_md(self) -> None:
         from pixeltable.runtime import get_runtime
 
-        # When we're running inside a transaction, we need to make sure to supply current metadata;
-        # mixing stale metadata with current metadata leads to query construction failures
-        # (multiple sqlalchemy Table instances for the same underlying table create corrupted From clauses).
-        # See the corresponding comment on TableVersionHandle.get() for the cross-thread / cross-runtime
-        # case. Snapshot the current cache once, decide whether to refresh, and atomically replace at
-        # the end - never reset to None mid-method, so that concurrent readers (this TVP can be shared
-        # across threads via Table._tbl_version_path) always observe a complete TableVersion.
+        # Reject cross-thread access. Tables hold a TVP and are not thread-safe: their
+        # cached metadata is a per-instance, per-thread cache. Concurrent threads sharing a
+        # Table would race on this cache, and even if races are made benign via atomic
+        # replace, the cache pings between catalogs and forces redundant metadata loads.
+        # Cross-thread sharing is supposed to go through Query.collect() (which deepcopies
+        # and produces a thread-local TVP), or through a per-thread pxt.get_table().
+        if self._origin_thread_id != threading.get_ident():
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_STATE,
+                f'Table {self.tbl_version.id} was accessed from a thread other than the one that constructed it. '
+                f'Tables are not thread-safe; call pxt.get_table(...) on this thread to obtain a thread-local '
+                f'instance.',
+            )
+        # Same thread but different Catalog (e.g., after reset_runtime): drop the cache and
+        # re-resolve. When we're inside a transaction, also reload if our cached TV's
+        # is_validated flipped (mixing stale and current metadata produces multiple
+        # sqlalchemy Table instances for the same underlying table and corrupts From
+        # clauses). Snapshot the cache, then atomically replace - never set to None
+        # mid-method.
         cat = get_runtime().catalog
         cached = self._cached_tbl_version
         needs_refresh = (

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -97,7 +97,7 @@ class TableVersionPath:
         # (multiple sqlalchemy Table instances for the same underlying table create corrupted From clauses).
         # See the corresponding comment on TableVersionHandle.get() for the cross-thread / cross-runtime
         # case. Snapshot the current cache once, decide whether to refresh, and atomically replace at
-        # the end — never reset to None mid-method, so that concurrent readers (this TVP can be shared
+        # the end - never reset to None mid-method, so that concurrent readers (this TVP can be shared
         # across threads via Table._tbl_version_path) always observe a complete TableVersion.
         cat = get_runtime().catalog
         cached = self._cached_tbl_version

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -91,8 +91,8 @@ class TableVersionPath:
         return result
 
     def refresh_cached_md(self) -> None:
-        # guard against cross-thread access
-        assert self._origin_thread_id == threading.get_ident()
+        # guard against incorrect cross-thread access; inherited-context threads are allowed
+        assert self._origin_thread_id == threading.get_ident() or get_runtime().context_inherited
 
         # re-resolve if the Catalog instance changed
         cat = get_runtime().catalog

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from pixeltable.metadata import schema
@@ -10,6 +10,9 @@ from .column import Column
 from .globals import MediaValidation, QColumnId
 from .table_version import TableVersion, TableVersionKey
 from .table_version_handle import TableVersionHandle
+
+if TYPE_CHECKING:
+    from .catalog import Catalog
 
 
 class TableVersionPath:
@@ -37,16 +40,38 @@ class TableVersionPath:
 
     tbl_version: TableVersionHandle
     base: TableVersionPath | None
+    # Per-(thread, xact) cache of the resolved TableVersion. Reset on __deepcopy__ when the
+    # TVP crosses a thread/transaction boundary (e.g., a Query template captured at
+    # module-import time being executed in a worker thread, or a Query held across xacts in
+    # the face of a schema change from another process). Re-validation happens on the next
+    # tbl_version.get() through the catalog's is_validated machinery.
     _cached_tbl_version: TableVersion | None
+    # The Catalog instance this path was last resolved against. See the corresponding
+    # comment on TableVersionHandle._origin_catalog.
+    _origin_catalog: Catalog
 
     def __init__(self, tbl_version: TableVersionHandle, base: TableVersionPath | None = None):
+        from pixeltable.runtime import get_runtime
+
         assert tbl_version is not None
         self.tbl_version = tbl_version
         self.base = base
         self._cached_tbl_version = None
+        self._origin_catalog = get_runtime().catalog
 
         if self.base is not None and tbl_version.anchor_tbl_id is not None:
             self.base = self.base.anchor_to(tbl_version.anchor_tbl_id)
+
+    def __deepcopy__(self, memo: dict[int, object]) -> TableVersionPath:
+        # Reset _cached_tbl_version and recurse into tbl_version (TVH) and base (TVP). Both
+        # have their own __deepcopy__ that reset their respective per-(thread, xact) caches.
+        # See the comment on _cached_tbl_version above for the invariant.
+        result = TableVersionPath(
+            tbl_version=copy.deepcopy(self.tbl_version, memo),
+            base=copy.deepcopy(self.base, memo) if self.base is not None else None,
+        )
+        memo[id(self)] = result
+        return result
 
     @classmethod
     def from_md(cls, path: schema.TableVersionPath) -> TableVersionPath:
@@ -67,18 +92,25 @@ class TableVersionPath:
     def refresh_cached_md(self) -> None:
         from pixeltable.runtime import get_runtime
 
-        if get_runtime().in_xact:
-            # when we're running inside a transaction, we need to make sure to supply current metadata;
-            # mixing stale metadata with current metadata leads to query construction failures
-            # (multiple sqlalchemy Table instances for the same underlying table create corrupted From clauses)
-            if self._cached_tbl_version is not None and self._cached_tbl_version.is_validated:
-                # nothing to refresh
-                return
-        elif self._cached_tbl_version is not None:
+        # When we're running inside a transaction, we need to make sure to supply current metadata;
+        # mixing stale metadata with current metadata leads to query construction failures
+        # (multiple sqlalchemy Table instances for the same underlying table create corrupted From clauses).
+        # See the corresponding comment on TableVersionHandle.get() for the cross-thread / cross-runtime
+        # case. Snapshot the current cache once, decide whether to refresh, and atomically replace at
+        # the end — never reset to None mid-method, so that concurrent readers (this TVP can be shared
+        # across threads via Table._tbl_version_path) always observe a complete TableVersion.
+        cat = get_runtime().catalog
+        cached = self._cached_tbl_version
+        needs_refresh = (
+            self._origin_catalog is not cat or cached is None or (get_runtime().in_xact and not cached.is_validated)
+        )
+        if not needs_refresh:
             return
 
         with get_runtime().catalog.begin_xact(for_write=False, read_tbl_ids=[self.tbl_version.id]):
-            self._cached_tbl_version = self.tbl_version.get()
+            new_tv = self.tbl_version.get()
+        self._cached_tbl_version = new_tv
+        self._origin_catalog = cat
 
     def anchor_to(self, anchor_tbl_id: UUID | None) -> TableVersionPath:
         """

--- a/pixeltable/catalog/table_version_path.py
+++ b/pixeltable/catalog/table_version_path.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from pixeltable import exceptions as excs
 from pixeltable.metadata import schema
-
+from pixeltable.runtime import get_runtime
 from .column import Column
 from .globals import MediaValidation, QColumnId
 from .table_version import TableVersion, TableVersionKey
@@ -38,31 +38,23 @@ class TableVersionPath:
       query actually runs (at which point there is a transaction context) - there is no guarantee that in between
       constructing a Query and executing it, the underlying table schema hasn't changed (eg, a concurrent process
       could have dropped a column referenced in the query).
+
+    Not thread-safe.
     """
 
     tbl_version: TableVersionHandle
     base: TableVersionPath | None
-    # Per-(thread, xact) cache of the resolved TableVersion. Reset on __deepcopy__ when the
-    # TVP crosses a thread boundary (e.g., a Query template captured at module-import time
-    # being executed in a worker thread, or a Query held across xacts in the face of a
-    # schema change from another process). Re-validation happens on the next
-    # tbl_version.get() through the catalog's is_validated machinery.
+
+    # cache of the resolved TableVersion; needs to be reset on transaction and thread boundaries
     _cached_tbl_version: TableVersion | None
-    # The thread that constructed (or most recently deepcopied) this TVP. Tables hold a TVP
-    # via Table._tbl_version_path; cross-thread access through a Table is rejected at
-    # refresh_cached_md() with a clear error pointing the user at pxt.get_table(). Queries,
-    # by contrast, defensively deepcopy at collect-time, so the per-Query TVPs end up tagged
-    # to the executing thread.
+
+    # id of the constructing thread; used to guard against cross-thread access
     _origin_thread_id: int
-    # The Catalog instance this path was last resolved against. Used for the same-thread
-    # cross-Catalog case (reset_runtime in tests): we self-heal by dropping the cache and
-    # re-resolving via the new Catalog. See the corresponding comment on
-    # TableVersionHandle._origin_catalog.
+
+    # Catalog instance against which this path was last resolved; used to invalidate cached state/force re-resolution
     _origin_catalog: Catalog
 
     def __init__(self, tbl_version: TableVersionHandle, base: TableVersionPath | None = None):
-        from pixeltable.runtime import get_runtime
-
         assert tbl_version is not None
         self.tbl_version = tbl_version
         self.base = base
@@ -74,9 +66,7 @@ class TableVersionPath:
             self.base = self.base.anchor_to(tbl_version.anchor_tbl_id)
 
     def __deepcopy__(self, memo: dict[int, object]) -> TableVersionPath:
-        # Reset _cached_tbl_version and recurse into tbl_version (TVH) and base (TVP). Both
-        # have their own __deepcopy__ that reset their respective per-(thread, xact) caches.
-        # See the comment on _cached_tbl_version above for the invariant.
+        # reset thread-specific state
         result = TableVersionPath(
             tbl_version=copy.deepcopy(self.tbl_version, memo),
             base=copy.deepcopy(self.base, memo) if self.base is not None else None,
@@ -101,14 +91,7 @@ class TableVersionPath:
         return result
 
     def refresh_cached_md(self) -> None:
-        from pixeltable.runtime import get_runtime
-
-        # Reject cross-thread access. Tables hold a TVP and are not thread-safe: their
-        # cached metadata is a per-instance, per-thread cache. Concurrent threads sharing a
-        # Table would race on this cache, and even if races are made benign via atomic
-        # replace, the cache pings between catalogs and forces redundant metadata loads.
-        # Cross-thread sharing is supposed to go through Query.collect() (which deepcopies
-        # and produces a thread-local TVP), or through a per-thread pxt.get_table().
+        # guard against cross-thread access
         if self._origin_thread_id != threading.get_ident():
             raise excs.RequestError(
                 excs.ErrorCode.INVALID_STATE,
@@ -116,12 +99,8 @@ class TableVersionPath:
                 f'Tables are not thread-safe; call pxt.get_table(...) on this thread to obtain a thread-local '
                 f'instance.',
             )
-        # Same thread but different Catalog (e.g., after reset_runtime): drop the cache and
-        # re-resolve. When we're inside a transaction, also reload if our cached TV's
-        # is_validated flipped (mixing stale and current metadata produces multiple
-        # sqlalchemy Table instances for the same underlying table and corrupts From
-        # clauses). Snapshot the cache, then atomically replace - never set to None
-        # mid-method.
+
+        # re-resolve if the Catalog instance changed
         cat = get_runtime().catalog
         cached = self._cached_tbl_version
         needs_refresh = (

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -312,11 +312,13 @@ class View(Table):
         print_stats: bool = False,
         **kwargs: Any,
     ) -> UpdateStatus:
+        self._check_thread()
         raise excs.RequestError(
             excs.ErrorCode.UNSUPPORTED_OPERATION, f'{self._display_str()}: Cannot insert into a {self._display_name()}.'
         )
 
     def delete(self, where: exprs.Expr | None = None) -> UpdateStatus:
+        self._check_thread()
         raise excs.RequestError(
             excs.ErrorCode.UNSUPPORTED_OPERATION, f'{self._display_str()}: Cannot delete from a {self._display_name()}.'
         )

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -312,13 +312,13 @@ class View(Table):
         print_stats: bool = False,
         **kwargs: Any,
     ) -> UpdateStatus:
-        self._check_thread()
+        self._validate_thread()
         raise excs.RequestError(
             excs.ErrorCode.UNSUPPORTED_OPERATION, f'{self._display_str()}: Cannot insert into a {self._display_name()}.'
         )
 
     def delete(self, where: exprs.Expr | None = None) -> UpdateStatus:
-        self._check_thread()
+        self._validate_thread()
         raise excs.RequestError(
             excs.ErrorCode.UNSUPPORTED_OPERATION, f'{self._display_str()}: Cannot delete from a {self._display_name()}.'
         )

--- a/pixeltable/exec/in_memory_data_node.py
+++ b/pixeltable/exec/in_memory_data_node.py
@@ -59,7 +59,9 @@ class InMemoryDataNode(ExecNode):
                 col = col_info.col
                 if col.col_type.is_image_type() and isinstance(val, bytes):
                     # this is a literal media file, ie, a sequence of bytes; save it as a binary file and store the path
-                    filepath, _ = TempStore.save_media_object(val, col, format=None)
+                    filepath, _ = TempStore.save_media_object(
+                        val, col.tbl_handle.id, col.id, col.get_tbl().version, format=None
+                    )
                     output_row[col_info.slot_idx] = str(filepath)
                 else:
                     output_row[col_info.slot_idx] = val

--- a/pixeltable/exec/object_store_save_node.py
+++ b/pixeltable/exec/object_store_save_node.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from typing import AsyncIterator, Iterator, NamedTuple
 
 from pixeltable import exprs
-from pixeltable.utils.object_stores import ObjectOps, ObjectPath, StorageTarget
+from pixeltable.utils.object_stores import (
+    ObjectOps,
+    ObjectPath,
+    ObjectStoreBase,
+    ResolvedFileDestination,
+    StorageTarget,
+)
 from pixeltable.utils.progress_reporter import ProgressReporter
 
 from .data_row_batch import DataRowBatch
@@ -51,7 +57,11 @@ class ObjectStoreSaveNode(ExecNode):
     class WorkItem(NamedTuple):
         src_path: Path
         destination: str | None
-        info: exprs.ColumnSlotIdx  # column info for the file being processed
+        info: exprs.ColumnSlotIdx  # column info for the file being processed (caller-thread post-processing only)
+        # Resolved on the caller thread so that worker threads do not need catalog access
+        # to perform the file write.
+        store: ObjectStoreBase
+        resolved: ResolvedFileDestination
         destination_count: int = 1  # number of unique destinations for this file
 
     retain_input_order: bool  # if True, return rows in the exact order they were received
@@ -251,7 +261,13 @@ class ObjectStoreSaveNode(ExecNode):
                 num_missing += 1
                 continue
 
-            work_item = ObjectStoreSaveNode.WorkItem(src_path, destination, info)
+            # Resolve the destination on the caller thread (catalog context). The worker thread
+            # consumes only `store` and `resolved` and never accesses catalog state.
+            store = ObjectOps.get_store(destination, False, col.name)
+            resolved = store.prepare_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
+            work_item = ObjectStoreSaveNode.WorkItem(
+                src_path=src_path, destination=destination, info=info, store=store, resolved=resolved
+            )
             row_to_do.append(work_item)
             self.in_flight_work[work_designator] = [(row, info)]
             num_missing += 1
@@ -264,13 +280,8 @@ class ObjectStoreSaveNode(ExecNode):
                 new_to_do.append(work_item)
             else:
                 new_to_do.append(
-                    ObjectStoreSaveNode.WorkItem(
-                        work_item.src_path,
-                        work_item.destination,
-                        work_item.info,
-                        destination_count=unique_destinations[work_item.src_path] + 1,
-                        # +1 for the TempStore destination
-                    )
+                    work_item._replace(destination_count=unique_destinations[work_item.src_path] + 1)
+                    # +1 for the TempStore destination
                 )
         delete_destinations = [k for k, v in unique_destinations.items() if v > 1 and TempStore.contains_path(k)]
         row_to_do = new_to_do
@@ -302,13 +313,16 @@ class ObjectStoreSaveNode(ExecNode):
             _logger.debug(f'submitted {work_item}')
 
     def __persist_media_file(self, work_item: WorkItem) -> tuple[str | None, Exception | None]:
-        """Move data from the TempStore to another location"""
-        src_path = work_item.src_path
-        col = work_item.info.col
-        assert col.destination == work_item.destination
+        """Move data from the TempStore to another location.
+
+        Runs on a worker thread of the ThreadPoolExecutor. Performs no catalog access:
+        the destination was resolved on the caller thread when the WorkItem was built.
+        """
         try:
-            new_file_url = ObjectOps.put_file(col, src_path, work_item.destination_count == 1)
+            new_file_url = ObjectOps.put_file_resolved(
+                work_item.store, work_item.src_path, work_item.resolved, work_item.destination_count == 1
+            )
             return new_file_url, None
         except Exception as e:
-            _logger.debug(f'Failed to move/copy {src_path}: {e}', exc_info=e)
+            _logger.debug(f'Failed to move/copy {work_item.src_path}: {e}', exc_info=e)
             return None, e

--- a/pixeltable/exec/object_store_save_node.py
+++ b/pixeltable/exec/object_store_save_node.py
@@ -9,13 +9,7 @@ from pathlib import Path
 from typing import AsyncIterator, Iterator, NamedTuple
 
 from pixeltable import exprs
-from pixeltable.utils.object_stores import (
-    ObjectOps,
-    ObjectPath,
-    ObjectStoreBase,
-    ResolvedFileDestination,
-    StorageTarget,
-)
+from pixeltable.utils.object_stores import FileDestination, ObjectOps, ObjectPath, ObjectStoreBase, StorageTarget
 from pixeltable.utils.progress_reporter import ProgressReporter
 
 from .data_row_batch import DataRowBatch
@@ -61,7 +55,7 @@ class ObjectStoreSaveNode(ExecNode):
         # Resolved on the caller thread so that worker threads do not need catalog access
         # to perform the file write.
         store: ObjectStoreBase
-        resolved: ResolvedFileDestination
+        dest: FileDestination
         destination_count: int = 1  # number of unique destinations for this file
 
     retain_input_order: bool  # if True, return rows in the exact order they were received
@@ -262,11 +256,11 @@ class ObjectStoreSaveNode(ExecNode):
                 continue
 
             # Resolve the destination on the caller thread (catalog context). The worker thread
-            # consumes only store and resolved and never accesses catalog state.
+            # consumes only store and dest and never accesses catalog state.
             store = ObjectOps.get_store(destination, False, col.name)
-            resolved = store.prepare_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
+            dest = store.resolve_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
             work_item = ObjectStoreSaveNode.WorkItem(
-                src_path=src_path, destination=destination, info=info, store=store, resolved=resolved
+                src_path=src_path, destination=destination, info=info, store=store, dest=dest
             )
             row_to_do.append(work_item)
             self.in_flight_work[work_designator] = [(row, info)]
@@ -320,7 +314,7 @@ class ObjectStoreSaveNode(ExecNode):
         """
         try:
             new_file_url = ObjectOps.put_file_resolved(
-                work_item.store, work_item.src_path, work_item.resolved, work_item.destination_count == 1
+                work_item.store, work_item.src_path, work_item.dest, work_item.destination_count == 1
             )
             return new_file_url, None
         except Exception as e:

--- a/pixeltable/exec/object_store_save_node.py
+++ b/pixeltable/exec/object_store_save_node.py
@@ -262,7 +262,7 @@ class ObjectStoreSaveNode(ExecNode):
                 continue
 
             # Resolve the destination on the caller thread (catalog context). The worker thread
-            # consumes only `store` and `resolved` and never accesses catalog state.
+            # consumes only store and resolved and never accesses catalog state.
             store = ObjectOps.get_store(destination, False, col.name)
             resolved = store.prepare_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
             work_item = ObjectStoreSaveNode.WorkItem(

--- a/pixeltable/exec/sql_node.py
+++ b/pixeltable/exec/sql_node.py
@@ -369,7 +369,7 @@ class SqlNode(ExecNode):
             except Exception:
                 # log something if we can't log the compiled stmt
                 _logger.debug(f'SqlLookupNode proto-stmt:\n{stmt}')
-            self._log_explain(stmt)
+            # self._log_explain(stmt)  # disabled for benchmarking — issues a per-request EXPLAIN
 
             conn = get_runtime().conn
             result_cursor = conn.execute(stmt)

--- a/pixeltable/exec/sql_node.py
+++ b/pixeltable/exec/sql_node.py
@@ -139,10 +139,10 @@ class SqlNode(ExecNode):
         # We query for unstored outputs only if we're not loading a view; when we're loading a view, we are populating
         # those columns, so we need to keep them out of the select list. This isn't a problem, because view loads never
         # need to call set_pos().
-        # TODO: This is necessary because create_view_load_plan passes stored output columns to RowBuilder via the
-        #     columns parameter (even though they don't appear in output_exprs). This causes them to be recorded as
-        #     expressions in RowBuilder, which creates a conflict if we add them here. If RowBuilder is restructured
-        #     to keep them out of unique_exprs, then this conditional can be removed.
+        # TODO: This is necessary because create_view_load_plan passes stored output columns to `RowBuilder` via the
+        #     `columns` parameter (even though they don't appear in `output_exprs`). This causes them to be recorded as
+        #     expressions in `RowBuilder`, which creates a conflict if we add them here. If `RowBuilder` is restructured
+        #     to keep them out of `unique_exprs`, then this conditional can be removed.
         if not row_builder.for_view_load:
             for outputs in row_builder.unstored_iter_outputs.values():
                 self.select_list.update(outputs)

--- a/pixeltable/exec/sql_node.py
+++ b/pixeltable/exec/sql_node.py
@@ -369,7 +369,8 @@ class SqlNode(ExecNode):
             except Exception:
                 # log something if we can't log the compiled stmt
                 _logger.debug(f'SqlLookupNode proto-stmt:\n{stmt}')
-            # self._log_explain(stmt)  # disabled for benchmarking; issues a per-request EXPLAIN
+            if _logger.isEnabledFor(logging.DEBUG):
+                self._log_explain(stmt)
 
             conn = get_runtime().conn
             result_cursor = conn.execute(stmt)

--- a/pixeltable/exec/sql_node.py
+++ b/pixeltable/exec/sql_node.py
@@ -139,10 +139,10 @@ class SqlNode(ExecNode):
         # We query for unstored outputs only if we're not loading a view; when we're loading a view, we are populating
         # those columns, so we need to keep them out of the select list. This isn't a problem, because view loads never
         # need to call set_pos().
-        # TODO: This is necessary because create_view_load_plan passes stored output columns to `RowBuilder` via the
-        #     `columns` parameter (even though they don't appear in `output_exprs`). This causes them to be recorded as
-        #     expressions in `RowBuilder`, which creates a conflict if we add them here. If `RowBuilder` is restructured
-        #     to keep them out of `unique_exprs`, then this conditional can be removed.
+        # TODO: This is necessary because create_view_load_plan passes stored output columns to RowBuilder via the
+        #     columns parameter (even though they don't appear in output_exprs). This causes them to be recorded as
+        #     expressions in RowBuilder, which creates a conflict if we add them here. If RowBuilder is restructured
+        #     to keep them out of unique_exprs, then this conditional can be removed.
         if not row_builder.for_view_load:
             for outputs in row_builder.unstored_iter_outputs.values():
                 self.select_list.update(outputs)
@@ -369,7 +369,7 @@ class SqlNode(ExecNode):
             except Exception:
                 # log something if we can't log the compiled stmt
                 _logger.debug(f'SqlLookupNode proto-stmt:\n{stmt}')
-            # self._log_explain(stmt)  # disabled for benchmarking — issues a per-request EXPLAIN
+            # self._log_explain(stmt)  # disabled for benchmarking; issues a per-request EXPLAIN
 
             conn = get_runtime().conn
             result_cursor = conn.execute(stmt)

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -129,6 +129,25 @@ class ColumnRef(Expr):
         col = target.cols_by_id[self.col.id]
         return ColumnRef(col, self.reference_tbl)
 
+    def copy(self) -> ColumnRef:
+        # Re-resolve self.col against the current thread's catalog. The Catalog is thread-local:
+        # each request thread has its own TableVersion / StoreTable / sa_tbl. Preserving the
+        # original col reference (which is what Expr.copy() does by default via __dict__.update)
+        # would bind the copied expression to the import-time sa_tbl, producing a FROM-clause
+        # mismatch (FROM tbl_xxx, tbl_xxx) when the planner uses the current thread's sa_tbl.
+        # If the table isn't cached on the current thread, fall back to the default behavior;
+        # the caller is expected to warm the catalog before relying on this re-binding.
+        from pixeltable.runtime import get_runtime
+
+        result = super().copy()
+        cat = get_runtime().catalog
+        tv = cat._tbl_versions.get(self.col.tbl_handle.key)
+        if tv is not None and self.col.id in tv.cols_by_id:
+            new_col = tv.cols_by_id[self.col.id]
+            result.col = new_col
+            result.col_handle = new_col.handle
+        return result
+
     def __getattr__(self, name: str) -> Expr:
         from .column_property_ref import ColumnPropertyRef
 

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -48,9 +48,9 @@ class ColumnRef(Expr):
     # - the non-validating ColumnRef is used for SQL translation
 
     # A ColumnRef may have an optional reference table, which carries the context of the ColumnRef resolution. Thus
-    # if v is a view of t (for example), then v.my_col and t.my_col refer to the same underlying column, but
-    # their reference tables will be v and t, respectively. This is to ensure correct behavior of expressions such
-    # as v.my_col.head().
+    # if `v` is a view of `t` (for example), then `v.my_col` and `t.my_col` refer to the same underlying column, but
+    # their reference tables will be `v` and `t`, respectively. This is to ensure correct behavior of expressions such
+    # as `v.my_col.head()`.
 
     # TODO:
     # separate Exprs (like validating ColumnRefs) from the logical expression tree and instead have RowBuilder

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import warnings
 from typing import TYPE_CHECKING, Any, Iterator, Sequence, cast
 from uuid import UUID
@@ -55,7 +56,11 @@ class ColumnRef(Expr):
     # separate Exprs (like validating ColumnRefs) from the logical expression tree and instead have RowBuilder
     # insert them into the EvalCtxs as needed
 
-    col: catalog.Column  # TODO: merge with col_handle
+    # `col_handle` is the source of truth. Column metadata is owned by the catalog and resolved
+    # on every access via the catalog's `is_validated`-gated machinery, which gives us correctness
+    # across (a) transactions, including ones triggered by other processes, (b) threads, and
+    # (c) future cache evictions. The `col` property below derives from col_handle; we never
+    # cache a Column reference on this instance.
     col_handle: catalog.ColumnHandle
     reference_tbl: catalog.TableVersionPath | None
     needs_iterator_evaluation: bool
@@ -76,7 +81,6 @@ class ColumnRef(Expr):
         perform_validation: bool | None = None,
     ):
         super().__init__(col.col_type)
-        self.col = col
         self.reference_tbl = reference_tbl
         self.col_handle = col.handle
 
@@ -106,6 +110,15 @@ class ColumnRef(Expr):
             self.components = [non_validating_col_ref]
         self.id = self._create_id()
 
+    @property
+    def col(self) -> catalog.Column:
+        # Always re-resolve via the catalog. Column metadata may have been mutated by another
+        # transaction (in this process or another) since this ColumnRef was constructed; the
+        # handle resolves through TableVersionHandle.get(), which validates against the current
+        # transaction's view of the catalog. Hot-path callers should bind to a local at the top
+        # of their function rather than reading `self.col.<attr>` repeatedly.
+        return self.col_handle.get()
+
     def set_iter_arg_ctx(self, iter_arg_ctx: RowBuilder.EvalCtx, iter_outputs: list[ColumnRef]) -> None:
         self.iter_arg_ctx = iter_arg_ctx
         self.iter_outputs = iter_outputs
@@ -116,37 +129,32 @@ class ColumnRef(Expr):
         assert len(self.iter_arg_ctx.target_slot_idxs) == 1  # a single inline dict
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
+        # Use col_handle directly (its `tbl_version.id` and `col_id` are immutable identity)
+        # rather than going through self.col.<...>; avoids a catalog lookup on every hash.
         return [
             *super()._id_attrs(),
-            ('tbl_id', self.col.tbl_handle.id),
-            ('col_id', self.col.id),
+            ('tbl_id', self.col_handle.tbl_version.id),
+            ('col_id', self.col_handle.col_id),
             ('perform_validation', self.perform_validation),
         ]
 
     # override
     def _retarget(self, tbl_versions: dict[UUID, catalog.TableVersion]) -> ColumnRef:
-        target = tbl_versions[self.col.tbl_handle.id]
-        assert self.col.id in target.cols_by_id, f'{target}: {self.col.id} not in {list(target.cols_by_id.keys())}'
-        col = target.cols_by_id[self.col.id]
+        target = tbl_versions[self.col_handle.tbl_version.id]
+        col_id = self.col_handle.col_id
+        assert col_id in target.cols_by_id, f'{target}: {col_id} not in {list(target.cols_by_id.keys())}'
+        col = target.cols_by_id[col_id]
         return ColumnRef(col, self.reference_tbl)
 
+    # override
     def copy(self) -> ColumnRef:
-        # Re-resolve self.col against the current thread's catalog. The Catalog is thread-local:
-        # each request thread has its own TableVersion / StoreTable / sa_tbl. Preserving the
-        # original col reference (which is what Expr.copy() does by default via __dict__.update)
-        # would bind the copied expression to the import-time sa_tbl, producing a FROM-clause
-        # mismatch (FROM tbl_xxx, tbl_xxx) when the planner uses the current thread's sa_tbl.
-        # If the table isn't cached on the current thread, fall back to the default behavior;
-        # the caller is expected to warm the catalog before relying on this re-binding.
-        from pixeltable.runtime import get_runtime
-
+        # Deepcopy the catalog-bound handles so the copy is safe across thread/transaction
+        # boundaries: TableVersionHandle.__deepcopy__ and TableVersionPath.__deepcopy__ reset
+        # their per-(thread, xact) caches. self.col is a property over col_handle, no field.
         result = super().copy()
-        cat = get_runtime().catalog
-        tv = cat._tbl_versions.get(self.col.tbl_handle.key)
-        if tv is not None and self.col.id in tv.cols_by_id:
-            new_col = tv.cols_by_id[self.col.id]
-            result.col = new_col
-            result.col_handle = new_col.handle
+        result.col_handle = copy.deepcopy(self.col_handle)
+        if self.reference_tbl is not None:
+            result.reference_tbl = copy.deepcopy(self.reference_tbl)
         return result
 
     def __getattr__(self, name: str) -> Expr:
@@ -161,7 +169,8 @@ class ColumnRef(Expr):
             name == ColumnPropertyRef.Property.ERRORTYPE.name.lower()
             or name == ColumnPropertyRef.Property.ERRORMSG.name.lower()
         ):
-            is_valid = (self.col.is_computed or self.col.col_type.is_media_type()) and self.col.is_stored
+            col = self.col_handle.get()
+            is_valid = (col.is_computed or col.col_type.is_media_type()) and col.is_stored
             if not is_valid:
                 raise excs.RequestError(
                     excs.ErrorCode.UNSUPPORTED_OPERATION,
@@ -172,12 +181,13 @@ class ColumnRef(Expr):
             name == ColumnPropertyRef.Property.FILEURL.name.lower()
             or name == ColumnPropertyRef.Property.LOCALPATH.name.lower()
         ):
-            if not self.col.col_type.is_media_type():
+            col = self.col_handle.get()
+            if not col.col_type.is_media_type():
                 raise excs.RequestError(
                     excs.ErrorCode.UNSUPPORTED_OPERATION,
                     f'{name} only valid for image/video/audio/document columns: {self}',
                 )
-            if self.col.is_computed and not self.col.is_stored:
+            if col.is_computed and not col.is_stored:
                 raise excs.RequestError(
                     excs.ErrorCode.UNSUPPORTED_OPERATION, f'{name} not valid for computed unstored columns: {self}'
                 )
@@ -497,13 +507,17 @@ class ColumnRef(Expr):
 
     @property
     def tbl(self) -> catalog.TableVersionHandle:
-        return self.reference_tbl.tbl_version if self.reference_tbl is not None else self.col.tbl_handle
+        # Use col_handle.tbl_version (the immutable identity) rather than going through col.
+        return self.reference_tbl.tbl_version if self.reference_tbl is not None else self.col_handle.tbl_version
 
     def default_column_name(self) -> str | None:
-        return self.col.name if self.col is not None else None
+        return self.col_handle.get().name
 
     def _equals(self, other: ColumnRef) -> bool:
-        return self.col == other.col and self.perform_validation == other.perform_validation
+        # Compare by handle identity (key + col_id) rather than dereferencing to Column;
+        # avoids a catalog lookup and is the right semantic: two ColumnRefs are equal iff
+        # they refer to the same logical column.
+        return self.col_handle == other.col_handle and self.perform_validation == other.perform_validation
 
     def select(self) -> 'Query':
         import pixeltable.plan as plan
@@ -511,7 +525,7 @@ class ColumnRef(Expr):
 
         if self.reference_tbl is None:
             # No reference table; use the current version of the table to which the column belongs
-            tbl = get_runtime().catalog.get_table_by_id(self.col.tbl_handle.id)
+            tbl = get_runtime().catalog.get_table_by_id(self.col_handle.tbl_version.id)
             return tbl.select(self)
         else:
             # Explicit reference table; construct a Query directly from it
@@ -534,10 +548,11 @@ class ColumnRef(Expr):
         return self.select().distinct()
 
     def __str__(self) -> str:
-        if self.col.name is None:
-            return f'<unnamed column {self.col.id}>'
+        col = self.col_handle.get()
+        if col.name is None:
+            return f'<unnamed column {col.id}>'
         else:
-            return self.col.name
+            return col.name
 
     def __repr__(self) -> str:
         return self._descriptors().to_string()
@@ -547,12 +562,13 @@ class ColumnRef(Expr):
 
     def _descriptors(self) -> DescriptionHelper:
         with get_runtime().catalog.begin_xact():
-            tbl = get_runtime().catalog.get_table_by_id(self.col.tbl_handle.id)
+            tbl = get_runtime().catalog.get_table_by_id(self.col_handle.tbl_version.id)
+        col = self.col_handle.get()
         helper = DescriptionHelper()
-        helper.append(f'Column\n{self.col.name!r}\n(of table {tbl._path()!r})')
-        col_df, _ = tbl._col_descriptor([self.col.name])
+        helper.append(f'Column\n{col.name!r}\n(of table {tbl._path()!r})')
+        col_df, _ = tbl._col_descriptor([col.name])
         helper.append(col_df)
-        idxs = tbl._index_descriptor([self.col.name])
+        idxs = tbl._index_descriptor([col.name])
         if len(idxs) > 0:
             helper.append(idxs)
         return helper
@@ -571,10 +587,10 @@ class ColumnRef(Expr):
     def sql_expr(self, _: SqlElementCache) -> sql.ColumnElement | None:
         if self.perform_validation:
             return None
-        self.col = self.col_handle.get()
-        return self.col.sa_col
+        return self.col_handle.get().sa_col
 
     def eval(self, data_row: DataRow, row_builder: RowBuilder) -> None:
+        col = self.col_handle.get()  # bind once for the per-row hot path
         if self.perform_validation:
             # validate media file of our input ColumnRef and if successful, replicate the state of that slot
             # to our slot
@@ -588,7 +604,7 @@ class ColumnRef(Expr):
                 return
 
             try:
-                self.col.col_type.validate_media(data_row.file_paths[unvalidated_slot_idx])
+                col.col_type.validate_media(data_row.file_paths[unvalidated_slot_idx])
                 # access the value only after successful validation
                 val = data_row[unvalidated_slot_idx]
                 data_row.vals[self.slot_idx] = val
@@ -614,24 +630,24 @@ class ColumnRef(Expr):
             assert self.iter_arg_ctx is not None
             row_builder.eval(data_row, self.iter_arg_ctx)
             iterator_args = data_row[self.iter_arg_ctx.target_slot_idxs[0]]
-            self.iterator = self.col.get_tbl().iterator_call.eval(iterator_args)
+            self.iterator = col.get_tbl().iterator_call.eval(iterator_args)
             self.base_rowid = data_row.pk[: self.base_rowid_len]
         stored_outputs = {col_ref.col.name: data_row[col_ref.slot_idx] for col_ref in self.iter_outputs}
         assert all(name is not None for name in stored_outputs)
         assert isinstance(self.iterator, func.PxtIterator)  # Otherwise we could not have an unstored column
         self.iterator.seek(data_row.pk[self.pos_idx], **stored_outputs)
         res = next(self.iterator)
-        data_row[self.slot_idx] = res[self.col.name]
+        data_row[self.slot_idx] = res[col.name]
 
     def _as_dict(self) -> dict:
-        tbl_handle = self.col.tbl_handle
+        tbl_handle = self.col_handle.tbl_version
         # we omit self.components, even if this is a validating ColumnRef, because init() will recreate the
         # non-validating component ColumnRef
         assert tbl_handle.anchor_tbl_id is None  # TODO: support anchor_tbl_id for view-over-replica
         return {
             'tbl_id': str(tbl_handle.id),
             'tbl_version': tbl_handle.effective_version,
-            'col_id': self.col.id,
+            'col_id': self.col_handle.col_id,
             'reference_tbl': self.reference_tbl.as_dict() if self.reference_tbl is not None else None,
             'perform_validation': self.perform_validation,
         }

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -48,18 +48,18 @@ class ColumnRef(Expr):
     # - the non-validating ColumnRef is used for SQL translation
 
     # A ColumnRef may have an optional reference table, which carries the context of the ColumnRef resolution. Thus
-    # if `v` is a view of `t` (for example), then `v.my_col` and `t.my_col` refer to the same underlying column, but
-    # their reference tables will be `v` and `t`, respectively. This is to ensure correct behavior of expressions such
-    # as `v.my_col.head()`.
+    # if v is a view of t (for example), then v.my_col and t.my_col refer to the same underlying column, but
+    # their reference tables will be v and t, respectively. This is to ensure correct behavior of expressions such
+    # as v.my_col.head().
 
     # TODO:
     # separate Exprs (like validating ColumnRefs) from the logical expression tree and instead have RowBuilder
     # insert them into the EvalCtxs as needed
 
-    # `col_handle` is the source of truth. Column metadata is owned by the catalog and resolved
-    # on every access via the catalog's `is_validated`-gated machinery, which gives us correctness
+    # col_handle is the source of truth. Column metadata is owned by the catalog and resolved
+    # on every access via the catalog's is_validated-gated machinery, which gives us correctness
     # across (a) transactions, including ones triggered by other processes, (b) threads, and
-    # (c) future cache evictions. The `col` property below derives from col_handle; we never
+    # (c) future cache evictions. The col property below derives from col_handle; we never
     # cache a Column reference on this instance.
     col_handle: catalog.ColumnHandle
     reference_tbl: catalog.TableVersionPath | None
@@ -116,7 +116,7 @@ class ColumnRef(Expr):
         # transaction (in this process or another) since this ColumnRef was constructed; the
         # handle resolves through TableVersionHandle.get(), which validates against the current
         # transaction's view of the catalog. Hot-path callers should bind to a local at the top
-        # of their function rather than reading `self.col.<attr>` repeatedly.
+        # of their function rather than reading self.col.<attr> repeatedly.
         return self.col_handle.get()
 
     def set_iter_arg_ctx(self, iter_arg_ctx: RowBuilder.EvalCtx, iter_outputs: list[ColumnRef]) -> None:
@@ -129,7 +129,7 @@ class ColumnRef(Expr):
         assert len(self.iter_arg_ctx.target_slot_idxs) == 1  # a single inline dict
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        # Use col_handle directly (its `tbl_version.id` and `col_id` are immutable identity)
+        # Use col_handle directly (its tbl_version.id and col_id are immutable identity)
         # rather than going through self.col.<...>; avoids a catalog lookup on every hash.
         return [
             *super()._id_attrs(),

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -56,12 +56,9 @@ class ColumnRef(Expr):
     # separate Exprs (like validating ColumnRefs) from the logical expression tree and instead have RowBuilder
     # insert them into the EvalCtxs as needed
 
-    # col_handle is the source of truth. Column metadata is owned by the catalog and resolved
-    # on every access via the catalog's is_validated-gated machinery, which gives us correctness
-    # across (a) transactions, including ones triggered by other processes, (b) threads, and
-    # (c) future cache evictions. The col property below derives from col_handle; we never
-    # cache a Column reference on this instance.
+    # ColumnHandle, not a Column: avoid caching of catalog objects, they get invalidated across xact/thread boundaries
     col_handle: catalog.ColumnHandle
+
     reference_tbl: catalog.TableVersionPath | None
     needs_iterator_evaluation: bool
     perform_validation: bool  # if True, performs media validation
@@ -112,11 +109,7 @@ class ColumnRef(Expr):
 
     @property
     def col(self) -> catalog.Column:
-        # Always re-resolve via the catalog. Column metadata may have been mutated by another
-        # transaction (in this process or another) since this ColumnRef was constructed; the
-        # handle resolves through TableVersionHandle.get(), which validates against the current
-        # transaction's view of the catalog. Hot-path callers should bind to a local at the top
-        # of their function rather than reading self.col.<attr> repeatedly.
+        # re-resolve via the current Catalog when we need the actual Column
         return self.col_handle.get()
 
     def set_iter_arg_ctx(self, iter_arg_ctx: RowBuilder.EvalCtx, iter_outputs: list[ColumnRef]) -> None:
@@ -129,8 +122,6 @@ class ColumnRef(Expr):
         assert len(self.iter_arg_ctx.target_slot_idxs) == 1  # a single inline dict
 
     def _id_attrs(self) -> list[tuple[str, Any]]:
-        # Use col_handle directly (its tbl_version.id and col_id are immutable identity)
-        # rather than going through self.col.<...>; avoids a catalog lookup on every hash.
         return [
             *super()._id_attrs(),
             ('tbl_id', self.col_handle.tbl_version.id),
@@ -148,9 +139,7 @@ class ColumnRef(Expr):
 
     # override
     def copy(self) -> ColumnRef:
-        # Deepcopy the catalog-bound handles so the copy is safe across thread/transaction
-        # boundaries: TableVersionHandle.__deepcopy__ and TableVersionPath.__deepcopy__ reset
-        # their per-(thread, xact) caches. self.col is a property over col_handle, no field.
+        # deepcopy(tvh) is needed to create a copy for the local thread/catalog
         result = super().copy()
         result.col_handle = copy.deepcopy(self.col_handle)
         if self.reference_tbl is not None:
@@ -169,7 +158,7 @@ class ColumnRef(Expr):
             name == ColumnPropertyRef.Property.ERRORTYPE.name.lower()
             or name == ColumnPropertyRef.Property.ERRORMSG.name.lower()
         ):
-            col = self.col_handle.get()
+            col = self.col
             is_valid = (col.is_computed or col.col_type.is_media_type()) and col.is_stored
             if not is_valid:
                 raise excs.RequestError(
@@ -181,7 +170,7 @@ class ColumnRef(Expr):
             name == ColumnPropertyRef.Property.FILEURL.name.lower()
             or name == ColumnPropertyRef.Property.LOCALPATH.name.lower()
         ):
-            col = self.col_handle.get()
+            col = self.col
             if not col.col_type.is_media_type():
                 raise excs.RequestError(
                     excs.ErrorCode.UNSUPPORTED_OPERATION,
@@ -507,16 +496,12 @@ class ColumnRef(Expr):
 
     @property
     def tbl(self) -> catalog.TableVersionHandle:
-        # Use col_handle.tbl_version (the immutable identity) rather than going through col.
         return self.reference_tbl.tbl_version if self.reference_tbl is not None else self.col_handle.tbl_version
 
     def default_column_name(self) -> str | None:
         return self.col_handle.get().name
 
     def _equals(self, other: ColumnRef) -> bool:
-        # Compare by handle identity (key + col_id) rather than dereferencing to Column;
-        # avoids a catalog lookup and is the right semantic: two ColumnRefs are equal iff
-        # they refer to the same logical column.
         return self.col_handle == other.col_handle and self.perform_validation == other.perform_validation
 
     def select(self) -> 'Query':
@@ -548,7 +533,7 @@ class ColumnRef(Expr):
         return self.select().distinct()
 
     def __str__(self) -> str:
-        col = self.col_handle.get()
+        col = self.col
         if col.name is None:
             return f'<unnamed column {col.id}>'
         else:
@@ -563,7 +548,7 @@ class ColumnRef(Expr):
     def _descriptors(self) -> DescriptionHelper:
         with get_runtime().catalog.begin_xact():
             tbl = get_runtime().catalog.get_table_by_id(self.col_handle.tbl_version.id)
-        col = self.col_handle.get()
+        col = self.col
         helper = DescriptionHelper()
         helper.append(f'Column\n{col.name!r}\n(of table {tbl._path()!r})')
         col_df, _ = tbl._col_descriptor([col.name])
@@ -578,7 +563,7 @@ class ColumnRef(Expr):
 
         if not self.needs_iterator_evaluation:
             return
-        col = self.col_handle.get()
+        col = self.col
         self.base_rowid_len = col.get_tbl().base.get().num_rowid_columns()
         self.base_rowid = [None] * self.base_rowid_len
         assert isinstance(col.get_tbl().store_tbl, store.StoreComponentView)
@@ -587,10 +572,10 @@ class ColumnRef(Expr):
     def sql_expr(self, _: SqlElementCache) -> sql.ColumnElement | None:
         if self.perform_validation:
             return None
-        return self.col_handle.get().sa_col
+        return self.col.sa_col
 
     def eval(self, data_row: DataRow, row_builder: RowBuilder) -> None:
-        col = self.col_handle.get()  # bind once for the per-row hot path
+        col = self.col
         if self.perform_validation:
             # validate media file of our input ColumnRef and if successful, replicate the state of that slot
             # to our slot

--- a/pixeltable/exprs/column_ref.py
+++ b/pixeltable/exprs/column_ref.py
@@ -33,6 +33,8 @@ class ColumnRef(Expr):
     """
     A Pixeltable expression that references a column of a table. A `ColumnRef` is created by column access
     on a [`Table`][pixeltable.Table], such as `t.col`.
+
+    Not thread-safe.
     """
 
     # When this reference is created in the context of a view, it can also refer to a column of the view base.
@@ -109,7 +111,8 @@ class ColumnRef(Expr):
 
     @property
     def col(self) -> catalog.Column:
-        # re-resolve via the current Catalog when we need the actual Column
+        # re-resolve via the current Catalog when we need the actual Column, in the context of a transaction;
+        # this does *not* make ColumnRef thread-safe
         return self.col_handle.get()
 
     def set_iter_arg_ctx(self, iter_arg_ctx: RowBuilder.EvalCtx, iter_outputs: list[ColumnRef]) -> None:

--- a/pixeltable/exprs/data_row.py
+++ b/pixeltable/exprs/data_row.py
@@ -376,7 +376,9 @@ class DataRow:
         format = None
         if isinstance(val, PIL.Image.Image):
             format = image_utils.default_format(val)
-        filepath, url = TempStore.save_media_object(val, col, format=format)
+        filepath, url = TempStore.save_media_object(
+            val, col.tbl_handle.id, col.id, col.get_tbl().version, format=format
+        )
         self.file_paths[index] = str(filepath) if filepath is not None else None
         self.vals[index] = None
         return url

--- a/pixeltable/exprs/expr.py
+++ b/pixeltable/exprs/expr.py
@@ -50,6 +50,8 @@ class Expr(abc.ABC):
 
     All Pixeltable expressions, including [column references][pixeltable.exprs.ColumnRef] (such as `t.col`),
     UDF calls (`t.my_string.lower()`), and compound expressions (`t.col + 5`) are instances of this class.
+
+    Not thread-safe: Expr and subclasses contain execution state and are never thread-safe.
     """
 
     # Rules for using state in subclasses:

--- a/pixeltable/exprs/rowid_ref.py
+++ b/pixeltable/exprs/rowid_ref.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Any, cast
 from uuid import UUID
@@ -74,6 +75,17 @@ class RowidRef(Expr):
             ('normalized_base_id', self.normalized_base_id),
             ('idx', self.rowid_component_idx),
         ]
+
+    # override
+    def copy(self) -> RowidRef:
+        # Deepcopy the TVHs so the copy is safe across thread/transaction boundaries:
+        # TableVersionHandle.__deepcopy__ resets the per-(thread, xact) cache.
+        result = super().copy()
+        if self.tbl is not None:
+            result.tbl = copy.deepcopy(self.tbl)
+        if self.normalized_base is not None:
+            result.normalized_base = copy.deepcopy(self.normalized_base)
+        return result
 
     def __repr__(self) -> str:
         # check if this is the pos column of a component view

--- a/pixeltable/exprs/rowid_ref.py
+++ b/pixeltable/exprs/rowid_ref.py
@@ -78,8 +78,7 @@ class RowidRef(Expr):
 
     # override
     def copy(self) -> RowidRef:
-        # Deepcopy the TVHs so the copy is safe across thread/transaction boundaries:
-        # TableVersionHandle.__deepcopy__ resets the per-(thread, xact) cache.
+        # deepcopy(tvh) is needed to create a copy for the local thread/catalog
         result = super().copy()
         if self.tbl is not None:
             result.tbl = copy.deepcopy(self.tbl)

--- a/pixeltable/runtime.py
+++ b/pixeltable/runtime.py
@@ -39,6 +39,9 @@ class Runtime:
     _event_loop: asyncio.AbstractEventLoop | None  # event loop for this thread
     _run_coro_executor: concurrent.futures.ThreadPoolExecutor | None
 
+    # True if this thread's runtime was populated from another thread via copy_db_context()
+    context_inherited: bool
+
     # we need to cache client instances on a per-thread basis because some of them are thread-specific (eg, async
     # clients which are tied to an event loop)
     _clients: dict[str, Any]
@@ -54,6 +57,7 @@ class Runtime:
         self._event_loop = None
         self._run_coro_executor = None
         self._clients = {}
+        self.context_inherited = False
 
     def copy_db_context(self, other: Runtime) -> None:
         """Copy the db-related state from another Runtime instance."""
@@ -62,6 +66,7 @@ class Runtime:
         self.isolation_level = other.isolation_level
         self._catalog = other.catalog
         self._progress = other._progress
+        self.context_inherited = True
 
     @property
     def in_xact(self) -> bool:

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -23,7 +23,6 @@ from pydantic.fields import FieldInfo
 
 import pixeltable as pxt
 from pixeltable import catalog, exceptions as excs, exprs, func, type_system as ts
-from pixeltable.runtime import get_runtime
 from pixeltable.config import Config
 from pixeltable.env import Env
 from pixeltable.serving import SqlExport
@@ -1000,14 +999,8 @@ class FastAPIRouter(fastapi.APIRouter):
             )
 
         def run_query(call_kwargs: dict[str, Any], url_for_media: Callable[[str], str]) -> Any:
-            # Warm the current thread's catalog for the tables referenced in the template,
-            # so that ColumnRef.copy() (invoked by template_query.bind() via deepcopy) can
-            # re-resolve to this thread's TableVersion / sa_tbl. Without this, the first call
-            # from each worker thread would still bind to the importing thread's sa_tbl and
-            # produce FROM-clause mismatches.
-            with get_runtime().catalog.begin_xact(read_tvps=template_query._from_clause.tbls):
-                bound_df = template_query.bind(call_kwargs)
-                result_set = bound_df.collect()
+            bound_df = template_query.bind(call_kwargs)
+            result_set = bound_df.collect()
             rows = list(result_set)
 
             # do error checking now, before converting data

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -23,6 +23,7 @@ from pydantic.fields import FieldInfo
 
 import pixeltable as pxt
 from pixeltable import catalog, exceptions as excs, exprs, func, type_system as ts
+from pixeltable.runtime import get_runtime
 from pixeltable.config import Config
 from pixeltable.env import Env
 from pixeltable.serving import SqlExport
@@ -999,8 +1000,14 @@ class FastAPIRouter(fastapi.APIRouter):
             )
 
         def run_query(call_kwargs: dict[str, Any], url_for_media: Callable[[str], str]) -> Any:
-            bound_df = template_query.bind(call_kwargs)
-            result_set = bound_df.collect()
+            # Warm the current thread's catalog for the tables referenced in the template,
+            # so that ColumnRef.copy() (invoked by template_query.bind() via deepcopy) can
+            # re-resolve to this thread's TableVersion / sa_tbl. Without this, the first call
+            # from each worker thread would still bind to the importing thread's sa_tbl and
+            # produce FROM-clause mismatches.
+            with get_runtime().catalog.begin_xact(read_tvps=template_query._from_clause.tbls):
+                bound_df = template_query.bind(call_kwargs)
+                result_set = bound_df.collect()
             rows = list(result_set)
 
             # do error checking now, before converting data

--- a/pixeltable/share/packager.py
+++ b/pixeltable/share/packager.py
@@ -792,7 +792,15 @@ class TableRestorer:
                 # in self.media_files.
                 src_path = self.tmp_dir / 'media' / parsed_url.netloc
                 # Move the file to the media store and update the URL.
-                self.media_files[url] = ObjectOps.put_file(media_col, src_path, relocate_or_delete=True)
+                self.media_files[url] = ObjectOps.put_file(
+                    media_col.destination,
+                    media_col.tbl_handle.id,
+                    media_col.id,
+                    media_col.get_tbl().version,
+                    media_col.name,
+                    src_path,
+                    relocate_or_delete=True,
+                )
             return self.media_files[url]
         # For any type of URL other than a local file, just return the URL as-is.
         return url

--- a/pixeltable/utils/azure_store.py
+++ b/pixeltable/utils/azure_store.py
@@ -14,12 +14,10 @@ from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 from pixeltable import env, exceptions as excs
 from pixeltable.config import Config
 from pixeltable.runtime import get_runtime
-from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, StorageObjectAddress
+from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, ResolvedFileDestination, StorageObjectAddress
 
 if TYPE_CHECKING:
     from azure.storage.blob import BlobProperties, BlobServiceClient
-
-    from pixeltable.catalog import Column
 
 
 _logger = logging.getLogger('pixeltable')
@@ -134,21 +132,22 @@ class AzureBlobStore(ObjectStoreBase):
             self.handle_azure_error(e, self.container_name, f'download file {src_path}')
             raise
 
-    # TODO: utils package should not include back-references to `Column`
-    def copy_local_file(self, col: 'Column', src_path: Path) -> str:
-        """Copy a local file to Azure Blob Storage, and return its new URL"""
-        prefix, filename = ObjectPath.create_prefix_raw(
-            col.get_tbl().id, col.id, col.get_tbl().version, ext=src_path.suffix
-        )
+    def prepare_destination(
+        self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
+    ) -> ResolvedFileDestination:
+        prefix, filename = ObjectPath.create_prefix_raw(tbl_id, col_id, tbl_version, ext=ext)
         blob_name = f'{self.prefix}{prefix}/{filename}'
         new_file_uri = f'{self.__base_uri}{prefix}/{filename}'
+        return ResolvedFileDestination(new_file_url=new_file_uri, remote_key=blob_name)
 
+    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
+        assert resolved.remote_key is not None
         try:
-            blob_client = self.client().get_blob_client(container=self.container_name, blob=blob_name)
+            blob_client = self.client().get_blob_client(container=self.container_name, blob=resolved.remote_key)
             with open(src_path, 'rb') as data:
                 blob_client.upload_blob(data, overwrite=True)
-            _logger.debug(f'Media Storage: copied {src_path} to {new_file_uri}')
-            return new_file_uri
+            _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
+            return resolved.new_file_url
         except AzureError as e:
             self.handle_azure_error(e, self.container_name, f'upload file {src_path}')
             raise

--- a/pixeltable/utils/azure_store.py
+++ b/pixeltable/utils/azure_store.py
@@ -14,7 +14,7 @@ from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 from pixeltable import env, exceptions as excs
 from pixeltable.config import Config
 from pixeltable.runtime import get_runtime
-from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, ResolvedFileDestination, StorageObjectAddress
+from pixeltable.utils.object_stores import FileDestination, ObjectPath, ObjectStoreBase, StorageObjectAddress
 
 if TYPE_CHECKING:
     from azure.storage.blob import BlobProperties, BlobServiceClient
@@ -132,22 +132,22 @@ class AzureBlobStore(ObjectStoreBase):
             self.handle_azure_error(e, self.container_name, f'download file {src_path}')
             raise
 
-    def prepare_destination(
+    def resolve_destination(
         self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
-    ) -> ResolvedFileDestination:
+    ) -> FileDestination:
         prefix, filename = ObjectPath.create_prefix_raw(tbl_id, col_id, tbl_version, ext=ext)
         blob_name = f'{self.prefix}{prefix}/{filename}'
-        new_file_uri = f'{self.__base_uri}{prefix}/{filename}'
-        return ResolvedFileDestination(new_file_url=new_file_uri, remote_key=blob_name)
+        url = f'{self.__base_uri}{prefix}/{filename}'
+        return FileDestination(url=url, remote_key=blob_name)
 
-    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
-        assert resolved.remote_key is not None
+    def copy_local_file(self, src_path: Path, dest: FileDestination) -> str:
+        assert dest.remote_key is not None
         try:
-            blob_client = self.client().get_blob_client(container=self.container_name, blob=resolved.remote_key)
+            blob_client = self.client().get_blob_client(container=self.container_name, blob=dest.remote_key)
             with open(src_path, 'rb') as data:
                 blob_client.upload_blob(data, overwrite=True)
-            _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
-            return resolved.new_file_url
+            _logger.debug(f'Media Storage: copied {src_path} to {dest.url}')
+            return dest.url
         except AzureError as e:
             self.handle_azure_error(e, self.container_name, f'upload file {src_path}')
             raise

--- a/pixeltable/utils/gcs_store.py
+++ b/pixeltable/utils/gcs_store.py
@@ -5,7 +5,7 @@ import re
 import urllib.parse
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import Any, Iterator
 
 from google.api_core.exceptions import GoogleAPIError
 from google.cloud import storage  # type: ignore[attr-defined]
@@ -14,10 +14,13 @@ from google.cloud.storage.client import Client  # type: ignore[import-untyped]
 
 from pixeltable import env, exceptions as excs
 from pixeltable.runtime import get_runtime
-from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, StorageObjectAddress, StorageTarget
-
-if TYPE_CHECKING:
-    from pixeltable.catalog import Column
+from pixeltable.utils.object_stores import (
+    ObjectPath,
+    ObjectStoreBase,
+    ResolvedFileDestination,
+    StorageObjectAddress,
+    StorageTarget,
+)
 
 _logger = logging.getLogger('pixeltable')
 
@@ -108,26 +111,23 @@ class GCSStore(ObjectStoreBase):
         parent = f'{self.__base_uri}{prefix}'
         return f'{parent}/{filename}'
 
-    def _prepare_uri(self, col: Column, ext: str | None = None) -> str:
-        """
-        Construct a new, unique URI for a persisted media file.
-        """
-        assert col.get_tbl() is not None, 'Column must be associated with a table'
-        return self._prepare_uri_raw(col.get_tbl().id, col.id, col.get_tbl().version, ext=ext)
-
-    def copy_local_file(self, col: Column, src_path: Path) -> str:
-        """Copy a local file, and return its new URL"""
-        new_file_uri = self._prepare_uri(col, ext=src_path.suffix)
+    def prepare_destination(
+        self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
+    ) -> ResolvedFileDestination:
+        new_file_uri = self._prepare_uri_raw(tbl_id, col_id, tbl_version, ext=ext)
         parsed = urllib.parse.urlparse(new_file_uri)
         blob_name = parsed.path.lstrip('/')
+        return ResolvedFileDestination(new_file_url=new_file_uri, remote_key=blob_name)
 
+    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
+        assert resolved.remote_key is not None
         try:
             client = self.client()
             bucket = client.bucket(self.bucket_name)
-            blob = bucket.blob(blob_name)
+            blob = bucket.blob(resolved.remote_key)
             blob.upload_from_filename(str(src_path))
-            _logger.debug(f'Media Storage: copied {src_path} to {new_file_uri}')
-            return new_file_uri
+            _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
+            return resolved.new_file_url
         except GoogleAPIError as e:
             self.handle_gcs_error(e, self.bucket_name, f'upload file {src_path}')
             raise

--- a/pixeltable/utils/gcs_store.py
+++ b/pixeltable/utils/gcs_store.py
@@ -15,9 +15,9 @@ from google.cloud.storage.client import Client  # type: ignore[import-untyped]
 from pixeltable import env, exceptions as excs
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.object_stores import (
+    FileDestination,
     ObjectPath,
     ObjectStoreBase,
-    ResolvedFileDestination,
     StorageObjectAddress,
     StorageTarget,
 )
@@ -111,23 +111,23 @@ class GCSStore(ObjectStoreBase):
         parent = f'{self.__base_uri}{prefix}'
         return f'{parent}/{filename}'
 
-    def prepare_destination(
+    def resolve_destination(
         self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
-    ) -> ResolvedFileDestination:
-        new_file_uri = self._prepare_uri_raw(tbl_id, col_id, tbl_version, ext=ext)
-        parsed = urllib.parse.urlparse(new_file_uri)
+    ) -> FileDestination:
+        url = self._prepare_uri_raw(tbl_id, col_id, tbl_version, ext=ext)
+        parsed = urllib.parse.urlparse(url)
         blob_name = parsed.path.lstrip('/')
-        return ResolvedFileDestination(new_file_url=new_file_uri, remote_key=blob_name)
+        return FileDestination(url=url, remote_key=blob_name)
 
-    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
-        assert resolved.remote_key is not None
+    def copy_local_file(self, src_path: Path, dest: FileDestination) -> str:
+        assert dest.remote_key is not None
         try:
             client = self.client()
             bucket = client.bucket(self.bucket_name)
-            blob = bucket.blob(resolved.remote_key)
+            blob = bucket.blob(dest.remote_key)
             blob.upload_from_filename(str(src_path))
-            _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
-            return resolved.new_file_url
+            _logger.debug(f'Media Storage: copied {src_path} to {dest.url}')
+            return dest.url
         except GoogleAPIError as e:
             self.handle_gcs_error(e, self.bucket_name, f'upload file {src_path}')
             raise

--- a/pixeltable/utils/local_store.py
+++ b/pixeltable/utils/local_store.py
@@ -10,16 +10,12 @@ import urllib.request
 import uuid
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 import PIL.Image
 
 from pixeltable import env, exceptions as excs
 from pixeltable.utils.object_stores import FileDestination, ObjectPath, ObjectStoreBase, StorageObjectAddress
-
-if TYPE_CHECKING:
-    from pixeltable.catalog import Column
 
 _logger = logging.getLogger('pixeltable')
 
@@ -125,14 +121,6 @@ class LocalStore(ObjectStoreBase):
         parent.mkdir(parents=True, exist_ok=True)
         return parent / filename
 
-    def _prepare_path(self, col: Column, ext: str | None = None) -> Path:
-        """
-        Construct a new, unique Path name in the __base_dir for a persisted file.
-        Create the parent directory for the new Path if it does not already exist.
-        """
-        assert col.get_tbl() is not None, 'Column must be associated with a table'
-        return self._prepare_path_raw(col.get_tbl().id, col.id, col.get_tbl().version, ext)
-
     def contains_path(self, file_path: Path) -> bool:
         """Return True if the given path refers to a file managed by this LocalStore, else False."""
         return str(file_path).startswith(str(self.__base_dir))
@@ -175,14 +163,15 @@ class LocalStore(ObjectStoreBase):
         _logger.debug(f'Media Storage: copied {src_path} to {dest.url}')
         return dest.url
 
-    def save_media_object(self, data: bytes | PIL.Image.Image, col: Column, format: str | None) -> tuple[Path, str]:
+    def save_media_object(
+        self, data: bytes | PIL.Image.Image, tbl_id: UUID, col_id: int, tbl_version: int, format: str | None
+    ) -> tuple[Path, str]:
         """Save a data object to a file in a LocalStore
         Returns:
             dest_path: Path to the saved file
             url: URL of the saved file
         """
-        assert col.col_type.is_media_type(), f'LocalStore: request to store non media_type Column {col.name}'
-        dest_path = self._prepare_path(col)
+        dest_path = self._prepare_path_raw(tbl_id, col_id, tbl_version)
         if isinstance(data, bytes):
             dest_path = self._save_binary_media_file(data, dest_path, format)
         elif isinstance(data, PIL.Image.Image):
@@ -302,8 +291,10 @@ class TempStore:
         return LocalStore(cls._tmp_dir()).resolve_url(file_url)
 
     @classmethod
-    def save_media_object(cls, data: bytes | PIL.Image.Image, col: Column, format: str | None) -> tuple[Path, str]:
-        return LocalStore(cls._tmp_dir()).save_media_object(data, col, format)
+    def save_media_object(
+        cls, data: bytes | PIL.Image.Image, tbl_id: UUID, col_id: int, tbl_version: int, format: str | None
+    ) -> tuple[Path, str]:
+        return LocalStore(cls._tmp_dir()).save_media_object(data, tbl_id, col_id, tbl_version, format)
 
     @classmethod
     def delete_media_file(cls, file_path: Path) -> None:

--- a/pixeltable/utils/local_store.py
+++ b/pixeltable/utils/local_store.py
@@ -16,7 +16,7 @@ from uuid import UUID
 import PIL.Image
 
 from pixeltable import env, exceptions as excs
-from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, ResolvedFileDestination, StorageObjectAddress
+from pixeltable.utils.object_stores import FileDestination, ObjectPath, ObjectStoreBase, StorageObjectAddress
 
 if TYPE_CHECKING:
     from pixeltable.catalog import Column
@@ -156,24 +156,24 @@ class LocalStore(ObjectStoreBase):
             return None
         return file_path
 
-    def prepare_destination(
+    def resolve_destination(
         self, tbl_id: UUID, col_id: int, tbl_version: int, ext: str | None = None
-    ) -> ResolvedFileDestination:
+    ) -> FileDestination:
         dest_path = self._prepare_path_raw(tbl_id, col_id, tbl_version, ext)
-        new_file_url = urllib.parse.urljoin('file:', urllib.request.pathname2url(str(dest_path)))
-        return ResolvedFileDestination(new_file_url=new_file_url, local_path=dest_path)
+        url = urllib.parse.urljoin('file:', urllib.request.pathname2url(str(dest_path)))
+        return FileDestination(url=url, local_path=dest_path)
 
-    def move_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str | None:
-        assert resolved.local_path is not None
-        src_path.rename(resolved.local_path)
-        _logger.debug(f'Media Storage: moved {src_path} to {resolved.new_file_url}')
-        return resolved.new_file_url
+    def move_local_file(self, src_path: Path, dest: FileDestination) -> str | None:
+        assert dest.local_path is not None
+        src_path.rename(dest.local_path)
+        _logger.debug(f'Media Storage: moved {src_path} to {dest.url}')
+        return dest.url
 
-    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
-        assert resolved.local_path is not None
-        shutil.copy2(src_path, resolved.local_path)
-        _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
-        return resolved.new_file_url
+    def copy_local_file(self, src_path: Path, dest: FileDestination) -> str:
+        assert dest.local_path is not None
+        shutil.copy2(src_path, dest.local_path)
+        _logger.debug(f'Media Storage: copied {src_path} to {dest.url}')
+        return dest.url
 
     def save_media_object(self, data: bytes | PIL.Image.Image, col: Column, format: str | None) -> tuple[Path, str]:
         """Save a data object to a file in a LocalStore

--- a/pixeltable/utils/local_store.py
+++ b/pixeltable/utils/local_store.py
@@ -16,7 +16,7 @@ from uuid import UUID
 import PIL.Image
 
 from pixeltable import env, exceptions as excs
-from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, StorageObjectAddress
+from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, ResolvedFileDestination, StorageObjectAddress
 
 if TYPE_CHECKING:
     from pixeltable.catalog import Column
@@ -156,21 +156,24 @@ class LocalStore(ObjectStoreBase):
             return None
         return file_path
 
-    def move_local_file(self, col: Column, src_path: Path) -> str:
-        """Move a local file to this store, and return its new URL"""
-        dest_path = self._prepare_path(col, ext=src_path.suffix)
-        src_path.rename(dest_path)
+    def prepare_destination(
+        self, tbl_id: UUID, col_id: int, tbl_version: int, ext: str | None = None
+    ) -> ResolvedFileDestination:
+        dest_path = self._prepare_path_raw(tbl_id, col_id, tbl_version, ext)
         new_file_url = urllib.parse.urljoin('file:', urllib.request.pathname2url(str(dest_path)))
-        _logger.debug(f'Media Storage: moved {src_path} to {new_file_url}')
-        return new_file_url
+        return ResolvedFileDestination(new_file_url=new_file_url, local_path=dest_path)
 
-    def copy_local_file(self, col: Column, src_path: Path) -> str:
-        """Copy a local file to a this store, and return its new URL"""
-        dest_path = self._prepare_path(col, ext=src_path.suffix)
-        shutil.copy2(src_path, dest_path)
-        new_file_url = urllib.parse.urljoin('file:', urllib.request.pathname2url(str(dest_path)))
-        _logger.debug(f'Media Storage: copied {src_path} to {new_file_url}')
-        return new_file_url
+    def move_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str | None:
+        assert resolved.local_path is not None
+        src_path.rename(resolved.local_path)
+        _logger.debug(f'Media Storage: moved {src_path} to {resolved.new_file_url}')
+        return resolved.new_file_url
+
+    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
+        assert resolved.local_path is not None
+        shutil.copy2(src_path, resolved.local_path)
+        _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
+        return resolved.new_file_url
 
     def save_media_object(self, data: bytes | PIL.Image.Image, col: Column, format: str | None) -> tuple[Path, str]:
         """Save a data object to a file in a LocalStore

--- a/pixeltable/utils/object_stores.py
+++ b/pixeltable/utils/object_stores.py
@@ -18,16 +18,14 @@ if TYPE_CHECKING:
 
 
 @dataclasses.dataclass(frozen=True)
-class ResolvedFileDestination:
-    """A file destination resolved on the caller thread, used for thread-safe writes.
+class FileDestination:
+    """A file destination: the final URL plus exactly one store-specific identifier.
 
-    Built by ObjectStoreBase.prepare_destination on the caller thread (which has catalog
-    access). Consumed by ObjectStoreBase.{move,copy}_local_file_resolved and
-    ObjectOps.put_file_resolved on a worker thread, which performs the I/O without further
-    catalog state access.
+    Self-contained (no catalog references), so instances can be passed across threads.
     """
 
-    new_file_url: str  # final URL of the persisted file (returned to the caller on success)
+    url: str  # final URL of the persisted file (returned to the caller on success)
+
     # Store-specific destination identifier; exactly one is set, depending on store type.
     local_path: Path | None = None  # LocalStore: filesystem destination
     remote_key: str | None = None  # cloud stores: object key / blob name within the bucket / container
@@ -353,28 +351,28 @@ class ObjectStoreBase:
         """
         raise AssertionError
 
-    def prepare_destination(
+    def resolve_destination(
         self, tbl_id: UUID, col_id: int, tbl_version: int, ext: str | None = None
-    ) -> ResolvedFileDestination:
-        """Caller-thread side: resolve a destination for a new file.
+    ) -> FileDestination:
+        """Caller-thread side: compute a destination for a new file.
 
-        Returns a ResolvedFileDestination that captures everything a worker thread needs to
+        Returns a FileDestination that captures everything a worker thread needs to
         perform the write, with no further catalog access required.
         """
         raise AssertionError
 
-    def move_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str | None:
-        """Worker-thread side: attempt to move a local file to the resolved destination.
+    def move_local_file(self, src_path: Path, dest: FileDestination) -> str | None:
+        """Worker-thread side: attempt to move a local file to the destination.
 
         Returns the new file URL on success, or None if move is not supported (in which case
-        the caller should fall back to copy_local_file_resolved). The default returns None;
+        the caller should fall back to copy_local_file). The default returns None;
         only stores that can perform an atomic move (e.g., LocalStore via filesystem rename)
         override this.
         """
         return None
 
-    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
-        """Worker-thread side: copy a local file to the resolved destination, returning the new file URL."""
+    def copy_local_file(self, src_path: Path, dest: FileDestination) -> str:
+        """Worker-thread side: copy a local file to the destination, returning the new file URL."""
         raise AssertionError
 
     def copy_object_to_local_file(self, src_path: str, dest_path: Path) -> None:
@@ -523,18 +521,14 @@ class ObjectOps:
     def put_file(cls, col: Column, src_path: Path, relocate_or_delete: bool) -> str:
         """Move or copy a file to the destination, returning the file's URL within the destination.
         If relocate_or_delete is True and the file is in the TempStore, the file will be deleted after the operation.
-
-        Caller-thread convenience that resolves the destination from the Column and dispatches
-        to put_file_resolved. Worker threads (e.g., ObjectStoreSaveNode's executor) should
-        precompute the destination on the caller thread and call put_file_resolved directly.
         """
         store = cls.get_store(col.destination, False, col.name)
-        resolved = store.prepare_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
-        return cls.put_file_resolved(store, src_path, resolved, relocate_or_delete)
+        dest = store.resolve_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
+        return cls.put_file_resolved(store, src_path, dest, relocate_or_delete)
 
     @classmethod
     def put_file_resolved(
-        cls, store: ObjectStoreBase, src_path: Path, resolved: ResolvedFileDestination, relocate_or_delete: bool
+        cls, store: ObjectStoreBase, src_path: Path, dest: FileDestination, relocate_or_delete: bool
     ) -> str:
         """Worker-thread version of put_file: performs move-or-copy with no catalog access."""
         from pixeltable.utils.local_store import TempStore
@@ -542,13 +536,13 @@ class ObjectOps:
         if relocate_or_delete:
             # File is temporary, used only once, so we can delete it after copy if it can't be moved
             assert TempStore.contains_path(src_path)
-            moved_file_url = store.move_local_file_resolved(src_path, resolved)
-            if moved_file_url is not None:
-                return moved_file_url
-        new_file_url = store.copy_local_file_resolved(src_path, resolved)
+            moved_url = store.move_local_file(src_path, dest)
+            if moved_url is not None:
+                return moved_url
+        url = store.copy_local_file(src_path, dest)
         if relocate_or_delete:
             TempStore.delete_media_file(src_path)
-        return new_file_url
+        return url
 
     @classmethod
     def delete(cls, dest: str | None, tbl_id: UUID, tbl_version: int | None = None) -> int | None:

--- a/pixeltable/utils/object_stores.py
+++ b/pixeltable/utils/object_stores.py
@@ -8,13 +8,10 @@ import urllib.parse
 import urllib.request
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple
+from typing import NamedTuple
 from uuid import UUID
 
 from pixeltable import env, exceptions as excs
-
-if TYPE_CHECKING:
-    from pixeltable.catalog import Column
 
 
 @dataclasses.dataclass(frozen=True)
@@ -518,12 +515,21 @@ class ObjectOps:
         store.copy_object_to_local_file(soa.object_name, dest_path)
 
     @classmethod
-    def put_file(cls, col: Column, src_path: Path, relocate_or_delete: bool) -> str:
+    def put_file(
+        cls,
+        destination: str | None,
+        tbl_id: UUID,
+        col_id: int,
+        tbl_version: int,
+        col_name: str,
+        src_path: Path,
+        relocate_or_delete: bool,
+    ) -> str:
         """Move or copy a file to the destination, returning the file's URL within the destination.
         If relocate_or_delete is True and the file is in the TempStore, the file will be deleted after the operation.
         """
-        store = cls.get_store(col.destination, False, col.name)
-        dest = store.resolve_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
+        store = cls.get_store(destination, False, col_name)
+        dest = store.resolve_destination(tbl_id, col_id, tbl_version, ext=src_path.suffix)
         return cls.put_file_resolved(store, src_path, dest, relocate_or_delete)
 
     @classmethod

--- a/pixeltable/utils/object_stores.py
+++ b/pixeltable/utils/object_stores.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import enum
 import os
 import re
@@ -14,6 +15,22 @@ from pixeltable import env, exceptions as excs
 
 if TYPE_CHECKING:
     from pixeltable.catalog import Column
+
+
+@dataclasses.dataclass(frozen=True)
+class ResolvedFileDestination:
+    """A file destination resolved on the caller thread, used for thread-safe writes.
+
+    Built by ObjectStoreBase.prepare_destination on the caller thread (which has catalog
+    access). Consumed by ObjectStoreBase.{move,copy}_local_file_resolved and
+    ObjectOps.put_file_resolved on a worker thread, which performs the I/O without further
+    catalog state access.
+    """
+
+    new_file_url: str  # final URL of the persisted file (returned to the caller on success)
+    # Store-specific destination identifier; exactly one is set, depending on store type.
+    local_path: Path | None = None  # LocalStore: filesystem destination
+    remote_key: str | None = None  # cloud stores: object key / blob name within the bucket / container
 
 
 class StorageTarget(enum.Enum):
@@ -336,29 +353,29 @@ class ObjectStoreBase:
         """
         raise AssertionError
 
-    def copy_local_file(self, col: Column, src_path: Path) -> str:
-        """Copy a file associated with a Column to the store, returning the file's URL within the destination.
+    def prepare_destination(
+        self, tbl_id: UUID, col_id: int, tbl_version: int, ext: str | None = None
+    ) -> ResolvedFileDestination:
+        """Caller-thread side: resolve a destination for a new file.
 
-        Args:
-            col: The Column to which the file belongs, used to generate the URI of the stored object.
-            src_path: The Path to the local file
-
-        Returns:
-            The URI of the object in the store
+        Returns a ResolvedFileDestination that captures everything a worker thread needs to
+        perform the write, with no further catalog access required.
         """
         raise AssertionError
 
-    def move_local_file(self, col: Column, src_path: Path) -> str | None:
-        """Move a file associated with a Column to the store, returning the file's URL within the destination.
+    def move_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str | None:
+        """Worker-thread side: attempt to move a local file to the resolved destination.
 
-        Args:
-            col: The Column to which the file belongs, used to generate the URI of the stored object.
-            src_path: The Path to the local file
-
-        Returns:
-            The URI of the object in the store, None if the object cannot be moved to the store
+        Returns the new file URL on success, or None if move is not supported (in which case
+        the caller should fall back to copy_local_file_resolved). The default returns None;
+        only stores that can perform an atomic move (e.g., LocalStore via filesystem rename)
+        override this.
         """
         return None
+
+    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
+        """Worker-thread side: copy a local file to the resolved destination, returning the new file URL."""
+        raise AssertionError
 
     def copy_object_to_local_file(self, src_path: str, dest_path: Path) -> None:
         """Copies an object from the store to a local media file.
@@ -506,35 +523,32 @@ class ObjectOps:
     def put_file(cls, col: Column, src_path: Path, relocate_or_delete: bool) -> str:
         """Move or copy a file to the destination, returning the file's URL within the destination.
         If relocate_or_delete is True and the file is in the TempStore, the file will be deleted after the operation.
+
+        Caller-thread convenience that resolves the destination from the Column and dispatches
+        to put_file_resolved. Worker threads (e.g., ObjectStoreSaveNode's executor) should
+        precompute the destination on the caller thread and call put_file_resolved directly.
         """
+        store = cls.get_store(col.destination, False, col.name)
+        resolved = store.prepare_destination(col.tbl_handle.id, col.id, col.get_tbl().version, ext=src_path.suffix)
+        return cls.put_file_resolved(store, src_path, resolved, relocate_or_delete)
+
+    @classmethod
+    def put_file_resolved(
+        cls, store: ObjectStoreBase, src_path: Path, resolved: ResolvedFileDestination, relocate_or_delete: bool
+    ) -> str:
+        """Worker-thread version of put_file: performs move-or-copy with no catalog access."""
         from pixeltable.utils.local_store import TempStore
 
         if relocate_or_delete:
             # File is temporary, used only once, so we can delete it after copy if it can't be moved
             assert TempStore.contains_path(src_path)
-        dest = col.destination
-        store = cls.get_store(dest, False, col.name)
-        # Attempt to move
-        if relocate_or_delete:
-            moved_file_url = store.move_local_file(col, src_path)
+            moved_file_url = store.move_local_file_resolved(src_path, resolved)
             if moved_file_url is not None:
                 return moved_file_url
-        new_file_url = store.copy_local_file(col, src_path)
+        new_file_url = store.copy_local_file_resolved(src_path, resolved)
         if relocate_or_delete:
             TempStore.delete_media_file(src_path)
         return new_file_url
-
-    @classmethod
-    def move_local_file(cls, col: Column, src_path: Path) -> str:
-        """Move a file to the destination specified by the Column, returning the file's URL within the destination."""
-        store = cls.get_store(col.destination, False, col.name)
-        return store.move_local_file(col, src_path)
-
-    @classmethod
-    def copy_local_file(cls, col: Column, src_path: Path) -> str:
-        """Copy a file to the destination specified by the Column, returning the file's URL within the destination."""
-        store = cls.get_store(col.destination, False, col.name)
-        return store.copy_local_file(col, src_path)
 
     @classmethod
     def delete(cls, dest: str | None, tbl_id: UUID, tbl_version: int | None = None) -> int | None:

--- a/pixeltable/utils/pxt_store.py
+++ b/pixeltable/utils/pxt_store.py
@@ -23,8 +23,8 @@ from pixeltable.runtime import get_runtime
 from pixeltable.utils.cloud_utils import get_bucket_credentials, get_presigned_url_from_cloud
 from pixeltable.utils.object_stores import (
     S3_COMPATIBLE_TARGETS,
+    FileDestination,
     ObjectStoreBase,
-    ResolvedFileDestination,
     StorageObjectAddress,
     StorageTarget,
 )
@@ -260,23 +260,21 @@ class PxtStore(ObjectStoreBase):
                 provider=self._pxt_store_entry.storage_provider,
             ) from e
 
-    def prepare_destination(
+    def resolve_destination(
         self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
-    ) -> ResolvedFileDestination:
-        inner = self._store.prepare_destination(tbl_id, col_id, tbl_version, ext=ext)
-        return ResolvedFileDestination(
-            new_file_url=self._to_logical_uri(inner.new_file_url), remote_key=inner.remote_key
-        )
+    ) -> FileDestination:
+        inner = self._store.resolve_destination(tbl_id, col_id, tbl_version, ext=ext)
+        return FileDestination(url=self._to_logical_uri(inner.url), remote_key=inner.remote_key)
 
-    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
+    def copy_local_file(self, src_path: Path, dest: FileDestination) -> str:
         if self._pxt_store_entry.no_space_left:
             raise excs.ServiceUnavailableError(
                 ErrorCode.STORE_UNAVAILABLE,
                 'No space left in Pixeltable store. Only read and delete operations are allowed.',
             )
-        # Inner S3 store reads resolved.remote_key for the upload and returns resolved.new_file_url;
-        # since new_file_url is already the logical (pxtfs://) URL, we can pass resolved through unchanged.
-        return self._store.copy_local_file_resolved(src_path, resolved)
+        # Inner S3 store reads dest.remote_key for the upload and returns dest.url; since
+        # dest.url is already the logical (pxtfs://) URL, we can pass dest through unchanged.
+        return self._store.copy_local_file(src_path, dest)
 
     def copy_object_to_local_file(self, src_path: str, dest_path: Path) -> None:
         return self._store.copy_object_to_local_file(src_path, dest_path)

--- a/pixeltable/utils/pxt_store.py
+++ b/pixeltable/utils/pxt_store.py
@@ -9,7 +9,6 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import boto3
 import botocore
@@ -22,11 +21,14 @@ from botocore.session import get_session as get_botocore_session
 from pixeltable import ErrorCode, env, exceptions as excs
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.cloud_utils import get_bucket_credentials, get_presigned_url_from_cloud
-from pixeltable.utils.object_stores import S3_COMPATIBLE_TARGETS, ObjectStoreBase, StorageObjectAddress, StorageTarget
+from pixeltable.utils.object_stores import (
+    S3_COMPATIBLE_TARGETS,
+    ObjectStoreBase,
+    ResolvedFileDestination,
+    StorageObjectAddress,
+    StorageTarget,
+)
 from pixeltable.utils.s3_store import S3CompatClientDict, S3Store
-
-if TYPE_CHECKING:
-    from pixeltable.catalog import Column
 
 _logger = logging.getLogger('pixeltable')
 
@@ -258,13 +260,23 @@ class PxtStore(ObjectStoreBase):
                 provider=self._pxt_store_entry.storage_provider,
             ) from e
 
-    def copy_local_file(self, col: Column, src_path: Path) -> str:
+    def prepare_destination(
+        self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
+    ) -> ResolvedFileDestination:
+        inner = self._store.prepare_destination(tbl_id, col_id, tbl_version, ext=ext)
+        return ResolvedFileDestination(
+            new_file_url=self._to_logical_uri(inner.new_file_url), remote_key=inner.remote_key
+        )
+
+    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
         if self._pxt_store_entry.no_space_left:
             raise excs.ServiceUnavailableError(
                 ErrorCode.STORE_UNAVAILABLE,
                 'No space left in Pixeltable store. Only read and delete operations are allowed.',
             )
-        return self._to_logical_uri(self._store.copy_local_file(col, src_path))
+        # Inner S3 store reads resolved.remote_key for the upload and returns resolved.new_file_url;
+        # since new_file_url is already the logical (pxtfs://) URL, we can pass resolved through unchanged.
+        return self._store.copy_local_file_resolved(src_path, resolved)
 
     def copy_object_to_local_file(self, src_path: str, dest_path: Path) -> None:
         return self._store.copy_object_to_local_file(src_path, dest_path)

--- a/pixeltable/utils/s3_store.py
+++ b/pixeltable/utils/s3_store.py
@@ -30,7 +30,7 @@ class S3CompatClientDict(NamedTuple):
     """Container for S3-compatible storage access objects (R2, B2, etc.)."""
 
     profile: str | None  # AWS-style profile used to locate credentials
-    clients: dict[str, Any]  # Map of endpoint URL → boto3 client instance
+    clients: dict[str, Any]  # Map of endpoint URL to boto3 client instance
 
 
 @env.register_client('r2')

--- a/pixeltable/utils/s3_store.py
+++ b/pixeltable/utils/s3_store.py
@@ -16,9 +16,9 @@ from pixeltable import env, exceptions as excs
 from pixeltable.config import Config
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.object_stores import (
+    FileDestination,
     ObjectPath,
     ObjectStoreBase,
-    ResolvedFileDestination,
     StorageObjectAddress,
     StorageTarget,
 )
@@ -300,11 +300,11 @@ class S3Store(ObjectStoreBase):
         parent = f'{self.__base_uri}{prefix}'
         return f'{parent}/{filename}'
 
-    def prepare_destination(
+    def resolve_destination(
         self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
-    ) -> ResolvedFileDestination:
-        new_file_uri = self._prepare_uri_raw(tbl_id, col_id, tbl_version, ext=ext)
-        parsed = urllib.parse.urlparse(new_file_uri)
+    ) -> FileDestination:
+        url = self._prepare_uri_raw(tbl_id, col_id, tbl_version, ext=ext)
+        parsed = urllib.parse.urlparse(url)
         key = parsed.path.lstrip('/')
         if self.soa.storage_target in {
             StorageTarget.R2_STORE,
@@ -313,7 +313,7 @@ class S3Store(ObjectStoreBase):
             StorageTarget.PIXELTABLE_STORE,
         }:
             key = key.split('/', 1)[-1]  # Remove the bucket name from the key for R2/B2
-        return ResolvedFileDestination(new_file_url=new_file_uri, remote_key=key)
+        return FileDestination(url=url, remote_key=key)
 
     def copy_object_to_local_file(self, src_path: str, dest_path: Path) -> None:
         """Copies an object to a local file. Thread safe."""
@@ -323,17 +323,17 @@ class S3Store(ObjectStoreBase):
             self.handle_s3_error(e, f'downloading file {src_path!r}')
             raise
 
-    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
-        assert resolved.remote_key is not None
+    def copy_local_file(self, src_path: Path, dest: FileDestination) -> str:
+        assert dest.remote_key is not None
         try:
-            _logger.debug(f'Media Storage: copying {src_path} to {resolved.new_file_url} : Key: {resolved.remote_key}')
+            _logger.debug(f'Media Storage: copying {src_path} to {dest.url} : Key: {dest.remote_key}')
             content_type = puremagic.from_file(str(src_path), mime=True)
             extra_args = {'ContentType': content_type} if content_type is not None else None
             self.client().upload_file(
-                Filename=str(src_path), Bucket=self.bucket_name, Key=resolved.remote_key, ExtraArgs=extra_args
+                Filename=str(src_path), Bucket=self.bucket_name, Key=dest.remote_key, ExtraArgs=extra_args
             )
-            _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
-            return resolved.new_file_url
+            _logger.debug(f'Media Storage: copied {src_path} to {dest.url}')
+            return dest.url
         except ClientError as e:
             self.handle_s3_error(e, 'uploading file')
             raise

--- a/pixeltable/utils/s3_store.py
+++ b/pixeltable/utils/s3_store.py
@@ -3,7 +3,7 @@ import re
 import urllib.parse
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator, NamedTuple
+from typing import Any, Iterator, NamedTuple
 
 import boto3
 import botocore
@@ -15,10 +15,13 @@ from botocore.exceptions import ClientError, ConnectionError
 from pixeltable import env, exceptions as excs
 from pixeltable.config import Config
 from pixeltable.runtime import get_runtime
-from pixeltable.utils.object_stores import ObjectPath, ObjectStoreBase, StorageObjectAddress, StorageTarget
-
-if TYPE_CHECKING:
-    from pixeltable.catalog import Column
+from pixeltable.utils.object_stores import (
+    ObjectPath,
+    ObjectStoreBase,
+    ResolvedFileDestination,
+    StorageObjectAddress,
+    StorageTarget,
+)
 
 _logger = logging.getLogger('pixeltable')
 
@@ -297,24 +300,10 @@ class S3Store(ObjectStoreBase):
         parent = f'{self.__base_uri}{prefix}'
         return f'{parent}/{filename}'
 
-    def _prepare_uri(self, col: 'Column', ext: str | None = None) -> str:
-        """
-        Construct a new, unique URI for a persisted media file.
-        """
-        assert col.get_tbl() is not None, 'Column must be associated with a table'
-        return self._prepare_uri_raw(col.get_tbl().id, col.id, col.get_tbl().version, ext=ext)
-
-    def copy_object_to_local_file(self, src_path: str, dest_path: Path) -> None:
-        """Copies an object to a local file. Thread safe."""
-        try:
-            self.client().download_file(Bucket=self.bucket_name, Key=self.prefix + src_path, Filename=str(dest_path))
-        except ClientError as e:
-            self.handle_s3_error(e, f'downloading file {src_path!r}')
-            raise
-
-    def copy_local_file(self, col: 'Column', src_path: Path) -> str:
-        """Copy a local file, and return its new URL"""
-        new_file_uri = self._prepare_uri(col, ext=src_path.suffix)
+    def prepare_destination(
+        self, tbl_id: uuid.UUID, col_id: int, tbl_version: int, ext: str | None = None
+    ) -> ResolvedFileDestination:
+        new_file_uri = self._prepare_uri_raw(tbl_id, col_id, tbl_version, ext=ext)
         parsed = urllib.parse.urlparse(new_file_uri)
         key = parsed.path.lstrip('/')
         if self.soa.storage_target in {
@@ -324,13 +313,27 @@ class S3Store(ObjectStoreBase):
             StorageTarget.PIXELTABLE_STORE,
         }:
             key = key.split('/', 1)[-1]  # Remove the bucket name from the key for R2/B2
+        return ResolvedFileDestination(new_file_url=new_file_uri, remote_key=key)
+
+    def copy_object_to_local_file(self, src_path: str, dest_path: Path) -> None:
+        """Copies an object to a local file. Thread safe."""
         try:
-            _logger.debug(f'Media Storage: copying {src_path} to {new_file_uri} : Key: {key}')
+            self.client().download_file(Bucket=self.bucket_name, Key=self.prefix + src_path, Filename=str(dest_path))
+        except ClientError as e:
+            self.handle_s3_error(e, f'downloading file {src_path!r}')
+            raise
+
+    def copy_local_file_resolved(self, src_path: Path, resolved: ResolvedFileDestination) -> str:
+        assert resolved.remote_key is not None
+        try:
+            _logger.debug(f'Media Storage: copying {src_path} to {resolved.new_file_url} : Key: {resolved.remote_key}')
             content_type = puremagic.from_file(str(src_path), mime=True)
             extra_args = {'ContentType': content_type} if content_type is not None else None
-            self.client().upload_file(Filename=str(src_path), Bucket=self.bucket_name, Key=key, ExtraArgs=extra_args)
-            _logger.debug(f'Media Storage: copied {src_path} to {new_file_uri}')
-            return new_file_uri
+            self.client().upload_file(
+                Filename=str(src_path), Bucket=self.bucket_name, Key=resolved.remote_key, ExtraArgs=extra_args
+            )
+            _logger.debug(f'Media Storage: copied {src_path} to {resolved.new_file_url}')
+            return resolved.new_file_url
         except ClientError as e:
             self.handle_s3_error(e, 'uploading file')
             raise

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -4,7 +4,6 @@ from typing import Callable
 import pytest
 
 import pixeltable as pxt
-from pixeltable import exceptions as excs
 from tests.utils import DummyIterator, pxt_raises, validate_update_status
 
 
@@ -180,6 +179,54 @@ class TestConcurrentOps:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
+    def test_shared_query_udf(self, uses_db: None) -> None:
+        t = pxt.create_table('t15', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(50)]), expected_rows=50)
+
+        @pxt.query
+        def find_above(threshold: int) -> pxt.Query:
+            return t.where(t.a >= threshold).select(t.a)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                bound = find_above.template_query.bind({'threshold': 40})
+                rows = bound.collect()
+                assert len(rows) == 10
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_shared_join(self, uses_db: None) -> None:
+        t1 = pxt.create_table('t17_a', {'id': pxt.Required[pxt.Int], 'i': pxt.Required[pxt.Int]})
+        t2 = pxt.create_table('t17_b', {'id': pxt.Required[pxt.Int], 'f': pxt.Required[pxt.Float]})
+        validate_update_status(t1.insert([{'id': i, 'i': i} for i in range(20)]), expected_rows=20)
+        validate_update_status(t2.insert([{'id': i, 'f': i * 1.5} for i in range(20)]), expected_rows=20)
+
+        q = t1.join(t2, on=t1.id == t2.id, how='inner').select(t1.i, t2.f, out=t1.i + t2.f).order_by(t1.i)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = q.collect()
+                assert len(rows) == 20
+                assert all(row['out'] == row['i'] + row['f'] for row in rows)
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_shared_snapshot_query(self, uses_db: None) -> None:
+        t = pxt.create_table('t19_base', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(20)]), expected_rows=20)
+        s = pxt.create_snapshot('t19_snap', t)
+
+        q = s.where(s.a >= 10).select(s.a)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                assert len(q.collect()) == 10
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
     def test_table_public_methods(self, uses_db: None) -> None:
         """All public Table methods guard against cross-thread calls."""
         t = pxt.create_table('t_xthread', {'a': pxt.Required[pxt.Int], 'keep': pxt.Required[pxt.Int]})
@@ -241,86 +288,3 @@ class TestConcurrentOps:
 
         # Sanity: Table is still usable on the main thread.
         assert t.count() == 1
-
-    def test_shared_query_udf(self, uses_db: None) -> None:
-        t = pxt.create_table('t15', {'a': pxt.Required[pxt.Int]})
-        validate_update_status(t.insert([{'a': i} for i in range(50)]), expected_rows=50)
-
-        @pxt.query
-        def find_above(threshold: int) -> pxt.Query:
-            return t.where(t.a >= threshold).select(t.a)
-
-        def worker(_tid: int) -> None:
-            for _ in range(self.ITERATIONS):
-                bound = find_above.template_query.bind({'threshold': 40})
-                rows = bound.collect()
-                assert len(rows) == 10
-
-        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
-        assert errors == [], f'errors: {errors[:3]}'
-
-    def test_shared_join(self, uses_db: None) -> None:
-        t1 = pxt.create_table('t17_a', {'id': pxt.Required[pxt.Int], 'i': pxt.Required[pxt.Int]})
-        t2 = pxt.create_table('t17_b', {'id': pxt.Required[pxt.Int], 'f': pxt.Required[pxt.Float]})
-        validate_update_status(t1.insert([{'id': i, 'i': i} for i in range(20)]), expected_rows=20)
-        validate_update_status(t2.insert([{'id': i, 'f': i * 1.5} for i in range(20)]), expected_rows=20)
-
-        q = t1.join(t2, on=t1.id == t2.id, how='inner').select(t1.i, t2.f, out=t1.i + t2.f).order_by(t1.i)
-
-        def worker(_tid: int) -> None:
-            for _ in range(self.ITERATIONS):
-                rows = q.collect()
-                assert len(rows) == 20
-                assert all(row['out'] == row['i'] + row['f'] for row in rows)
-
-        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
-        assert errors == [], f'errors: {errors[:3]}'
-
-    def test_shared_snapshot_query(self, uses_db: None) -> None:
-        t = pxt.create_table('t19_base', {'a': pxt.Required[pxt.Int]})
-        validate_update_status(t.insert([{'a': i} for i in range(20)]), expected_rows=20)
-        s = pxt.create_snapshot('t19_snap', t)
-
-        q = s.where(s.a >= 10).select(s.a)
-
-        def worker(_tid: int) -> None:
-            for _ in range(self.ITERATIONS):
-                assert len(q.collect()) == 10
-
-        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
-        assert errors == [], f'errors: {errors[:3]}'
-
-    def test_query_after_schema_change(self, uses_db: None) -> None:
-        t = pxt.create_table('t7', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
-        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(10)]), expected_rows=10)
-        q = t.select(t.a, t.b)
-        assert len(q.collect()) == 10  # pre-drop sanity check
-
-        t.drop_column('b')
-
-        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match='dropped'):
-            q.collect()
-
-    def test_column_ref_attr_after_drop_and_readd(self, uses_db: None) -> None:
-        """T8: ColumnRef captured pre-change, drop+re-add the column. Accessing
-        the captured ref should re-resolve through the catalog (and raise, since
-        the original col_id is gone) rather than returning stale Column metadata."""
-        # The "keep" column exists so dropping "a" is allowed (tables need at least one column).
-        # The new "a" is nullable since add_column on a non-empty table can't add a required column.
-        t = pxt.create_table('t8', {'a': pxt.Required[pxt.Int], 'keep': pxt.Required[pxt.Int]})
-        validate_update_status(t.insert([{'a': 1, 'keep': 0}]), expected_rows=1)
-
-        a_ref = t.a
-        # The Expr's col_type is set at __init__ from col.col_type; that snapshot
-        # is fine. The bug is downstream: accessing ColumnRef.col on master
-        # returned the cached Column instance forever.
-        assert a_ref.col_type.is_int_type()
-
-        t.drop_column('a')
-        t.add_column(a=pxt.String)
-
-        # On loadtest, .col is a property over col_handle.get(), which raises NotFoundError
-        # because the captured col_id was dropped. On master, .col is a cached
-        # field and silently returns the stale Column.
-        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match='dropped'):
-            _ = a_ref.col

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -318,6 +318,26 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
+    def test_join_query_cross_thread(self, uses_db: None) -> None:
+        """T17: join Query collected from workers. Multi-TVP plan: SELECT and FROM
+        reference two distinct tables, so the deepcopy traversal must produce a
+        consistent worker-side TableVersion / sa_tbl per side."""
+        t1 = pxt.create_table('t17_a', {'id': pxt.Required[pxt.Int], 'i': pxt.Required[pxt.Int]})
+        t2 = pxt.create_table('t17_b', {'id': pxt.Required[pxt.Int], 'f': pxt.Required[pxt.Float]})
+        validate_update_status(t1.insert([{'id': i, 'i': i} for i in range(20)]), expected_rows=20)
+        validate_update_status(t2.insert([{'id': i, 'f': i * 1.5} for i in range(20)]), expected_rows=20)
+
+        q = t1.join(t2, on=t1.id == t2.id, how='inner').select(t1.i, t2.f, out=t1.i + t2.f).order_by(t1.i)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = q.collect()
+                assert len(rows) == 20
+                assert all(row['out'] == row['i'] + row['f'] for row in rows)
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
     def test_snapshot_query_cross_thread(self, uses_db: None) -> None:
         """T19: snapshot Query collected from workers. Snapshots take the
         effective_version is not None branch in TableVersionHandle.get(); worth

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -213,6 +213,24 @@ class TestConcurrentOps:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
+    def test_shared_join2(self, uses_db: None) -> None:
+        t1 = pxt.create_table('j1', {'id': pxt.Required[pxt.Int]})
+        t2 = pxt.create_table('j2', {'id': pxt.Required[pxt.Int]})
+        validate_update_status(t1.insert([{'id': i} for i in range(5)]), expected_rows=5)
+        validate_update_status(t2.insert([{'id': i} for i in range(5)]), expected_rows=5)
+
+        def worker(_tid: int) -> None:
+            t1_worker = pxt.get_table('j1')
+
+            # re-using t2 from the main thread raises
+            with pxt_raises(pxt.ErrorCode.INVALID_STATE, match='thread'):
+                t1_worker.join(t2, on=t1_worker.id == t2.id)
+            with pxt_raises(pxt.ErrorCode.INVALID_STATE, match='thread'):
+                t1_worker.select().join(t2, on=t1_worker.id == t2.id)
+
+        errors = _run_workers(worker, n_threads=1)
+        assert errors == [], f'worker raised: {errors[0][1]!r}'
+
     def test_shared_snapshot_query(self, uses_db: None) -> None:
         t = pxt.create_table('t19_base', {'a': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i} for i in range(20)]), expected_rows=20)

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -173,7 +173,7 @@ class TestCrossThreadCatalog:
     def test_iterator_view_query_cross_thread(self, uses_db: None) -> None:
         """T6: query over a component (iterator) view across threads. Iterator views
         carry both base TVH and view TVH, plus the iterator function's own catalog
-        references — the most TVH instances in a single plan."""
+        references; the most TVH instances in a single plan."""
         t = pxt.create_table('t6_base', {'n': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'n': 3}, {'n': 5}]), expected_rows=2)
         iv = pxt.create_view('t6_iter_view', t, iterator=DummyIterator(t.n))
@@ -216,22 +216,21 @@ class TestCrossXactStaleness:
         """T8: ColumnRef captured pre-change, drop+re-add the column. Accessing
         the captured ref should re-resolve through the catalog (and raise, since
         the original col_id is gone) rather than returning stale Column metadata."""
-        # `keep` exists so dropping 'a' is allowed (tables need at least one column).
-        # The new 'a' is nullable since add_column on a non-empty table can't add a
-        # required column.
+        # The "keep" column exists so dropping "a" is allowed (tables need at least one column).
+        # The new "a" is nullable since add_column on a non-empty table can't add a required column.
         t = pxt.create_table('t8', {'a': pxt.Required[pxt.Int], 'keep': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': 1, 'keep': 0}]), expected_rows=1)
 
         a_ref = t.a
         # The Expr's col_type is set at __init__ from col.col_type; that snapshot
-        # is fine. The bug is downstream — accessing ColumnRef.col on master
+        # is fine. The bug is downstream: accessing ColumnRef.col on master
         # returned the cached Column instance forever.
         assert a_ref.col_type.is_int_type()
 
         t.drop_column('a')
         t.add_column(a=pxt.String)
 
-        # On loadtest, .col is a property → col_handle.get() → raises NotFoundError
+        # On loadtest, .col is a property over col_handle.get(), which raises NotFoundError
         # because the captured col_id was dropped. On master, .col is a cached
         # field and silently returns the stale Column.
         with pytest.raises(excs.Error):

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -1,9 +1,31 @@
 import threading
+from typing import Callable
 
 import pytest
 
 import pixeltable as pxt
-from tests.utils import validate_update_status
+from pixeltable import exceptions as excs
+from tests.utils import DummyIterator, validate_update_status
+
+
+def _run_workers(target: Callable[[int], None], n_threads: int) -> list[tuple[int, BaseException]]:
+    """Run target(tid) on n_threads workers; return any exceptions raised."""
+    errors: list[tuple[int, BaseException]] = []
+    lock = threading.Lock()
+
+    def runner(tid: int) -> None:
+        try:
+            target(tid)
+        except BaseException as e:
+            with lock:
+                errors.append((tid, e))
+
+    threads = [threading.Thread(target=runner, args=(i,)) for i in range(n_threads)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+    return errors
 
 
 class TestConcurrentOps:
@@ -52,3 +74,165 @@ class TestConcurrentOps:
             assert row['offset'] == row['value'] + 100
 
         assert all(c >= 0 for c in select_counts)
+
+
+class TestCrossThreadCatalog:
+    """Catalog-bound objects (Query, Table, ColumnRef) constructed on the main thread
+    must work safely when used from worker threads. Each thread has its own Catalog
+    instance with its own TableVersion / sa_tbl per logical table; the per-instance
+    _tbl_version cache on TVHs/TVPs and the cached `col` field on ColumnRefs were
+    leaking the originating thread's sa_tbl into the worker's query plan and
+    producing FROM-clause sa_tbl mismatches (DuplicateAlias) on master.
+    """
+
+    NUM_THREADS = 4
+    ITERATIONS = 20
+
+    def test_query_collected_from_workers(self, uses_db: None) -> None:
+        """T1: Query built on main thread, collect() from worker threads."""
+        t = pxt.create_table('t1', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(100)]), expected_rows=100)
+
+        q = t.where(t.a >= 50).select(t.a, t.b)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = q.collect()
+                assert len(rows) == 50
+                assert all(row['a'] >= 50 for row in rows)
+                assert all(row['b'] == row['a'] * 10 for row in rows)
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_dataframe_chained_on_main_executed_on_workers(self, uses_db: None) -> None:
+        """T2: richer Expr tree (arithmetic, ordering) built on main, executed by workers."""
+        t = pxt.create_table('t2', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(100)]), expected_rows=100)
+
+        q = t.where(t.a > 50).select(sum_ab=t.a + t.b, double_a=t.a * 2).order_by(t.a)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = q.collect()
+                assert len(rows) == 49
+                # rows are ordered by a; first row has a=51, b=510
+                assert rows[0]['double_a'] == 102
+                assert rows[0]['sum_ab'] == 51 + 510
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_table_held_across_threads(self, uses_db: None) -> None:
+        """T3: Table held on main, queries built and executed on workers."""
+        t = pxt.create_table('t3', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(100)]), expected_rows=100)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = t.select(t.a).collect()
+                assert len(rows) == 100
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_column_ref_held_across_threads(self, uses_db: None) -> None:
+        """T4: ColumnRefs captured on main are mixed into queries built on workers
+        from a freshly fetched Table. This is the cleanest demonstration: FROM
+        comes from worker's Table; SELECT references main's col_handle."""
+        t = pxt.create_table('t4', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(100)]), expected_rows=100)
+        a_ref = t.a
+        b_ref = t.b
+
+        def worker(_tid: int) -> None:
+            t_worker = pxt.get_table('t4')
+            for _ in range(self.ITERATIONS):
+                rows = t_worker.select(a_ref, b_ref).collect()
+                assert len(rows) == 100
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_view_query_cross_thread(self, uses_db: None) -> None:
+        """T5: query over a view, exercising the view+base TVP chain across threads."""
+        t = pxt.create_table('t5_base', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(100)]), expected_rows=100)
+        v = pxt.create_view('t5_view', t.where(t.a >= 50))
+
+        q = v.select(v.a)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = q.collect()
+                assert len(rows) == 50
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_iterator_view_query_cross_thread(self, uses_db: None) -> None:
+        """T6: query over a component (iterator) view across threads. Iterator views
+        carry both base TVH and view TVH, plus the iterator function's own catalog
+        references — the most TVH instances in a single plan."""
+        t = pxt.create_table('t6_base', {'n': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'n': 3}, {'n': 5}]), expected_rows=2)
+        iv = pxt.create_view('t6_iter_view', t, iterator=DummyIterator(t.n))
+
+        q = iv.select(iv.out1, iv.out2)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = q.collect()
+                assert len(rows) == 3 + 5
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+
+class TestCrossXactStaleness:
+    """ColumnRef.col was a cached field on master, so reads through a captured
+    ColumnRef returned the pre-change Column instance after a schema change in
+    a separate transaction. ColumnRef.col is now a property over col_handle and
+    re-resolves through the catalog on every access.
+    """
+
+    def test_query_after_column_drop(self, uses_db: None) -> None:
+        """T7: Query captured pre-drop, drop_column, re-execute. Should fail cleanly
+        rather than crashing on a stale sa_col or silently returning bad rows."""
+        t = pxt.create_table('t7', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(10)]), expected_rows=10)
+        q = t.select(t.a, t.b)
+        assert len(q.collect()) == 10  # pre-drop sanity check
+
+        t.drop_column('b')
+
+        # On loadtest, col_handle.get() raises NotFoundError because the dropped
+        # col_id is no longer in cols_by_id. On master, ColumnRef.col is the
+        # cached pre-drop Column and the plan references its stale sa_col.
+        with pytest.raises(excs.Error):
+            q.collect()
+
+    def test_column_ref_attr_after_drop_and_readd(self, uses_db: None) -> None:
+        """T8: ColumnRef captured pre-change, drop+re-add the column. Accessing
+        the captured ref should re-resolve through the catalog (and raise, since
+        the original col_id is gone) rather than returning stale Column metadata."""
+        # `keep` exists so dropping 'a' is allowed (tables need at least one column).
+        # The new 'a' is nullable since add_column on a non-empty table can't add a
+        # required column.
+        t = pxt.create_table('t8', {'a': pxt.Required[pxt.Int], 'keep': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': 1, 'keep': 0}]), expected_rows=1)
+
+        a_ref = t.a
+        # The Expr's col_type is set at __init__ from col.col_type; that snapshot
+        # is fine. The bug is downstream — accessing ColumnRef.col on master
+        # returned the cached Column instance forever.
+        assert a_ref.col_type.is_int_type()
+
+        t.drop_column('a')
+        t.add_column(a=pxt.String)
+
+        # On loadtest, .col is a property → col_handle.get() → raises NotFoundError
+        # because the captured col_id was dropped. On master, .col is a cached
+        # field and silently returns the stale Column.
+        with pytest.raises(excs.Error):
+            _ = a_ref.col

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -75,44 +75,28 @@ class TestConcurrentOps:
 
         assert all(c >= 0 for c in select_counts)
 
-
-class TestCrossThreadCatalog:
-    """Catalog-bound objects (Query, Table, ColumnRef) constructed on the main thread
-    must work safely when used from worker threads. Each thread has its own Catalog
-    instance with its own TableVersion / sa_tbl per logical table; the per-instance
-    _tbl_version cache on TVHs/TVPs and the cached `col` field on ColumnRefs were
-    leaking the originating thread's sa_tbl into the worker's query plan and
-    producing FROM-clause sa_tbl mismatches (DuplicateAlias) on master.
-    """
-
     NUM_THREADS = 4
     ITERATIONS = 20
 
-    def test_query_collected_from_workers(self, uses_db: None) -> None:
-        """T1: Query built on main thread, collect() from worker threads."""
+    def test_shared_query(self, uses_db: None) -> None:
         t = pxt.create_table('t1', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(100)]), expected_rows=100)
 
         q = t.where(t.a >= 50).select(t.a, t.b)
 
-        def worker(_tid: int) -> None:
+        def worker1(_tid: int) -> None:
             for _ in range(self.ITERATIONS):
                 rows = q.collect()
                 assert len(rows) == 50
                 assert all(row['a'] >= 50 for row in rows)
                 assert all(row['b'] == row['a'] * 10 for row in rows)
 
-        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        errors = _run_workers(worker1, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
-
-    def test_dataframe_chained_on_main_executed_on_workers(self, uses_db: None) -> None:
-        """T2: richer Expr tree (arithmetic, ordering) built on main, executed by workers."""
-        t = pxt.create_table('t2', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
-        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(100)]), expected_rows=100)
 
         q = t.where(t.a > 50).select(sum_ab=t.a + t.b, double_a=t.a * 2).order_by(t.a)
 
-        def worker(_tid: int) -> None:
+        def worker2(_tid: int) -> None:
             for _ in range(self.ITERATIONS):
                 rows = q.collect()
                 assert len(rows) == 49
@@ -120,13 +104,12 @@ class TestCrossThreadCatalog:
                 assert rows[0]['double_a'] == 102
                 assert rows[0]['sum_ab'] == 51 + 510
 
-        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        errors = _run_workers(worker2, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_table_per_thread_query(self, uses_db: None) -> None:
-        """T3: each worker fetches its own Table via pxt.get_table() and builds queries
-        against it. This is the supported pattern for using a Table from worker threads."""
-        pxt.create_table('t3', {'a': pxt.Required[pxt.Int]}).insert([{'a': i} for i in range(100)])
+    def test_get_table(self, uses_db: None) -> None:
+        t = pxt.create_table('t3', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(100)]), expected_rows=100)
 
         def worker(_tid: int) -> None:
             t_worker = pxt.get_table('t3')
@@ -137,10 +120,7 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_column_ref_held_across_threads(self, uses_db: None) -> None:
-        """T4: ColumnRefs captured on main are mixed into queries built on workers
-        from a freshly fetched Table. This is the cleanest demonstration: FROM
-        comes from worker's Table; SELECT references main's col_handle."""
+    def test_shared_colrefs(self, uses_db: None) -> None:
         t = pxt.create_table('t4', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(100)]), expected_rows=100)
         a_ref = t.a
@@ -155,8 +135,7 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_view_query_cross_thread(self, uses_db: None) -> None:
-        """T5: query over a view, exercising the view+base TVP chain across threads."""
+    def test_shared_view_query1(self, uses_db: None) -> None:
         t = pxt.create_table('t5_base', {'a': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i} for i in range(100)]), expected_rows=100)
         v = pxt.create_view('t5_view', t.where(t.a >= 50))
@@ -171,10 +150,7 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_iterator_view_query_cross_thread(self, uses_db: None) -> None:
-        """T6: query over a component (iterator) view across threads. Iterator views
-        carry both base TVH and view TVH, plus the iterator function's own catalog
-        references; the most TVH instances in a single plan."""
+    def test_shared_view_query2(self, uses_db: None) -> None:
         t = pxt.create_table('t6_base', {'n': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'n': 3}, {'n': 5}]), expected_rows=2)
         iv = pxt.create_view('t6_iter_view', t, iterator=DummyIterator(t.n))
@@ -189,36 +165,7 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_table_cross_thread_access_raises(self, uses_db: None) -> None:
-        """T9: a Table accessed from a thread other than the one that created it must
-        raise a clear error rather than silently mutating its TVP cache. The supported
-        pattern is to call pxt.get_table() per thread (T3) or to share Queries (T1, T5, T6)."""
-        t = pxt.create_table('t9', {'a': pxt.Required[pxt.Int]})
-        validate_update_status(t.insert([{'a': i} for i in range(10)]), expected_rows=10)
-
-        captured_errors: list[Exception] = []
-        lock = threading.Lock()
-
-        def worker(_tid: int) -> None:
-            try:
-                t.select(t.a).collect()
-            except excs.Error as e:
-                with lock:
-                    captured_errors.append(e)
-
-        threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
-        for th in threads:
-            th.start()
-        for th in threads:
-            th.join()
-
-        assert len(captured_errors) == 2, f'expected 2 errors, got {len(captured_errors)}'
-        assert all('thread' in str(e).lower() for e in captured_errors), captured_errors
-        assert all('pxt.get_table' in str(e) for e in captured_errors), captured_errors
-
-    def test_query_count_head_show_tail_from_workers(self, uses_db: None) -> None:
-        """T10-T12: Query.count(), .head(), .show(), .tail() built on main, called from
-        workers. These entry points must be cross-thread-safe like collect()."""
+    def test_non_collect_queries(self, uses_db: None) -> None:
         t = pxt.create_table('t10', {'a': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i} for i in range(20)]), expected_rows=20)
         q = t.where(t.a >= 5).select(t.a)
@@ -233,15 +180,13 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_table_public_methods_cross_thread_raise(self, uses_db: None) -> None:
-        """T13-T14: every public Table method called from a thread other than the
-        constructing one must raise pxt.Error(INVALID_STATE) with a 'thread' message.
-        Methods are exercised one at a time on a fresh worker thread."""
+    def test_table_public_methods(self, uses_db: None) -> None:
+        """All public Table methods guard against cross-thread calls."""
         t = pxt.create_table('t_xthread', {'a': pxt.Required[pxt.Int], 'keep': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': 1, 'keep': 1}]), expected_rows=1)
         a_plus_one = t.a + 1
 
-        def expect_xthread(call: Callable[[], object]) -> None:
+        def expect_error(call: Callable[[], object]) -> None:
             def worker(_tid: int) -> None:
                 with pxt_raises(pxt.ErrorCode.INVALID_STATE, match='thread'):
                     call()
@@ -250,58 +195,54 @@ class TestCrossThreadCatalog:
             assert errors == [], f'worker raised: {errors[0][1]!r}'
 
         # Read / introspection
-        expect_xthread(lambda: t.get_metadata())
-        expect_xthread(lambda: t.list_views())
-        expect_xthread(lambda: t.columns())
-        expect_xthread(lambda: t.describe())
-        expect_xthread(lambda: t.get_versions())
-        expect_xthread(lambda: t.history())
-        expect_xthread(lambda: t.external_stores())
-        expect_xthread(lambda: t.get_base_table())
+        expect_error(lambda: t.get_metadata())
+        expect_error(lambda: t.list_views())
+        expect_error(lambda: t.columns())
+        expect_error(lambda: t.describe())
+        expect_error(lambda: t.get_versions())
+        expect_error(lambda: t.history())
+        expect_error(lambda: t.external_stores())
+        expect_error(lambda: t.get_base_table())
 
         # Query-builder entry points
-        expect_xthread(lambda: t.select(t.a))
-        expect_xthread(lambda: t.where(t.a > 0))
-        expect_xthread(lambda: t.order_by(t.a))
-        expect_xthread(lambda: t.limit(10))
-        expect_xthread(lambda: t.distinct())
-        expect_xthread(lambda: t.group_by(t.a))
-        expect_xthread(lambda: t.sample(n=1))
+        expect_error(lambda: t.select(t.a))
+        expect_error(lambda: t.where(t.a > 0))
+        expect_error(lambda: t.order_by(t.a))
+        expect_error(lambda: t.limit(10))
+        expect_error(lambda: t.distinct())
+        expect_error(lambda: t.group_by(t.a))
+        expect_error(lambda: t.sample(n=1))
 
         # Query terminals
-        expect_xthread(lambda: t.collect())
-        expect_xthread(lambda: t.count())
-        expect_xthread(lambda: t.head(1))
-        expect_xthread(lambda: t.tail(1))
-        expect_xthread(lambda: t.show(1))
-        expect_xthread(lambda: t.cursor())
+        expect_error(lambda: t.collect())
+        expect_error(lambda: t.count())
+        expect_error(lambda: t.head(1))
+        expect_error(lambda: t.tail(1))
+        expect_error(lambda: t.show(1))
+        expect_error(lambda: t.cursor())
 
         # Schema
-        expect_xthread(lambda: t.add_column(b=pxt.String))
-        expect_xthread(lambda: t.add_columns({'c': pxt.String}))
-        expect_xthread(lambda: t.add_computed_column(double=a_plus_one))
-        expect_xthread(lambda: t.drop_column('a'))
-        expect_xthread(lambda: t.rename_column('a', 'aa'))
+        expect_error(lambda: t.add_column(b=pxt.String))
+        expect_error(lambda: t.add_columns({'c': pxt.String}))
+        expect_error(lambda: t.add_computed_column(double=a_plus_one))
+        expect_error(lambda: t.drop_column('a'))
+        expect_error(lambda: t.rename_column('a', 'aa'))
 
         # DML
-        expect_xthread(lambda: t.insert([{'a': 2, 'keep': 1}]))
-        expect_xthread(lambda: t.update({'a': a_plus_one}))
-        expect_xthread(lambda: t.batch_update([{'a': 99, 'keep': 99}]))
-        expect_xthread(lambda: t.delete())
-        expect_xthread(lambda: t.recompute_columns('a'))
+        expect_error(lambda: t.insert([{'a': 2, 'keep': 1}]))
+        expect_error(lambda: t.update({'a': a_plus_one}))
+        expect_error(lambda: t.batch_update([{'a': 99, 'keep': 99}]))
+        expect_error(lambda: t.delete())
+        expect_error(lambda: t.recompute_columns('a'))
 
         # Versioning + attribute access
-        expect_xthread(lambda: t.revert())
-        expect_xthread(lambda: t.a)
+        expect_error(lambda: t.revert())
+        expect_error(lambda: t.a)
 
         # Sanity: Table is still usable on the main thread.
         assert t.count() == 1
 
-    def test_pxt_query_template_from_workers(self, uses_db: None) -> None:
-        """T15: an @pxt.query template captured at module-import time, invoked from
-        worker threads via the same bind() + collect() path the FastAPI router uses.
-        Both bind() and collect() defensively deepcopy, so the template's main-thread
-        TVPs never get touched on the worker."""
+    def test_shared_query_udf(self, uses_db: None) -> None:
         t = pxt.create_table('t15', {'a': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i} for i in range(50)]), expected_rows=50)
 
@@ -318,10 +259,7 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_join_query_cross_thread(self, uses_db: None) -> None:
-        """T17: join Query collected from workers. Multi-TVP plan: SELECT and FROM
-        reference two distinct tables, so the deepcopy traversal must produce a
-        consistent worker-side TableVersion / sa_tbl per side."""
+    def test_shared_join(self, uses_db: None) -> None:
         t1 = pxt.create_table('t17_a', {'id': pxt.Required[pxt.Int], 'i': pxt.Required[pxt.Int]})
         t2 = pxt.create_table('t17_b', {'id': pxt.Required[pxt.Int], 'f': pxt.Required[pxt.Float]})
         validate_update_status(t1.insert([{'id': i, 'i': i} for i in range(20)]), expected_rows=20)
@@ -338,10 +276,7 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_snapshot_query_cross_thread(self, uses_db: None) -> None:
-        """T19: snapshot Query collected from workers. Snapshots take the
-        effective_version is not None branch in TableVersionHandle.get(); worth
-        direct coverage since the atomic-replace refactor changed that branch."""
+    def test_shared_snapshot_query(self, uses_db: None) -> None:
         t = pxt.create_table('t19_base', {'a': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i} for i in range(20)]), expected_rows=20)
         s = pxt.create_snapshot('t19_snap', t)
@@ -355,17 +290,7 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-
-class TestCrossXactStaleness:
-    """ColumnRef.col was a cached field on master, so reads through a captured
-    ColumnRef returned the pre-change Column instance after a schema change in
-    a separate transaction. ColumnRef.col is now a property over col_handle and
-    re-resolves through the catalog on every access.
-    """
-
-    def test_query_after_column_drop(self, uses_db: None) -> None:
-        """T7: Query captured pre-drop, drop_column, re-execute. Should fail cleanly
-        rather than crashing on a stale sa_col or silently returning bad rows."""
+    def test_query_after_schema_change(self, uses_db: None) -> None:
         t = pxt.create_table('t7', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(10)]), expected_rows=10)
         q = t.select(t.a, t.b)
@@ -373,10 +298,7 @@ class TestCrossXactStaleness:
 
         t.drop_column('b')
 
-        # On loadtest, col_handle.get() raises NotFoundError because the dropped
-        # col_id is no longer in cols_by_id. On master, ColumnRef.col is the
-        # cached pre-drop Column and the plan references its stale sa_col.
-        with pytest.raises(excs.Error):
+        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match='dropped'):
             q.collect()
 
     def test_column_ref_attr_after_drop_and_readd(self, uses_db: None) -> None:
@@ -400,5 +322,5 @@ class TestCrossXactStaleness:
         # On loadtest, .col is a property over col_handle.get(), which raises NotFoundError
         # because the captured col_id was dropped. On master, .col is a cached
         # field and silently returns the stale Column.
-        with pytest.raises(excs.Error):
+        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match='dropped'):
             _ = a_ref.col

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -5,7 +5,7 @@ import pytest
 
 import pixeltable as pxt
 from pixeltable import exceptions as excs
-from tests.utils import DummyIterator, validate_update_status
+from tests.utils import DummyIterator, pxt_raises, validate_update_status
 
 
 def _run_workers(target: Callable[[int], None], n_threads: int) -> list[tuple[int, BaseException]]:
@@ -123,14 +123,15 @@ class TestCrossThreadCatalog:
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
-    def test_table_held_across_threads(self, uses_db: None) -> None:
-        """T3: Table held on main, queries built and executed on workers."""
-        t = pxt.create_table('t3', {'a': pxt.Required[pxt.Int]})
-        validate_update_status(t.insert([{'a': i} for i in range(100)]), expected_rows=100)
+    def test_table_per_thread_query(self, uses_db: None) -> None:
+        """T3: each worker fetches its own Table via pxt.get_table() and builds queries
+        against it. This is the supported pattern for using a Table from worker threads."""
+        pxt.create_table('t3', {'a': pxt.Required[pxt.Int]}).insert([{'a': i} for i in range(100)])
 
         def worker(_tid: int) -> None:
+            t_worker = pxt.get_table('t3')
             for _ in range(self.ITERATIONS):
-                rows = t.select(t.a).collect()
+                rows = t_worker.select(t_worker.a).collect()
                 assert len(rows) == 100
 
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
@@ -184,6 +185,152 @@ class TestCrossThreadCatalog:
             for _ in range(self.ITERATIONS):
                 rows = q.collect()
                 assert len(rows) == 3 + 5
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_table_cross_thread_access_raises(self, uses_db: None) -> None:
+        """T9: a Table accessed from a thread other than the one that created it must
+        raise a clear error rather than silently mutating its TVP cache. The supported
+        pattern is to call pxt.get_table() per thread (T3) or to share Queries (T1, T5, T6)."""
+        t = pxt.create_table('t9', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(10)]), expected_rows=10)
+
+        captured_errors: list[Exception] = []
+        lock = threading.Lock()
+
+        def worker(_tid: int) -> None:
+            try:
+                t.select(t.a).collect()
+            except excs.Error as e:
+                with lock:
+                    captured_errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert len(captured_errors) == 2, f'expected 2 errors, got {len(captured_errors)}'
+        assert all('thread' in str(e).lower() for e in captured_errors), captured_errors
+        assert all('pxt.get_table' in str(e) for e in captured_errors), captured_errors
+
+    def test_query_count_head_show_tail_from_workers(self, uses_db: None) -> None:
+        """T10-T12: Query.count(), .head(), .show(), .tail() built on main, called from
+        workers. These entry points must be cross-thread-safe like collect()."""
+        t = pxt.create_table('t10', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(20)]), expected_rows=20)
+        q = t.where(t.a >= 5).select(t.a)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                assert q.count() == 15
+                assert len(q.head(5)) == 5
+                assert len(q.show(5)) == 5
+                assert len(q.tail(5)) == 5
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_table_public_methods_cross_thread_raise(self, uses_db: None) -> None:
+        """T13-T14: every public Table method called from a thread other than the
+        constructing one must raise pxt.Error(INVALID_STATE) with a 'thread' message.
+        Methods are exercised one at a time on a fresh worker thread."""
+        t = pxt.create_table('t_xthread', {'a': pxt.Required[pxt.Int], 'keep': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': 1, 'keep': 1}]), expected_rows=1)
+        a_plus_one = t.a + 1
+
+        def expect_xthread(call: Callable[[], object]) -> None:
+            def worker(_tid: int) -> None:
+                with pxt_raises(pxt.ErrorCode.INVALID_STATE, match='thread'):
+                    call()
+
+            errors = _run_workers(worker, n_threads=1)
+            assert errors == [], f'worker raised: {errors[0][1]!r}'
+
+        # Read / introspection
+        expect_xthread(lambda: t.get_metadata())
+        expect_xthread(lambda: t.list_views())
+        expect_xthread(lambda: t.columns())
+        expect_xthread(lambda: t.describe())
+        expect_xthread(lambda: t.get_versions())
+        expect_xthread(lambda: t.history())
+        expect_xthread(lambda: t.external_stores())
+        expect_xthread(lambda: t.get_base_table())
+
+        # Query-builder entry points
+        expect_xthread(lambda: t.select(t.a))
+        expect_xthread(lambda: t.where(t.a > 0))
+        expect_xthread(lambda: t.order_by(t.a))
+        expect_xthread(lambda: t.limit(10))
+        expect_xthread(lambda: t.distinct())
+        expect_xthread(lambda: t.group_by(t.a))
+        expect_xthread(lambda: t.sample(n=1))
+
+        # Query terminals
+        expect_xthread(lambda: t.collect())
+        expect_xthread(lambda: t.count())
+        expect_xthread(lambda: t.head(1))
+        expect_xthread(lambda: t.tail(1))
+        expect_xthread(lambda: t.show(1))
+        expect_xthread(lambda: t.cursor())
+
+        # Schema
+        expect_xthread(lambda: t.add_column(b=pxt.String))
+        expect_xthread(lambda: t.add_columns({'c': pxt.String}))
+        expect_xthread(lambda: t.add_computed_column(double=a_plus_one))
+        expect_xthread(lambda: t.drop_column('a'))
+        expect_xthread(lambda: t.rename_column('a', 'aa'))
+
+        # DML
+        expect_xthread(lambda: t.insert([{'a': 2, 'keep': 1}]))
+        expect_xthread(lambda: t.update({'a': a_plus_one}))
+        expect_xthread(lambda: t.batch_update([{'a': 99, 'keep': 99}]))
+        expect_xthread(lambda: t.delete())
+        expect_xthread(lambda: t.recompute_columns('a'))
+
+        # Versioning + attribute access
+        expect_xthread(lambda: t.revert())
+        expect_xthread(lambda: t.a)
+
+        # Sanity: Table is still usable on the main thread.
+        assert t.count() == 1
+
+    def test_pxt_query_template_from_workers(self, uses_db: None) -> None:
+        """T15: an @pxt.query template captured at module-import time, invoked from
+        worker threads via the same bind() + collect() path the FastAPI router uses.
+        Both bind() and collect() defensively deepcopy, so the template's main-thread
+        TVPs never get touched on the worker."""
+        t = pxt.create_table('t15', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(50)]), expected_rows=50)
+
+        @pxt.query
+        def find_above(threshold: int) -> pxt.Query:
+            return t.where(t.a >= threshold).select(t.a)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                bound = find_above.template_query.bind({'threshold': 40})
+                rows = bound.collect()
+                assert len(rows) == 10
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
+    def test_snapshot_query_cross_thread(self, uses_db: None) -> None:
+        """T19: snapshot Query collected from workers. Snapshots take the
+        effective_version is not None branch in TableVersionHandle.get(); worth
+        direct coverage since the atomic-replace refactor changed that branch."""
+        t = pxt.create_table('t19_base', {'a': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i} for i in range(20)]), expected_rows=20)
+        s = pxt.create_snapshot('t19_snap', t)
+
+        q = s.where(s.a >= 10).select(s.a)
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                assert len(q.collect()) == 10
 
         errors = _run_workers(worker, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -106,6 +106,22 @@ class TestConcurrentOps:
         errors = _run_workers(worker2, n_threads=self.NUM_THREADS)
         assert errors == [], f'errors: {errors[:3]}'
 
+    def test_shared_query_extended(self, uses_db: None) -> None:
+        """A Query built on the main thread can be extended on a worker thread via builder methods."""
+        t = pxt.create_table('t_ext', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(100)]), expected_rows=100)
+        base = t.where(t.a >= 50).select(t.a, t.b)
+        a_ref = t.a
+
+        def worker(_tid: int) -> None:
+            for _ in range(self.ITERATIONS):
+                rows = base.order_by(a_ref).limit(10).collect()
+                assert len(rows) == 10
+                assert rows[0]['a'] == 50
+
+        errors = _run_workers(worker, n_threads=self.NUM_THREADS)
+        assert errors == [], f'errors: {errors[:3]}'
+
     def test_get_table(self, uses_db: None) -> None:
         t = pxt.create_table('t3', {'a': pxt.Required[pxt.Int]})
         validate_update_status(t.insert([{'a': i} for i in range(100)]), expected_rows=100)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1158,3 +1158,26 @@ class TestQuery:
             assert len(res) == row_count
 
         benchmark(select_inexpensive)
+
+    def test_query_after_column_drop(self, uses_db: None) -> None:
+        t = pxt.create_table('t_drop', {'a': pxt.Required[pxt.Int], 'b': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': i, 'b': i * 10} for i in range(10)]), expected_rows=10)
+        q = t.select(t.a, t.b)
+        assert len(q.collect()) == 10
+
+        t.drop_column('b')
+
+        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match='dropped'):
+            q.collect()
+
+    def test_query_after_column_drop_and_add(self, uses_db: None) -> None:
+        t = pxt.create_table('t_readd', {'a': pxt.Required[pxt.Int], 'keep': pxt.Required[pxt.Int]})
+        validate_update_status(t.insert([{'a': 1, 'keep': 0}]), expected_rows=1)
+        q = t.select(t.a)
+        assert len(q.collect()) == 1
+
+        t.drop_column('a')
+        t.add_column(a=pxt.String)
+
+        with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match='dropped'):
+            q.collect()


### PR DESCRIPTION
- Validate that Table public methods are called on the constructing thread; raise on cross-thread use
- Replace cached Column in ColumnRef with ColumnHandle indirection (re-resolves through catalog on every access; stale references after drop/re-add now raise instead of silently returning stale metadata)                                                                                                      
- Track origin thread + origin catalog on TableVersionHandle and TableVersionPath, with asserts to catch cross-thread/cross-catalog leaks; deepcopy resets thread-specific state                                                                                                                             
- Query defensively deepcopies on cross-catalog use; grouping table stored as a handle
- Add Runtime.context_inherited (set by copy_db_context) so ExecNode._thread_iter worker threads are sanctioned delegates and pass the origin-thread asserts                                                                                                                                                  
- Refactor object-store writes: caller thread resolves FileDestination from catalog, worker threads perform I/O without catalog access (new put_file_resolved/copy_local_file/move_local_file path)                                                                                                  
- ObjectOps.put_file and LocalStore/TempStore.save_media_object take primitives (tbl_id, col_id, tbl_version, col_name) instead of Column, decoupling the storage layer from catalog internals   