### PR TITLE
[PXT-1154] Invalidate cached TV version after acquiring write lock

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -676,6 +676,10 @@ class Catalog:
         if tbl_md.is_mutable:
             locked.add(row.id)
             conn.execute(sql.update(schema.Table).values(lock_dummy=1).where(where_clause))
+            # Invalidate the cached TableVersion to make sure we are acting on the latest version after locking.
+            cached_tv = self._tbl_versions.get(TableVersionKey(tbl_id, None, None))
+            if cached_tv is not None:
+                cached_tv.is_validated = False
 
         if check_pending_ops:
             # check for pending ops after getting table lock
@@ -2580,6 +2584,9 @@ class Catalog:
                         is_fragment=version_record.md['is_fragment'],
                         additional_md=version_record.md['additional_md'],
                     )
+                ), (
+                    'Table version already exists in store. Expected no change outside of is_fragment and'
+                    f' additional_md, but stored version md is {version_record.md} and new one is {version_md}'
                 )
                 result = session.execute(
                     sql.update(schema.TableVersion.__table__)


### PR DESCRIPTION
The problem is that `Catalog.create_view` calls `self._acquire_write_lock` inside of a retry loop and fails to invalidate the cached `TableVersion`. It then makes some writes based on a possibly outdated metadata, which in turn can result in a corruption, all despite despite the write lock being held on the table.

This bug is not detectable with `SERIALIZABLE` isolation thanks to read-write conflicts that force the offending transaction to retry, but `READ COMMITTED` that won't happen.