### PR TITLE
Allow deploying services defined in code

### DIFF
--- a/pixeltable/cli.py
+++ b/pixeltable/cli.py
@@ -53,8 +53,8 @@ Examples:
   pxt serve query --query myapp.queries.search_docs --path /search"""
 
 _EPILOG_DEPLOY = """\
-To deploy into the deployment `staging`:
-  pxt deploy staging
+To deploy a configured deployment:
+  pxt deploy <deployment-name>
 """
 
 
@@ -86,7 +86,7 @@ def main() -> None:
 
     deploy_parser = subparsers.add_parser(
         'deploy',
-        help='Deploy the services in the specified deployment to Pixeltable cloud.',
+        help='Deploy the service in the specified deployment configuration to Pixeltable cloud.',
         epilog=_EPILOG_DEPLOY,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/pixeltable/cli.py
+++ b/pixeltable/cli.py
@@ -53,7 +53,7 @@ Examples:
   pxt serve query --query myapp.queries.search_docs --path /search"""
 
 _EPILOG_DEPLOY = """\
-To deploy into the environment `staging`:
+To deploy into the deployment `staging`:
   pxt deploy staging
 """
 
@@ -86,11 +86,11 @@ def main() -> None:
 
     deploy_parser = subparsers.add_parser(
         'deploy',
-        help='Deploy the services in the specified environment to Pixeltable cloud.',
+        help='Deploy the services in the specified deployment to Pixeltable cloud.',
         epilog=_EPILOG_DEPLOY,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    deploy_parser.add_argument('env', help='Name of the target environment')
+    deploy_parser.add_argument('deployment', help='Name of the target deployment')
     deploy_parser.add_argument('--json', action='store_true', dest='json', help='Emit machine-readable JSON output')
 
     args = parser.parse_args()
@@ -270,7 +270,7 @@ def _add_serve_subparsers(serve_parser: argparse.ArgumentParser) -> None:
 
 
 def _deploy(args: argparse.Namespace) -> None:
-    deploy.build_deploy_bundle(args.env)
+    deploy.build_deploy_bundle(args.deployment)
 
 
 def _serve(args: argparse.Namespace) -> None:

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -139,7 +139,7 @@ class ServiceConfig(pydantic.BaseModel):
         return v
 
 
-class EnvironmentConfig(pydantic.BaseModel):
+class DeploymentConfig(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra='forbid')
 
     name: str
@@ -469,7 +469,7 @@ KNOWN_CONFIG_OPTIONS: dict[str, dict[str, Any]] = {
         'b2_profile': 'AWS config profile name used to access Backblaze B2 storage',
         'tigris_profile': 'AWS config profile name used to access Tigris object storage',
         'service': ('Service configurations', list[ServiceConfig]),
-        'environment': ('Environment configurations', list[EnvironmentConfig]),
+        'deployment': ('Deployment configurations', list[DeploymentConfig]),
     },
     'anthropic': {'api_key': 'Anthropic API key'},
     'azure': {'storage_account_name': 'Azure storage account name', 'storage_account_key': 'Azure storage account key'},

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -69,8 +69,11 @@ class RouteConfigBase(pydantic.BaseModel):
         return v
 
 
+# Right now, 'compute' simply functions as an alias for 'insert' (that is permitted by `pxt deploy`).
+# TODO: Implement a separate 'compute' operation (possibly still reusing `InsertRouteConfig`) once
+#     `Table.compute()` has been implemented.
 class InsertRouteConfig(RouteConfigBase):
-    type: Literal['insert']
+    type: Literal['compute', 'insert']
     table: str
     inputs: list[str] | None = None
     uploadfile_inputs: list[str] | None = None

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -143,11 +143,11 @@ class DeploymentConfig(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra='forbid')
 
     name: str
+    service: str
     include: list[str] | None = None
     exclude: list[str] | None = None
     env_dependencies: list[str] = pydantic.Field(default_factory=list)
     python_dependencies: list[str] = pydantic.Field(default_factory=list)
-    services: list[str] = pydantic.Field(default_factory=list)
 
     @pydantic.field_validator('name')
     @classmethod

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -122,6 +122,15 @@ class ServiceConfig(pydantic.BaseModel):
     routes: list[RouteConfig] = pydantic.Field(default_factory=list)
     modules: list[str] = pydantic.Field(default_factory=list)  # List of user modules to import
 
+    @pydantic.field_validator('name')
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        from pixeltable.catalog import is_valid_identifier
+
+        if not is_valid_identifier(v, allow_hyphens=True):
+            raise ValueError(f'{v!r} is not a valid Pixeltable identifier')
+        return v
+
     @pydantic.field_validator('prefix')
     @classmethod
     def _validate_prefix(cls, v: str) -> str:
@@ -139,6 +148,15 @@ class EnvironmentConfig(pydantic.BaseModel):
     env_dependencies: list[str] = pydantic.Field(default_factory=list)
     python_dependencies: list[str] = pydantic.Field(default_factory=list)
     services: list[str] = pydantic.Field(default_factory=list)
+
+    @pydantic.field_validator('name')
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        from pixeltable.catalog import is_valid_identifier
+
+        if not is_valid_identifier(v, allow_hyphens=True):
+            raise ValueError(f'{v!r} is not a valid Pixeltable identifier')
+        return v
 
 
 class Config:

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -144,6 +144,7 @@ class DeploymentConfig(pydantic.BaseModel):
 
     name: str
     service: str
+    env: str
     include: list[str] | None = None
     exclude: list[str] | None = None
     env_dependencies: list[str] = pydantic.Field(default_factory=list)

--- a/pixeltable/exceptions.py
+++ b/pixeltable/exceptions.py
@@ -42,7 +42,7 @@ class ErrorCode(enum.Enum):
     ROW_NOT_FOUND = 1006, 404, False
     STORAGE_NOT_FOUND = 1007, 404, False
     SERVICE_NOT_FOUND = 1008, 404, False
-    ENVIRONMENT_NOT_FOUND = 1009, 404, False
+    DEPLOYMENT_NOT_FOUND = 1009, 404, False
 
     # AlreadyExistsError (2xxx)
     COLUMN_ALREADY_EXISTS = 2000, 409, False

--- a/pixeltable/serving/_config.py
+++ b/pixeltable/serving/_config.py
@@ -70,7 +70,7 @@ def lookup_service_config(name: str) -> config.ServiceConfig:
 
 def lookup_deployment_config(name: str) -> config.DeploymentConfig:
     """Lookup a DeploymentConfig by name from the Pixeltable configuration."""
-    return _lookup_config('deployment', name, config.DeploymentConfig, excs.ErrorCode.ENVIRONMENT_NOT_FOUND)
+    return _lookup_config('deployment', name, config.DeploymentConfig, excs.ErrorCode.DEPLOYMENT_NOT_FOUND)
 
 
 def create_service_from_config(cfg: config.ServiceConfig) -> 'fastapi.FastAPI':

--- a/pixeltable/serving/_config.py
+++ b/pixeltable/serving/_config.py
@@ -68,9 +68,9 @@ def lookup_service_config(name: str) -> config.ServiceConfig:
     return _lookup_config('service', name, config.ServiceConfig, excs.ErrorCode.SERVICE_NOT_FOUND)
 
 
-def lookup_environment_config(name: str) -> config.EnvironmentConfig:
-    """Lookup an EnvironmentConfig by name from the Pixeltable configuration."""
-    return _lookup_config('environment', name, config.EnvironmentConfig, excs.ErrorCode.ENVIRONMENT_NOT_FOUND)
+def lookup_deployment_config(name: str) -> config.DeploymentConfig:
+    """Lookup a DeploymentConfig by name from the Pixeltable configuration."""
+    return _lookup_config('deployment', name, config.DeploymentConfig, excs.ErrorCode.ENVIRONMENT_NOT_FOUND)
 
 
 def create_service_from_config(cfg: config.ServiceConfig) -> 'fastapi.FastAPI':

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -92,6 +92,68 @@ def _run_endpoint_op(
         raise
 
 
+class PxtEndpoint:
+    """
+    Wrapper for an endpoint `Callable` that carries additional metadata about the endpoint operation.
+    """
+
+    router: 'FastAPIRouter'
+    name: str
+    signature: inspect.Signature
+    uploadfile_inputs: list[str]
+    executor: ThreadPoolExecutor | None
+    endpoint_op: Callable[..., Any]
+    tbl: pxt.Table | None
+
+    def __init__(
+        self,
+        router: 'FastAPIRouter',
+        name: str,
+        signature: inspect.Signature,
+        uploadfile_inputs: list[str],
+        background: bool,
+        endpoint_op: Callable[..., Any],
+        tbl: pxt.Table | None,
+    ) -> None:
+        self.router = router
+        self.name = name
+        self.signature = signature
+        self.uploadfile_inputs = uploadfile_inputs
+        self.background = background
+        self.endpoint_op = endpoint_op
+        self.tbl = tbl
+
+        # FastAPI needs the correct signature and a name
+        self.__signature__ = signature
+        self.__name__ = name
+
+    def __call__(self, request: Request, **kwargs: Any) -> Any:
+        sample_url = str(request.url_for(_MEDIA_ROUTE_NAME, path='_'))
+        media_url_base = sample_url[:-1]
+
+        def url_for_media(rel_path: str) -> str:
+            return f'{media_url_base}{urllib.parse.quote(rel_path, safe="/")}'
+
+        # write out uploads while the request is still alive
+        tmp_paths: list[Path] = []
+        if len(self.uploadfile_inputs) > 0:
+            # list(...): make sure that the sequence of name/val pairs can't change underneath us
+            for input_name, val in list(kwargs.items()):
+                if input_name in self.uploadfile_inputs:
+                    path = self.router._write_to_temp(val)
+                    tmp_paths.append(path)
+                    kwargs[input_name] = str(path)
+
+        if self.background:
+            job_id = uuid.uuid4().hex
+            fut = self.router._executor.submit(_run_endpoint_op, self.endpoint_op, kwargs, tmp_paths, url_for_media)
+            with self.router._jobs_lock:
+                self.router._jobs[job_id] = fut
+            return BackgroundJobResponse(id=job_id, job_url=str(request.url_for(_JOB_STATUS_ROUTE_NAME, job_id=job_id)))
+        else:
+            return _run_endpoint_op(self.endpoint_op, kwargs, tmp_paths, url_for_media)
+
+
 class FastAPIRouter(fastapi.APIRouter):
     """
     A FastAPI `APIRouter` that exposes Pixeltable table operations as HTTP endpoints.
@@ -807,12 +869,14 @@ class FastAPIRouter(fastapi.APIRouter):
         cols_by_name = {col.name: col for col in t._tbl_version_path.columns()}
         match_cols = [cols_by_name[name] for name in match_columns]
         sig = self._create_endpoint_signature(input_cols=match_cols)
-        endpoint = self._create_endpoint(
+        endpoint = PxtEndpoint(
+            self,
             f'delete_{path.strip("/").replace("/", "_") or "root"}',
             sig,
             uploadfile_inputs=[],
             background=background,
             endpoint_op=run_delete,
+            tbl=t,
         )
         self.add_api_route(path, endpoint, methods=['POST'], response_model=endpoint_model)
 
@@ -1042,12 +1106,14 @@ class FastAPIRouter(fastapi.APIRouter):
             is_post=(method == 'post'),
             defaults=input_defaults,
         )
-        endpoint = self._create_endpoint(
+        endpoint = PxtEndpoint(
+            self,
             f'query_{path.strip("/").replace("/", "_") or "root"}',
             sig,
             uploadfile_inputs=uploadfile_inputs,
             background=background,
             endpoint_op=run_query,
+            tbl=None,
         )
 
         api_kwargs: dict[str, Any] = {'methods': [method.upper()]}
@@ -1150,8 +1216,14 @@ class FastAPIRouter(fastapi.APIRouter):
             return row_processor(rows[0], url_for_media)
 
         sig = self._create_endpoint_signature(input_cols=pk_cols + input_cols, upload_col_names=uploadfile_inputs)
-        endpoint = self._create_endpoint(
-            endpoint_name, sig, uploadfile_inputs=uploadfile_inputs, background=background, endpoint_op=run_dml
+        endpoint = PxtEndpoint(
+            self,
+            endpoint_name,
+            sig,
+            uploadfile_inputs=uploadfile_inputs,
+            background=background,
+            endpoint_op=run_dml,
+            tbl=t,
         )
         api_kwargs: dict[str, Any] = {'methods': ['POST']}
         if background:
@@ -1161,6 +1233,7 @@ class FastAPIRouter(fastapi.APIRouter):
             api_kwargs['response_model'] = row_processor_model
         if return_fileresponse:
             api_kwargs['response_class'] = FileResponse
+
         self.add_api_route(path, endpoint, **api_kwargs)
 
     def _validate_decorated_fn(
@@ -1314,47 +1387,6 @@ class FastAPIRouter(fastapi.APIRouter):
             output_item_str='column',
         )
         return pk_col_names, input_col_names, output_col_names, cols_by_name
-
-    def _create_endpoint(
-        self,
-        name: str,
-        signature: inspect.Signature,
-        uploadfile_inputs: list[str],
-        background: bool,
-        endpoint_op: Callable,
-    ) -> Callable[..., Any]:
-        def endpoint(request: Request, **kwargs: Any) -> Any:
-            sample_url = str(request.url_for(_MEDIA_ROUTE_NAME, path='_'))
-            media_url_base = sample_url[:-1]
-
-            def url_for_media(rel_path: str) -> str:
-                return f'{media_url_base}{urllib.parse.quote(rel_path, safe="/")}'
-
-            # write out uploads while the request is still alive
-            tmp_paths: list[Path] = []
-            if len(uploadfile_inputs) > 0:
-                # list(...): make sure that the sequence of name/val pairs can't change underneath us
-                for input_name, val in list(kwargs.items()):
-                    if input_name in uploadfile_inputs:
-                        path = self._write_to_temp(val)
-                        tmp_paths.append(path)
-                        kwargs[input_name] = str(path)
-
-            if background:
-                job_id = uuid.uuid4().hex
-                fut = self._executor.submit(_run_endpoint_op, endpoint_op, kwargs, tmp_paths, url_for_media)
-                with self._jobs_lock:
-                    self._jobs[job_id] = fut
-                return BackgroundJobResponse(
-                    id=job_id, job_url=str(request.url_for(_JOB_STATUS_ROUTE_NAME, job_id=job_id))
-                )
-            else:
-                return _run_endpoint_op(endpoint_op, kwargs, tmp_paths, url_for_media)
-
-        # FastAPI needs the correct signature and a name
-        endpoint.__signature__ = signature  # type: ignore[attr-defined]
-        endpoint.__name__ = name
-        return endpoint
 
     def _validate_args(
         self,

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -101,7 +101,7 @@ class PxtEndpoint:
     name: str
     signature: inspect.Signature
     uploadfile_inputs: list[str]
-    executor: ThreadPoolExecutor | None
+    background: bool
     endpoint_op: Callable[..., Any]
     tbl: pxt.Table | None
 

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -98,8 +98,6 @@ class PxtEndpoint:
     """
 
     router: 'FastAPIRouter'
-    name: str
-    signature: inspect.Signature
     uploadfile_inputs: list[str]
     background: bool
     endpoint_op: Callable[..., Any]
@@ -118,8 +116,6 @@ class PxtEndpoint:
         route_type: Literal['insert', 'update', 'delete', 'query', 'compute'],
     ) -> None:
         self.router = router
-        self.name = name
-        self.signature = signature
         self.uploadfile_inputs = uploadfile_inputs
         self.background = background
         self.endpoint_op = endpoint_op
@@ -399,8 +395,8 @@ class FastAPIRouter(fastapi.APIRouter):
             outputs=outputs,
             return_fileresponse=return_fileresponse,
             background=background,
-            error_prefix='add_insert_route()',
-            is_update=False,
+            error_prefix=f'add_{route_type}_route()',
+            route_type=route_type,
         )
         uploadfile_inputs = uploadfile_inputs or []
         output_cols = [cols_by_name[name] for name in output_col_names]
@@ -409,7 +405,7 @@ class FastAPIRouter(fastapi.APIRouter):
             export_sql,
             return_fileresponse=return_fileresponse,
             schema={name: cols_by_name[name].col_type for name in output_col_names},
-            error_prefix='add_insert_route()',
+            error_prefix=f'add_{route_type}_route()',
         )
 
         # response model derived from output columns, named after the path
@@ -434,10 +430,9 @@ class FastAPIRouter(fastapi.APIRouter):
             uploadfile_inputs=uploadfile_inputs,
             return_fileresponse=return_fileresponse,
             background=background,
-            endpoint_name=f'insert_{path.strip("/").replace("/", "_") or "root"}',
+            endpoint_name=f'{route_type}_{path.strip("/").replace("/", "_") or "root"}',
             row_processor=row_processor,
             row_processor_model=insert_response_model,
-            is_update=False,
             route_type=route_type,
         )
 
@@ -608,8 +603,8 @@ class FastAPIRouter(fastapi.APIRouter):
             outputs=outputs,
             return_fileresponse=False,
             background=background,
-            error_prefix='insert_route()',
-            is_update=False,
+            error_prefix=f'{route_type}_route()',
+            route_type=route_type,
         )
         uploadfile_inputs = uploadfile_inputs or []
 
@@ -617,11 +612,11 @@ class FastAPIRouter(fastapi.APIRouter):
             response_model = self._validate_decorated_fn(
                 user_fn,
                 output_schema={col_name: cols_by_name[col_name].col_type for col_name in output_col_names},
-                error_prefix='insert_route()',
+                error_prefix=f'{route_type}_route()',
             )
 
             sql_exporter = self._make_model_sql_exporter(
-                export_sql, response_model=response_model, error_prefix='insert_route()'
+                export_sql, response_model=response_model, error_prefix=f'{route_type}_route()'
             )
 
             def row_processor(row: dict[str, Any], url_for_media: Callable[[str], str]) -> pydantic.BaseModel:
@@ -639,10 +634,9 @@ class FastAPIRouter(fastapi.APIRouter):
                 uploadfile_inputs=uploadfile_inputs,
                 return_fileresponse=False,
                 background=background,
-                endpoint_name=f'insert_{path.strip("/").replace("/", "_") or "root"}',
+                endpoint_name=f'{route_type}_{path.strip("/").replace("/", "_") or "root"}',
                 row_processor=row_processor,
                 row_processor_model=response_model,
-                is_update=False,
                 route_type=route_type,
             )
             return user_fn
@@ -1344,7 +1338,6 @@ class FastAPIRouter(fastapi.APIRouter):
         endpoint_name: str,
         row_processor: Callable[[dict[str, Any], Callable[[str], str]], Any],
         row_processor_model: type[pydantic.BaseModel] | None,
-        is_update: bool,
         route_type: Literal['insert', 'update', 'compute'],
     ) -> None:
         """Create endpoint for insert/update.
@@ -1369,7 +1362,7 @@ class FastAPIRouter(fastapi.APIRouter):
                     status_code=409,
                     detail='table schema changed since route was registered; please restart the service',
                 )
-            if is_update:
+            if route_type == 'update':
                 status = tbl.batch_update([row_kwargs], if_not_exists='ignore', return_rows=True)
                 if status.num_rows == 0:
                     raise HTTPException(status_code=404, detail='row not found')
@@ -1403,7 +1396,7 @@ class FastAPIRouter(fastapi.APIRouter):
         self.add_api_route(path, endpoint, **api_kwargs)
 
     def _validate_decorated_fn(
-        self, user_fn: Callable, *, output_schema: dict[str, ts.ColumnType], error_prefix: str = 'insert_route()'
+        self, user_fn: Callable, *, output_schema: dict[str, ts.ColumnType], error_prefix: str
     ) -> type[pydantic.BaseModel]:
         """Validate the decorated function of insert_/update_route(); return the resolved response model."""
         sig = inspect.signature(user_fn)
@@ -1488,12 +1481,12 @@ class FastAPIRouter(fastapi.APIRouter):
         return_fileresponse: bool,
         background: bool,
         error_prefix: str,
-        is_update: bool,
+        route_type: Literal['insert', 'update', 'compute'],
     ) -> tuple[list[str], list[str], list[str], dict[str, catalog.Column]]:
         """
         Validate insert-/update-route args. Returns (pk_col_names, input_col_names, output_col_names, cols_by_name).
         """
-        verb = 'update' if is_update else 'insert into'
+        verb = 'insert into' if route_type == 'insert' else route_type
         md = t.get_metadata()
         if md['kind'] != 'table':
             raise pxt.RequestError(
@@ -1507,7 +1500,7 @@ class FastAPIRouter(fastapi.APIRouter):
 
         col_md = md['columns']
         pk_col_names = [name for name, c in col_md.items() if c['is_primary_key']]
-        if is_update and not pk_col_names:
+        if route_type == 'update' and not pk_col_names:
             raise pxt.RequestError(pxt.ErrorCode.UNSUPPORTED_OPERATION, f'{error_prefix}: table has no primary key')
 
         cols_by_name = {col.name: col for col in t._tbl_version_path.columns()}
@@ -1522,14 +1515,14 @@ class FastAPIRouter(fastapi.APIRouter):
                 )
 
             # PK columns cannot be inputs for an update route
-            if is_update and name in pk_set:
+            if route_type == 'update' and name in pk_set:
                 raise pxt.RequestError(
                     pxt.ErrorCode.INVALID_ARGUMENT,
                     f'{error_prefix}: {name!r} is a primary key column and cannot be used as input',
                 )
 
             # media columns cannot be updated
-            if is_update and name in cols_by_name and cols_by_name[name].col_type.is_media_type():
+            if route_type == 'update' and name in cols_by_name and cols_by_name[name].col_type.is_media_type():
                 raise pxt.RequestError(
                     pxt.ErrorCode.UNSUPPORTED_OPERATION,
                     f'{error_prefix}: {name!r} is a media column and cannot be updated',
@@ -1539,7 +1532,7 @@ class FastAPIRouter(fastapi.APIRouter):
         input_schema = {
             c.name: c.col_type
             for c in cols_by_name.values()
-            if not c.is_computed and not (is_update and (c.name in pk_set or c.col_type.is_media_type()))
+            if not c.is_computed and not (route_type == 'update' and (c.name in pk_set or c.col_type.is_media_type()))
         }
         input_col_names, output_col_names = self._validate_args(
             input_schema=input_schema,

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -479,6 +479,8 @@ class FastAPIRouter(fastapi.APIRouter):
                 the insert plus post-processing in a background thread. Poll `job_url` for the
                 result; the decorated function's return value is delivered as the job result.
         """
+        # Right now this is just an alias for insert_route().
+        # TODO: Once Table.compute() is implemented, implement this method properly.
         return self._insert_route(
             t,
             path=path,
@@ -598,6 +600,7 @@ class FastAPIRouter(fastapi.APIRouter):
         background: bool,
         route_type: Literal['insert', 'compute'],
     ) -> Callable[[Callable[..., pydantic.BaseModel]], Callable[..., pydantic.BaseModel]]:
+        # TODO: This can be folded back into insert_route() once compute_route() is properly implemented.
         _, input_col_names, output_col_names, cols_by_name = self._validate_dml_args(
             t,
             inputs=inputs,

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -104,6 +104,7 @@ class PxtEndpoint:
     background: bool
     endpoint_op: Callable[..., Any]
     tbl: pxt.Table | None
+    route_type: Literal['insert', 'update', 'delete', 'query', 'compute']
 
     def __init__(
         self,
@@ -114,6 +115,7 @@ class PxtEndpoint:
         background: bool,
         endpoint_op: Callable[..., Any],
         tbl: pxt.Table | None,
+        route_type: Literal['insert', 'update', 'delete', 'query', 'compute'],
     ) -> None:
         self.router = router
         self.name = name
@@ -122,6 +124,7 @@ class PxtEndpoint:
         self.background = background
         self.endpoint_op = endpoint_op
         self.tbl = tbl
+        self.route_type = route_type
 
         # FastAPI needs the correct signature and a name
         self.__signature__ = signature
@@ -193,6 +196,52 @@ class FastAPIRouter(fastapi.APIRouter):
             eng = sql.create_engine(db_connect)
             self._engine_cache[db_connect] = eng
         return eng
+
+    def add_compute_route(
+        self,
+        t: pxt.Table,
+        *,
+        path: str,
+        inputs: list[str] | None = None,
+        uploadfile_inputs: list[str] | None = None,
+        outputs: list[str] | None = None,
+        return_fileresponse: bool = False,
+        export_sql: SqlExport | None = None,
+        background: bool = False,
+    ) -> None:
+        """
+        Add a POST endpoint that computes the workflow given by `t` and returns the resulting rows.
+
+        This is identical to [[`add_insert_route()`][pixeltable.serving.FastAPIRouter.add_insert_route]],
+        except that no data is actually inserted into the table.
+
+        Args:
+            t: The table to compute rows over.
+            path: The URL path for the endpoint.
+            inputs: Columns to accept as request fields. Defaults to all non-computed columns.
+            uploadfile_inputs: Columns to accept as
+                [`UploadFile`](https://fastapi.tiangolo.com/tutorial/request-files/) fields
+                (must be media-typed). These are sent as multipart form data; all other inputs
+                become [`Form`](https://fastapi.tiangolo.com/tutorial/request-forms/) fields.
+            outputs: Columns to include in the response. Defaults to all columns (including inputs).
+            return_fileresponse: If True, return the single media-typed output column as a
+                [`FileResponse`](https://fastapi.tiangolo.com/advanced/custom-response/#fileresponse).
+                Requires exactly one media-typed output column.
+            export_sql: If set, export each inserted row into an external RDBMS table after the
+                Pixeltable insert succeeds. See [`SqlExport`][pixeltable.serving.SqlExport] for
+                the target specification and supported `method` values.
+
+                See the [[`add_insert_route()`][pixeltable.serving.FastAPIRouter.add_insert_route]]
+                documentation for more details.
+            background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
+                the insert plus post-processing in a background thread. Poll `job_url` for the
+                result; the decorated function's return value is delivered as the job result.
+        """
+        # Right now this is just an alias for add_insert_route().
+        # TODO: Once Table.compute() is implemented, implement this method properly.
+        return self._add_insert_route(t, path=path, inputs=inputs, uploadfile_inputs=uploadfile_inputs, outputs=outputs,
+                                      return_fileresponse=return_fileresponse, export_sql=export_sql, background=background,
+                                      route_type='compute')
 
     def add_insert_route(
         self,
@@ -309,6 +358,24 @@ class FastAPIRouter(fastapi.APIRouter):
             # {"status": "done", "result": {...}}
             ```
         """
+        self._add_insert_route(t, path=path, inputs=inputs, uploadfile_inputs=uploadfile_inputs, outputs=outputs,
+                               return_fileresponse=return_fileresponse, export_sql=export_sql, background=background,
+                               route_type='insert')
+
+    def _add_insert_route(
+        self,
+        t: pxt.Table,
+        *,
+        path: str,
+        inputs: list[str] | None,
+        uploadfile_inputs: list[str] | None,
+        outputs: list[str] | None,
+        return_fileresponse: bool,
+        export_sql: SqlExport | None,
+        background: bool,
+        route_type: Literal['insert', 'compute']
+    ) -> None:
+        # TODO: This can be folded back into add_insert_route() once add_compute_route() is properly implemented.
         _, input_col_names, output_col_names, cols_by_name = self._validate_dml_args(
             t,
             inputs=inputs,
@@ -355,6 +422,56 @@ class FastAPIRouter(fastapi.APIRouter):
             row_processor=row_processor,
             row_processor_model=insert_response_model,
             is_update=False,
+            route_type=route_type,
+        )
+
+    def compute_route(
+        self,
+        t: pxt.Table,
+        *,
+        path: str,
+        inputs: list[str] | None = None,
+        uploadfile_inputs: list[str] | None = None,
+        outputs: list[str] | None = None,
+        export_sql: SqlExport | None = None,
+        background: bool = False,
+    ) -> Callable[[Callable[..., pydantic.BaseModel]], Callable[..., pydantic.BaseModel]]:
+        """
+        Decorator that registers a POST endpoint computing the workflow given by `t` and returning the resulting rows.
+
+        This is identical to [[`@insert_route`][pixeltable.serving.FastAPIRouter.insert_route]],
+        except that no data is actually inserted into the table.
+
+        Args:
+            t: The table to compute rows over.
+            path: The URL path for the endpoint.
+            inputs: Columns to accept as request fields. Defaults to all non-computed columns.
+            uploadfile_inputs: Columns to accept as
+                [`UploadFile`](https://fastapi.tiangolo.com/tutorial/request-files/) fields
+                (must be media-typed). These are sent as multipart form data; all other inputs
+                become [`Form`](https://fastapi.tiangolo.com/tutorial/request-forms/) fields.
+            outputs: Columns from the inserted row to pass to the decorated function as keyword
+                arguments. Defaults to all columns.
+            export_sql: If set, export the decorated function's return value into an external
+                RDBMS table after the Pixeltable insert succeeds. See
+                [`SqlExport`][pixeltable.serving.SqlExport] for the target specification and
+                supported `method` values.
+
+                See the [[`@insert_route`][pixeltable.serving.FastAPIRouter.insert_route]] documentation for more
+                details.
+            background: If True, return immediately with `{"id": ..., "job_url": ...}` and run
+                the insert plus post-processing in a background thread. Poll `job_url` for the
+                result; the decorated function's return value is delivered as the job result.
+        """
+        return self._insert_route(
+            t,
+            path=path,
+            inputs=inputs,
+            uploadfile_inputs=uploadfile_inputs,
+            outputs=outputs,
+            export_sql=export_sql,
+            background=background,
+            route_type='compute',
         )
 
     def insert_route(
@@ -442,6 +559,29 @@ class FastAPIRouter(fastapi.APIRouter):
             Each successful POST inserts a row into the Pixeltable table and then appends a row
             with columns `caption`, `score` (the response model fields) to `captions`.
         """
+        return self._insert_route(
+            t,
+            path=path,
+            inputs=inputs,
+            uploadfile_inputs=uploadfile_inputs,
+            outputs=outputs,
+            export_sql=export_sql,
+            background=background,
+            route_type='insert',
+        )
+
+    def _insert_route(
+        self,
+        t: pxt.Table,
+        *,
+        path: str,
+        inputs: list[str] | None,
+        uploadfile_inputs: list[str] | None,
+        outputs: list[str] | None,
+        export_sql: SqlExport | None,
+        background: bool,
+        route_type: Literal['insert', 'compute'],
+    ) -> Callable[[Callable[..., pydantic.BaseModel]], Callable[..., pydantic.BaseModel]]:
         _, input_col_names, output_col_names, cols_by_name = self._validate_dml_args(
             t,
             inputs=inputs,
@@ -484,6 +624,7 @@ class FastAPIRouter(fastapi.APIRouter):
                 row_processor=row_processor,
                 row_processor_model=response_model,
                 is_update=False,
+                route_type=route_type,
             )
             return user_fn
 
@@ -632,6 +773,7 @@ class FastAPIRouter(fastapi.APIRouter):
             row_processor=row_processor,
             row_processor_model=update_response_model,
             is_update=True,
+            route_type='update',
         )
 
     def update_route(
@@ -785,6 +927,7 @@ class FastAPIRouter(fastapi.APIRouter):
                 row_processor=row_processor,
                 row_processor_model=response_model,
                 is_update=True,
+                route_type='update',
             )
             return user_fn
 
@@ -877,6 +1020,7 @@ class FastAPIRouter(fastapi.APIRouter):
             background=background,
             endpoint_op=run_delete,
             tbl=t,
+            route_type='delete',
         )
         self.add_api_route(path, endpoint, methods=['POST'], response_model=endpoint_model)
 
@@ -1114,6 +1258,7 @@ class FastAPIRouter(fastapi.APIRouter):
             background=background,
             endpoint_op=run_query,
             tbl=None,
+            route_type='query',
         )
 
         api_kwargs: dict[str, Any] = {'methods': [method.upper()]}
@@ -1181,6 +1326,7 @@ class FastAPIRouter(fastapi.APIRouter):
         row_processor: Callable[[dict[str, Any], Callable[[str], str]], Any],
         row_processor_model: type[pydantic.BaseModel] | None,
         is_update: bool,
+        route_type: Literal['insert', 'update', 'compute'],
     ) -> None:
         """Create endpoint for insert/update.
 
@@ -1224,6 +1370,7 @@ class FastAPIRouter(fastapi.APIRouter):
             background=background,
             endpoint_op=run_dml,
             tbl=t,
+            route_type=route_type,
         )
         api_kwargs: dict[str, Any] = {'methods': ['POST']}
         if background:

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -750,7 +750,7 @@ class FastAPIRouter(fastapi.APIRouter):
             return_fileresponse=return_fileresponse,
             background=background,
             error_prefix='add_update_route()',
-            is_update=True,
+            route_type='update',
         )
         output_cols = [cols_by_name[name] for name in output_col_names]
 
@@ -785,7 +785,6 @@ class FastAPIRouter(fastapi.APIRouter):
             endpoint_name=f'update_{path.strip("/").replace("/", "_") or "root"}',
             row_processor=row_processor,
             row_processor_model=update_response_model,
-            is_update=True,
             route_type='update',
         )
 
@@ -907,7 +906,7 @@ class FastAPIRouter(fastapi.APIRouter):
             return_fileresponse=False,
             background=background,
             error_prefix='update_route()',
-            is_update=True,
+            route_type='update',
         )
 
         def decorator(user_fn: Callable[..., pydantic.BaseModel]) -> Callable[..., pydantic.BaseModel]:
@@ -939,7 +938,6 @@ class FastAPIRouter(fastapi.APIRouter):
                 endpoint_name=f'update_{path.strip("/").replace("/", "_") or "root"}',
                 row_processor=row_processor,
                 row_processor_model=response_model,
-                is_update=True,
                 route_type='update',
             )
             return user_fn

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -239,9 +239,17 @@ class FastAPIRouter(fastapi.APIRouter):
         """
         # Right now this is just an alias for add_insert_route().
         # TODO: Once Table.compute() is implemented, implement this method properly.
-        return self._add_insert_route(t, path=path, inputs=inputs, uploadfile_inputs=uploadfile_inputs, outputs=outputs,
-                                      return_fileresponse=return_fileresponse, export_sql=export_sql, background=background,
-                                      route_type='compute')
+        return self._add_insert_route(
+            t,
+            path=path,
+            inputs=inputs,
+            uploadfile_inputs=uploadfile_inputs,
+            outputs=outputs,
+            return_fileresponse=return_fileresponse,
+            export_sql=export_sql,
+            background=background,
+            route_type='compute',
+        )
 
     def add_insert_route(
         self,
@@ -358,9 +366,17 @@ class FastAPIRouter(fastapi.APIRouter):
             # {"status": "done", "result": {...}}
             ```
         """
-        self._add_insert_route(t, path=path, inputs=inputs, uploadfile_inputs=uploadfile_inputs, outputs=outputs,
-                               return_fileresponse=return_fileresponse, export_sql=export_sql, background=background,
-                               route_type='insert')
+        self._add_insert_route(
+            t,
+            path=path,
+            inputs=inputs,
+            uploadfile_inputs=uploadfile_inputs,
+            outputs=outputs,
+            return_fileresponse=return_fileresponse,
+            export_sql=export_sql,
+            background=background,
+            route_type='insert',
+        )
 
     def _add_insert_route(
         self,
@@ -373,7 +389,7 @@ class FastAPIRouter(fastapi.APIRouter):
         return_fileresponse: bool,
         export_sql: SqlExport | None,
         background: bool,
-        route_type: Literal['insert', 'compute']
+        route_type: Literal['insert', 'compute'],
     ) -> None:
         # TODO: This can be folded back into add_insert_route() once add_compute_route() is properly implemented.
         _, input_col_names, output_col_names, cols_by_name = self._validate_dml_args(

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -95,8 +95,12 @@ def _process_services(cfg: config.EnvironmentConfig) -> tuple[list[config.Servic
 
 
 def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str) -> set[str]:
-    """Given a "module:attribute" reference to a FastAPI app, import the module and inspect the app's routes to find
-    all tables mentioned by any insert routes."""
+    """
+    Given a "module:attribute" reference to a FastAPI app, import the module and inspect the app's routes to find
+    all tables mentioned by any compute routes.
+
+    Validate the config to ensure there are no non-compute routes and that all routes refer to valid FastAPI apps.
+    """
     from fastapi import FastAPI
     from starlette.routing import Route
 

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -227,7 +227,7 @@ def package(
     """Bundle the contents of a Pixeltable project directory into a tarball.
 
     Args:
-        deployment_config: Environment configuration.
+        deployment_config: Deployment configuration.
         config_export: The deployment and service configuration to include in the bundle, as a dict.
         md_export: The table metadata to include in the bundle, as a dict.
         conda_export: Output of `conda env export --no-builds`, included as `conda-env.yml`

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import tarfile
 import tempfile
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -12,10 +13,11 @@ import toml
 from pathspec import PathSpec
 
 import pixeltable as pxt
-from pixeltable import config, metadata
+from pixeltable import config, exceptions as excs, metadata
 from pixeltable.env import Env
 from pixeltable.runtime import get_runtime
 from pixeltable.serving._config import lookup_environment_config, lookup_service_config
+from pixeltable.serving._fastapi import PxtEndpoint
 
 _logger = logging.getLogger('pixeltable')
 
@@ -27,22 +29,23 @@ def build_deploy_bundle(environment_name: str) -> Path:
     - catalog metadata for any relevant tables
     - environment and service configuration
     """
+    Env.get().require_package('fastapi')
 
     cfg = lookup_environment_config(environment_name)
     Env.get().console_logger.info(f'Deploying {environment_name!r} ...')
-    services_cfg = [lookup_service_config(name) for name in cfg.services]
-    if len(services_cfg) == 0:
+
+    # Process the list of services, validating them and collecting their configs and table MD.
+    services_cfg, md_export = _process_services(cfg)
+
+    if len(cfg.services) == 0:
         Env.get().console_logger.warning('That environment contains no services.')
     else:
-        Env.get().console_logger.info(
-            f'The following service(s) will be deployed: {", ".join(service.name for service in services_cfg)}'
-        )
+        Env.get().console_logger.info(f'The following service(s) will be deployed: {", ".join(cfg.services)}')
 
     config_export = {
         'environment': [cfg.model_dump(mode='json')],
         'service': [service.model_dump(mode='json') for service in services_cfg],
     }
-    md_export = _export_tables_md(services_cfg)
     conda_export = _export_conda_env()
     lockfile = _find_lockfile()
     if conda_export is None and len(cfg.env_dependencies) == 0:
@@ -58,6 +61,70 @@ def build_deploy_bundle(environment_name: str) -> Path:
     bundle_path = package(cfg, config_export=config_export, md_export=md_export, conda_export=conda_export)
     Env.get().console_logger.info(f'Built project bundle: {bundle_path}')
     return bundle_path
+
+
+def _process_services(cfg: config.EnvironmentConfig) -> tuple[list[config.ServiceConfig], dict[str, Any]]:
+    """
+    Validate the services listed in the environment config.
+
+    Returns: (list of service configs, table md export)
+    """
+    services_cfg: list[config.ServiceConfig] = []
+    table_paths: set[str] = set()
+    for service_name in cfg.services:
+        if ':' in service_name:
+            # "module:attribute" references a service defined as a FastAPI app in user code.
+            paths = _tables_from_fastapi_app(cfg, service_name)
+            table_paths.update(paths)
+        else:
+            # Otherwise, it references a service defined in config.
+            service_cfg = lookup_service_config(service_name)
+            for route in service_cfg.routes:
+                # Query routes are only supported for cloud-hosted tables (not implemented yet)
+                # TODO: we should catch this upstream to prevent users from trying to deploy unsupported configurations
+                assert not isinstance(route, config.QueryRouteConfig)
+                table_paths.add(route.table)
+            services_cfg.append(service_cfg)
+            _logger.info(f'Validated service {service_name!r} with {len(service_cfg.routes)} route(s).')
+
+    md_export = _export_tables_md(table_paths)
+    return services_cfg, md_export
+
+
+def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str) -> set[str]:
+    """Given a "module:attribute" reference to a FastAPI app, import the module and inspect the app's routes to find
+    all tables mentioned by any insert routes."""
+    from fastapi import FastAPI
+    from starlette.routing import Route
+
+    module_path, attr_name = module_attr.split(':', 1)
+    try:
+        module = import_module(module_path)
+    except Exception as e:
+        raise excs.RequestError(
+            excs.ErrorCode.INVALID_CONFIGURATION,
+            f'Could not import module `{module_path}` referenced in environment {env_cfg.name!r}: {e}',
+        ) from e
+    if not hasattr(module, attr_name):
+        raise excs.RequestError(
+            excs.ErrorCode.INVALID_CONFIGURATION,
+            f'Module `{module_path}` referenced in environment {env_cfg.name!r} has no attribute `{attr_name}`',
+        )
+    app = getattr(module, attr_name)
+    if not isinstance(app, FastAPI):
+        raise excs.RequestError(
+            excs.ErrorCode.INVALID_CONFIGURATION,
+            f'Service `{module_attr}` referenced in environment {env_cfg.name!r} is not a FastAPI app',
+        )
+    table_paths: set[str] = set()
+    for route in app.routes:
+        if isinstance(route, Route) and isinstance(route.endpoint, PxtEndpoint):
+            table_paths.add(route.endpoint.tbl._path())
+
+    _logger.info(
+        f'Validated service {module_attr!r} with {len(table_paths)} table(s) referenced by {len(app.routes)} route(s).'
+    )
+    return table_paths
 
 
 def _resolve_patterns(project_dir: Path, patterns: list[str]) -> set[Path]:
@@ -86,15 +153,8 @@ def _collect_project_files(project_dir: Path, include: list[str] | None, exclude
     return sorted(files)
 
 
-def _export_tables_md(services_cfg: list[config.ServiceConfig]) -> dict[str, Any]:
+def _export_tables_md(table_paths: set[str]) -> dict[str, Any]:
     # Get all tables mentioned by any route contained in this environment.
-    table_paths: set[str] = set()
-    for service in services_cfg:
-        for route in service.routes:
-            # Query routes are only supported for cloud-hosted tables (not implemented yet)
-            # TODO: we should catch this upstream to prevent users from trying to deploy unsupported configurations
-            assert not isinstance(route, config.QueryRouteConfig)
-            table_paths.add(route.table)
     tables = [pxt.get_table(path) for path in sorted(table_paths)]
 
     # Get the md for all ancestors of all such tables.

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -83,7 +83,7 @@ def _process_services(cfg: config.EnvironmentConfig) -> tuple[list[config.Servic
                     raise excs.RequestError(
                         excs.ErrorCode.INVALID_CONFIGURATION,
                         f'Service {service_name!r} referenced in environment {cfg.name!r} has a route {route.path!r} '
-                        f"of type {route.type!r}. Currently, only 'compute' routes are supported for deployment."
+                        f"of type {route.type!r}. Currently, only 'compute' routes are supported for deployment.",
                     )
                 assert isinstance(route, config.InsertRouteConfig)
                 table_paths.add(route.table)
@@ -128,7 +128,8 @@ def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str
                 raise excs.RequestError(
                     excs.ErrorCode.INVALID_CONFIGURATION,
                     f'Service `{module_attr}` referenced in environment {env_cfg.name!r} has a route {route.path!r} '
-                    f"of type {route.endpoint.route_type!r}. Currently, only 'compute' routes are supported for deployment."
+                    f"of type {route.endpoint.route_type!r}. Currently, only 'compute' routes are supported for "
+                    'deployment.',
                 )
             assert route.endpoint.tbl is not None  # It's always non-None for 'compute' routes
             table_paths.add(route.endpoint.tbl._path())

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -40,7 +40,7 @@ def build_deploy_bundle(deployment_name: str) -> Path:
 
     config_export = {'deployment': [cfg.model_dump(mode='json')]}
     if service_cfg is not None:
-        config_export.update({'service': [service_cfg.model_dump(mode='json')]})
+        config_export['service'] = [service_cfg.model_dump(mode='json')]
     conda_export = _export_conda_env()
     lockfile = _find_lockfile()
 

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -54,7 +54,7 @@ def build_deploy_bundle(deployment_name: str) -> Path:
             'No dependency lockfile was found and no Python dependencies are specified in config.\n'
             'The deployment may not have the necessary dependencies to run correctly.'
         )
-        
+
     bundle_path = package(cfg, config_export=config_export, md_export=md_export, conda_export=conda_export)
     Env.get().console_logger.info(f'Built project bundle: {bundle_path}')
     return bundle_path

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -16,40 +16,40 @@ import pixeltable as pxt
 from pixeltable import config, exceptions as excs, metadata
 from pixeltable.env import Env
 from pixeltable.runtime import get_runtime
-from pixeltable.serving._config import lookup_environment_config, lookup_service_config
+from pixeltable.serving._config import lookup_deployment_config, lookup_service_config
 
 _logger = logging.getLogger('pixeltable')
 
 
-def build_deploy_bundle(environment_name: str) -> Path:
+def build_deploy_bundle(deployment_name: str) -> Path:
     """
-    Packages the current Pixeltable projecti into a tarball, along with details of the environment:
+    Packages the current Pixeltable project into a tarball, along with:
     - conda environment, if present
     - catalog metadata for any relevant tables
-    - environment and service configuration
+    - deployment and service configuration
     """
     Env.get().require_package('fastapi')
 
-    cfg = lookup_environment_config(environment_name)
-    Env.get().console_logger.info(f'Deploying {environment_name!r} ...')
+    cfg = lookup_deployment_config(deployment_name)
+    Env.get().console_logger.info(f'Deploying {deployment_name!r} ...')
 
     # Process the list of services, validating them and collecting their configs and table MD.
     services_cfg, md_export = _process_services(cfg)
 
     if len(cfg.services) == 0:
-        Env.get().console_logger.warning('That environment contains no services.')
+        Env.get().console_logger.warning('That deployment contains no services.')
     else:
         Env.get().console_logger.info(f'The following service(s) will be deployed: {", ".join(cfg.services)}')
 
     config_export = {
-        'environment': [cfg.model_dump(mode='json')],
+        'deployment': [cfg.model_dump(mode='json')],
         'service': [service.model_dump(mode='json') for service in services_cfg],
     }
     conda_export = _export_conda_env()
     lockfile = _find_lockfile()
     if conda_export is None and len(cfg.env_dependencies) == 0:
         Env.get().console_logger.warning(
-            'No conda environment was detected and no environment dependencies are specified in config.\n'
+            'No conda environment was detected and no dependencies are specified in config.\n'
             'The deployment may not have the necessary dependencies to run correctly.'
         )
     if lockfile is None and len(cfg.python_dependencies) == 0:
@@ -62,9 +62,9 @@ def build_deploy_bundle(environment_name: str) -> Path:
     return bundle_path
 
 
-def _process_services(cfg: config.EnvironmentConfig) -> tuple[list[config.ServiceConfig], dict[str, Any]]:
+def _process_services(cfg: config.DeploymentConfig) -> tuple[list[config.ServiceConfig], dict[str, Any]]:
     """
-    Validate the services listed in the environment config.
+    Validate the services listed in the deployment config.
 
     Returns: (list of service configs, table md export)
     """
@@ -82,7 +82,7 @@ def _process_services(cfg: config.EnvironmentConfig) -> tuple[list[config.Servic
                 if route.type != 'compute':
                     raise excs.RequestError(
                         excs.ErrorCode.INVALID_CONFIGURATION,
-                        f'Service {service_name!r} referenced in environment {cfg.name!r} has a route {route.path!r} '
+                        f'Service {service_name!r} referenced in deployment {cfg.name!r} has a route {route.path!r} '
                         f"of type {route.type!r}. Currently, only 'compute' routes are supported for deployment.",
                     )
                 assert isinstance(route, config.InsertRouteConfig)
@@ -94,7 +94,7 @@ def _process_services(cfg: config.EnvironmentConfig) -> tuple[list[config.Servic
     return services_cfg, md_export
 
 
-def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str) -> set[str]:
+def _tables_from_fastapi_app(env_cfg: config.DeploymentConfig, module_attr: str) -> set[str]:
     """
     Given a "module:attribute" reference to a FastAPI app, import the module and inspect the app's routes to find
     all tables mentioned by any compute routes.
@@ -112,18 +112,18 @@ def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str
     except Exception as e:
         raise excs.RequestError(
             excs.ErrorCode.INVALID_CONFIGURATION,
-            f'Could not import module `{module_path}` referenced in environment {env_cfg.name!r}: {e}',
+            f'Could not import module `{module_path}` referenced in deployment {env_cfg.name!r}: {e}',
         ) from e
     if not hasattr(module, attr_name):
         raise excs.RequestError(
             excs.ErrorCode.INVALID_CONFIGURATION,
-            f'Module `{module_path}` referenced in environment {env_cfg.name!r} has no attribute `{attr_name}`',
+            f'Module `{module_path}` referenced in deployment {env_cfg.name!r} has no attribute `{attr_name}`',
         )
     app = getattr(module, attr_name)
     if not isinstance(app, FastAPI):
         raise excs.RequestError(
             excs.ErrorCode.INVALID_CONFIGURATION,
-            f'Service `{module_attr}` referenced in environment {env_cfg.name!r} is not a FastAPI app',
+            f'Service `{module_attr}` referenced in deployment {env_cfg.name!r} is not a FastAPI app',
         )
     table_paths: set[str] = set()
     for route in app.routes:
@@ -131,7 +131,7 @@ def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str
             if route.endpoint.route_type != 'compute':
                 raise excs.RequestError(
                     excs.ErrorCode.INVALID_CONFIGURATION,
-                    f'Service `{module_attr}` referenced in environment {env_cfg.name!r} has a route {route.path!r} '
+                    f'Service `{module_attr}` referenced in deployment {env_cfg.name!r} has a route {route.path!r} '
                     f"of type {route.endpoint.route_type!r}. Currently, only 'compute' routes are supported for "
                     'deployment.',
                 )
@@ -171,7 +171,7 @@ def _collect_project_files(project_dir: Path, include: list[str] | None, exclude
 
 
 def _export_tables_md(table_paths: set[str]) -> dict[str, Any]:
-    # Get all tables mentioned by any route contained in this environment.
+    # Get all tables mentioned by any route contained in this deployment.
     tables = [pxt.get_table(path) for path in sorted(table_paths)]
 
     # Get the md for all ancestors of all such tables.
@@ -221,7 +221,7 @@ def _find_lockfile() -> Path | None:
 
 
 def package(
-    env_config: config.EnvironmentConfig,
+    deployment_config: config.DeploymentConfig,
     config_export: dict[str, Any],
     md_export: dict[str, Any],
     conda_export: bytes | None = None,
@@ -230,8 +230,8 @@ def package(
     """Bundle the contents of a Pixeltable project directory into a tarball.
 
     Args:
-        env_config: Environment configuration.
-        config_export: The environment and service configuration to include in the bundle, as a dict.
+        deployment_config: Environment configuration.
+        config_export: The deployment and service configuration to include in the bundle, as a dict.
         md_export: The table metadata to include in the bundle, as a dict.
         conda_export: Output of `conda env export --no-builds`, included as `conda-env.yml`
             in the bundle when provided.
@@ -252,7 +252,7 @@ def package(
     os.close(fd)
     bundle_path = Path(name)
 
-    files = _collect_project_files(project_dir, env_config.include, env_config.exclude)
+    files = _collect_project_files(project_dir, deployment_config.include, deployment_config.exclude)
     with tarfile.open(bundle_path, 'w:bz2') as tf:
         __add_tarfile(tf, 'config.toml', toml.dumps(config_export).encode('utf-8'))
         __add_tarfile(tf, 'metadata.json', json.dumps(md_export).encode('utf-8'))

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -79,9 +79,13 @@ def _process_services(cfg: config.EnvironmentConfig) -> tuple[list[config.Servic
             # Otherwise, it references a service defined in config.
             service_cfg = lookup_service_config(service_name)
             for route in service_cfg.routes:
-                # Query routes are only supported for cloud-hosted tables (not implemented yet)
-                # TODO: we should catch this upstream to prevent users from trying to deploy unsupported configurations
-                assert not isinstance(route, config.QueryRouteConfig)
+                if route.type != 'compute':
+                    raise excs.RequestError(
+                        excs.ErrorCode.INVALID_CONFIGURATION,
+                        f'Service {service_name!r} referenced in environment {cfg.name!r} has a route {route.path!r} '
+                        f"of type {route.type!r}. Currently, only 'compute' routes are supported for deployment."
+                    )
+                assert isinstance(route, config.InsertRouteConfig)
                 table_paths.add(route.table)
             services_cfg.append(service_cfg)
             _logger.info(f'Validated service {service_name!r} with {len(service_cfg.routes)} route(s).')
@@ -120,7 +124,13 @@ def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str
     table_paths: set[str] = set()
     for route in app.routes:
         if isinstance(route, Route) and isinstance(route.endpoint, PxtEndpoint):
-            assert route.endpoint.tbl is not None  # It's only None for Query routes
+            if route.endpoint.route_type != 'compute':
+                raise excs.RequestError(
+                    excs.ErrorCode.INVALID_CONFIGURATION,
+                    f'Service `{module_attr}` referenced in environment {env_cfg.name!r} has a route {route.path!r} '
+                    f"of type {route.endpoint.route_type!r}. Currently, only 'compute' routes are supported for deployment."
+                )
+            assert route.endpoint.tbl is not None  # It's always non-None for 'compute' routes
             table_paths.add(route.endpoint.tbl._path())
 
     _logger.info(

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -17,7 +17,6 @@ from pixeltable import config, exceptions as excs, metadata
 from pixeltable.env import Env
 from pixeltable.runtime import get_runtime
 from pixeltable.serving._config import lookup_environment_config, lookup_service_config
-from pixeltable.serving._fastapi import PxtEndpoint
 
 _logger = logging.getLogger('pixeltable')
 
@@ -96,6 +95,8 @@ def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str
     all tables mentioned by any insert routes."""
     from fastapi import FastAPI
     from starlette.routing import Route
+
+    from pixeltable.serving._fastapi import PxtEndpoint
 
     module_path, attr_name = module_attr.split(':', 1)
     try:

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -119,6 +119,7 @@ def _tables_from_fastapi_app(env_cfg: config.EnvironmentConfig, module_attr: str
     table_paths: set[str] = set()
     for route in app.routes:
         if isinstance(route, Route) and isinstance(route.endpoint, PxtEndpoint):
+            assert route.endpoint.tbl is not None  # It's only None for Query routes
             table_paths.add(route.endpoint.tbl._path())
 
     _logger.info(

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -33,20 +33,17 @@ def build_deploy_bundle(deployment_name: str) -> Path:
     cfg = lookup_deployment_config(deployment_name)
     Env.get().console_logger.info(f'Deploying {deployment_name!r} ...')
 
-    # Process the list of services, validating them and collecting their configs and table MD.
-    services_cfg, md_export = _process_services(cfg)
+    # Process the service, validating it and collecting its config and table MD.
+    service_cfg, md_export = _process_service(cfg)
 
-    if len(cfg.services) == 0:
-        Env.get().console_logger.warning('That deployment contains no services.')
-    else:
-        Env.get().console_logger.info(f'The following service(s) will be deployed: {", ".join(cfg.services)}')
+    Env.get().console_logger.info(f'The following service will be deployed: {cfg.service}')
 
-    config_export = {
-        'deployment': [cfg.model_dump(mode='json')],
-        'service': [service.model_dump(mode='json') for service in services_cfg],
-    }
+    config_export = {'deployment': [cfg.model_dump(mode='json')]}
+    if service_cfg is not None:
+        config_export.update({'service': [service_cfg.model_dump(mode='json')]})
     conda_export = _export_conda_env()
     lockfile = _find_lockfile()
+
     if conda_export is None and len(cfg.env_dependencies) == 0:
         Env.get().console_logger.warning(
             'No conda environment was detected and no dependencies are specified in config.\n'
@@ -57,41 +54,41 @@ def build_deploy_bundle(deployment_name: str) -> Path:
             'No dependency lockfile was found and no Python dependencies are specified in config.\n'
             'The deployment may not have the necessary dependencies to run correctly.'
         )
+        
     bundle_path = package(cfg, config_export=config_export, md_export=md_export, conda_export=conda_export)
     Env.get().console_logger.info(f'Built project bundle: {bundle_path}')
     return bundle_path
 
 
-def _process_services(cfg: config.DeploymentConfig) -> tuple[list[config.ServiceConfig], dict[str, Any]]:
+def _process_service(cfg: config.DeploymentConfig) -> tuple[config.ServiceConfig | None, dict[str, Any]]:
     """
-    Validate the services listed in the deployment config.
+    Validate the service referenced by the deployment config.
 
-    Returns: (list of service configs, table md export)
+    Returns: (service config, table md export)
     """
-    services_cfg: list[config.ServiceConfig] = []
+    service_cfg: config.ServiceConfig | None = None
     table_paths: set[str] = set()
-    for service_name in cfg.services:
-        if ':' in service_name:
-            # "module:attribute" references a service defined as a FastAPI app in user code.
-            paths = _tables_from_fastapi_app(cfg, service_name)
-            table_paths.update(paths)
-        else:
-            # Otherwise, it references a service defined in config.
-            service_cfg = lookup_service_config(service_name)
-            for route in service_cfg.routes:
-                if route.type != 'compute':
-                    raise excs.RequestError(
-                        excs.ErrorCode.INVALID_CONFIGURATION,
-                        f'Service {service_name!r} referenced in deployment {cfg.name!r} has a route {route.path!r} '
-                        f"of type {route.type!r}. Currently, only 'compute' routes are supported for deployment.",
-                    )
-                assert isinstance(route, config.InsertRouteConfig)
-                table_paths.add(route.table)
-            services_cfg.append(service_cfg)
-            _logger.info(f'Validated service {service_name!r} with {len(service_cfg.routes)} route(s).')
+    service_name = cfg.service
+    if ':' in service_name:
+        # "module:attribute" references a service defined as a FastAPI app in user code.
+        paths = _tables_from_fastapi_app(cfg, service_name)
+        table_paths.update(paths)
+    else:
+        # Otherwise, it references a service defined in config.
+        service_cfg = lookup_service_config(service_name)
+        for route in service_cfg.routes:
+            if route.type != 'compute':
+                raise excs.RequestError(
+                    excs.ErrorCode.INVALID_CONFIGURATION,
+                    f'Service {service_name!r} referenced in deployment {cfg.name!r} has a route {route.path!r} '
+                    f"of type {route.type!r}. Currently, only 'compute' routes are supported for deployment.",
+                )
+            assert isinstance(route, config.InsertRouteConfig)
+            table_paths.add(route.table)
+        _logger.info(f'Validated service {service_name!r} with {len(service_cfg.routes)} route(s).')
 
     md_export = _export_tables_md(table_paths)
-    return services_cfg, md_export
+    return service_cfg, md_export
 
 
 def _tables_from_fastapi_app(env_cfg: config.DeploymentConfig, module_attr: str) -> set[str]:

--- a/tests/serving/test_config.py
+++ b/tests/serving/test_config.py
@@ -253,6 +253,7 @@ class TestConfig:
         cases.append(
             ({'service': [{'name': 'test-service'}, {'name': 'test-service'}]}, 'Duplicate `ServiceConfig` name')
         )
+        cases.append(({'service': [{'name': '123bad'}]}, 'not a valid Pixeltable identifier'))
 
         for config_dict, expected_substring in cases:
             with tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False, encoding='utf-8') as f:

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -56,7 +56,7 @@ class TestDeploy:
             name = "myservice1"
 
             [[service.routes]]
-            type = "insert"
+            type = "compute"
             table = "table1"
             path = "/insert1"
 
@@ -64,7 +64,7 @@ class TestDeploy:
             name = "myservice2"
 
             [[service.routes]]
-            type = "insert"
+            type = "compute"
             table = "dir1.table2"
             path = "/insert2"
             """

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -133,6 +133,16 @@ class TestDeploy:
         config_path = tmp_path / 'pixeltable.toml'
         monkeypatch.chdir(tmp_path)
 
+        # Invalid environment name
+        config_path.write_text(
+            textwrap.dedent("""\
+            [[environment]]
+            name = "123bad"
+            """)
+        )
+        with pytest.raises(pxt.Error, match='not a valid Pixeltable identifier'):
+            Config.init({}, reinit=True)
+
         # No environments configured
         config_path.write_text('')
         Config.init({}, reinit=True)

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -48,17 +48,20 @@ class TestDeploy:
             """\
             [[deployment]]
             name = "deploy-svc1"
+            service = "myservice1"
+            env = "prod"
             include = ["*.toml", "a*.txt"]
             exclude = ["a_exclude.txt"]
-            service = "myservice1"
 
             [[deployment]]
             name = "deploy-svc2"
             service = "myservice2"
+            env = "prod"
 
             [[deployment]]
             name = "deploy-code"
             service = "pxttest:test_service"
+            env = "prod"
 
             [[service]]
             name = "myservice1"
@@ -172,6 +175,7 @@ class TestDeploy:
             [[deployment]]
             name = "123bad"
             service = "x"
+            env = "prod"
             """)
         )
         with pytest.raises(pxt.Error, match='not a valid Pixeltable identifier'):
@@ -189,6 +193,7 @@ class TestDeploy:
             [[deployment]]
             name = "other-env"
             service = "x"
+            env = "prod"
             """)
         )
         Config.init({}, reinit=True)
@@ -201,6 +206,7 @@ class TestDeploy:
             [[deployment]]
             name = "my-env"
             service = "missing-service"
+            env = "prod"
             """)
         )
         Config.init({}, reinit=True)
@@ -213,6 +219,7 @@ class TestDeploy:
             [[deployment]]
             name = "my-env"
             service = "missing-service"
+            env = "prod"
 
             [[service]]
             name = "other-service"
@@ -230,6 +237,7 @@ class TestDeploy:
                 [[deployment]]
                 name = "my-env"
                 service = "my-service"
+                env = "prod"
 
                 [[service]]
                 name = "my-service"
@@ -250,6 +258,7 @@ class TestDeploy:
             [[deployment]]
             name = "my-env"
             service = "my-service"
+            env = "prod"
 
             [[service]]
             name = "my-service"
@@ -270,6 +279,7 @@ class TestDeploy:
             [[deployment]]
             name = "my-env"
             service = "no_such_module:app"
+            env = "prod"
             """)
         )
         Config.init({}, reinit=True)
@@ -285,6 +295,7 @@ class TestDeploy:
             [[deployment]]
             name = "my-env"
             service = "pxttest_noattr:missing_app"
+            env = "prod"
             """)
         )
         Config.init({}, reinit=True)
@@ -300,6 +311,7 @@ class TestDeploy:
             [[deployment]]
             name = "my-env"
             service = "pxttest_bad:not_a_fastapi"
+            env = "prod"
             """)
         )
         Config.init({}, reinit=True)
@@ -322,6 +334,7 @@ class TestDeploy:
                 [[deployment]]
                 name = "my-env"
                 service = "pxttest:app"
+                env = "prod"
                 """)
             )
             Config.init({}, reinit=True)

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -15,16 +15,15 @@ import toml
 import pixeltable as pxt
 from pixeltable import exceptions as excs, metadata
 from pixeltable.config import Config
-from pixeltable.env import Env
 from pixeltable.serving.deploy import build_deploy_bundle
 
-from ..utils import pxt_raises
+from ..utils import pxt_raises, skip_test_if_not_installed
 
 
 class TestDeploy:
     def test_deploy_bundle(self, uses_db: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Build a deploy bundle from a TOML config and verify its contents."""
-        Env.get().require_package('fastapi')
+        skip_test_if_not_installed('fastapi')
         from fastapi import FastAPI
 
         from pixeltable.serving import FastAPIRouter

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -125,6 +125,8 @@ class TestDeploy:
 
     def test_deploy_bundle_errors(self, uses_db: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test error paths in build_deploy_bundle()."""
+        skip_test_if_not_installed('fastapi')
+
         config_path = tmp_path / 'pixeltable.toml'
         monkeypatch.chdir(tmp_path)
 

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -46,7 +46,7 @@ class TestDeploy:
         config_path = tmp_path / 'pixeltable.toml'
         config_contents = textwrap.dedent(
             """\
-            [[environment]]
+            [[deployment]]
             name = "test-deploy"
             include = ["*.toml", "a*.txt"]
             exclude = ["a_exclude.txt"]
@@ -101,7 +101,7 @@ class TestDeploy:
             config_member = tar.getmember('config.toml')
             with tar.extractfile(config_member) as f:
                 content = toml.loads(f.read().decode('utf-8'))
-                assert content['environment'][0]['name'] == 'test-deploy'
+                assert content['deployment'][0]['name'] == 'test-deploy'
                 assert len(content['service']) == 2
                 assert content['service'][0]['name'] == 'myservice1'
                 assert content['service'][0]['routes'][0]['table'] == 'table1'
@@ -133,37 +133,37 @@ class TestDeploy:
         config_path = tmp_path / 'pixeltable.toml'
         monkeypatch.chdir(tmp_path)
 
-        # Invalid environment name
+        # Invalid deployment name
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "123bad"
             """)
         )
         with pytest.raises(pxt.Error, match='not a valid Pixeltable identifier'):
             Config.init({}, reinit=True)
 
-        # No environments configured
+        # No deployments configured
         config_path.write_text('')
         Config.init({}, reinit=True)
-        with pxt_raises(excs.ErrorCode.ENVIRONMENT_NOT_FOUND, match='No environments found'):
+        with pxt_raises(excs.ErrorCode.ENVIRONMENT_NOT_FOUND, match='No deployments found'):
             build_deploy_bundle('nonexistent')
 
-        # Environment name not found among configured environments
+        # Deployment name not found among configured deployments
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "other-env"
             """)
         )
         Config.init({}, reinit=True)
-        with pxt_raises(excs.ErrorCode.ENVIRONMENT_NOT_FOUND, match="Environment 'nonexistent' not found"):
+        with pxt_raises(excs.ErrorCode.ENVIRONMENT_NOT_FOUND, match="Deployment 'nonexistent' not found"):
             build_deploy_bundle('nonexistent')
 
-        # Service referenced by environment not found (no services configured)
+        # Service referenced by deployment not found (no services configured)
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "my-env"
             services = ["missing-service"]
             """)
@@ -172,10 +172,10 @@ class TestDeploy:
         with pxt_raises(excs.ErrorCode.SERVICE_NOT_FOUND, match='No services found'):
             build_deploy_bundle('my-env')
 
-        # Service referenced by environment not found (different service configured)
+        # Service referenced by deployment not found (different service configured)
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "my-env"
             services = ["missing-service"]
 
@@ -192,7 +192,7 @@ class TestDeploy:
         for route_type in ('insert', 'update', 'delete'):
             config_path.write_text(
                 textwrap.dedent(f"""\
-                [[environment]]
+                [[deployment]]
                 name = "my-env"
                 services = ["my-service"]
 
@@ -212,7 +212,7 @@ class TestDeploy:
         # Table referenced in route does not exist
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "my-env"
             services = ["my-service"]
 
@@ -232,7 +232,7 @@ class TestDeploy:
         # Code-defined service: module cannot be imported
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "my-env"
             services = ["no_such_module:app"]
             """)
@@ -247,7 +247,7 @@ class TestDeploy:
         monkeypatch.setitem(sys.modules, 'pxttest_noattr', test_module)
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "my-env"
             services = ["pxttest_noattr:missing_app"]
             """)
@@ -262,7 +262,7 @@ class TestDeploy:
         monkeypatch.setitem(sys.modules, 'pxttest_bad', test_module_bad)
         config_path.write_text(
             textwrap.dedent("""\
-            [[environment]]
+            [[deployment]]
             name = "my-env"
             services = ["pxttest_bad:not_a_fastapi"]
             """)
@@ -284,7 +284,7 @@ class TestDeploy:
             monkeypatch.setitem(sys.modules, 'pxttest', test_module)
             config_path.write_text(
                 textwrap.dedent("""\
-                [[environment]]
+                [[deployment]]
                 name = "my-env"
                 services = ["pxttest:app"]
                 """)

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -30,8 +30,10 @@ class TestDeploy:
 
         _ = pxt.create_table('table1', {'id': pxt.Int, 'name': pxt.String})
         pxt.create_dir('dir1')
-        _ = pxt.create_table('dir1.table2', {'id': pxt.Int, 'value': pxt.Float})
-        tbl3 = pxt.create_table('dir1.table3', {'id': pxt.Int, 'description': pxt.String})
+        tbl2 = pxt.create_table('dir1.table2', {'id': pxt.Int, 'value': pxt.Float})
+        tbl2.add_computed_column(computed=(tbl2.value + 2.7))
+        tbl3 = pxt.create_table('dir1.table3', {'id': pxt.Int, 'value': pxt.Float})
+        tbl3.add_computed_column(computed=(tbl3.value + 2.9))
 
         app = FastAPI(title='Pixeltable Test Service', version='0.42')
         router = FastAPIRouter()
@@ -178,7 +180,7 @@ class TestDeploy:
             env = "prod"
             """)
         )
-        with pytest.raises(pxt.Error, match='not a valid Pixeltable identifier'):
+        with pxt_raises(excs.ErrorCode.INVALID_CONFIGURATION, match='not a valid Pixeltable identifier'):
             Config.init({}, reinit=True)
 
         # No deployments configured

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -191,3 +191,45 @@ class TestDeploy:
         Config.init({}, reinit=True)
         with pxt_raises(excs.ErrorCode.PATH_NOT_FOUND, match='no_such_table'):
             build_deploy_bundle('my-env')
+
+        # Code-defined service: module cannot be imported
+        config_path.write_text(
+            textwrap.dedent("""\
+            [[environment]]
+            name = "my-env"
+            services = ["no_such_module:app"]
+            """)
+        )
+        Config.init({}, reinit=True)
+        with pxt_raises(excs.ErrorCode.INVALID_CONFIGURATION, match='Could not import module'):
+            build_deploy_bundle('my-env')
+
+        # Code-defined service: module exists but attribute does not
+        skip_test_if_not_installed('fastapi')
+        test_module = MagicMock(spec=[])  # spec=[] means no attributes
+        monkeypatch.setitem(sys.modules, 'pxttest_noattr', test_module)
+        config_path.write_text(
+            textwrap.dedent("""\
+            [[environment]]
+            name = "my-env"
+            services = ["pxttest_noattr:missing_app"]
+            """)
+        )
+        Config.init({}, reinit=True)
+        with pxt_raises(excs.ErrorCode.INVALID_CONFIGURATION, match='has no attribute'):
+            build_deploy_bundle('my-env')
+
+        # Code-defined service: attribute exists but is not a FastAPI app
+        test_module_bad = MagicMock()
+        test_module_bad.not_a_fastapi = 'just a string'
+        monkeypatch.setitem(sys.modules, 'pxttest_bad', test_module_bad)
+        config_path.write_text(
+            textwrap.dedent("""\
+            [[environment]]
+            name = "my-env"
+            services = ["pxttest_bad:not_a_fastapi"]
+            """)
+        )
+        Config.init({}, reinit=True)
+        with pxt_raises(excs.ErrorCode.INVALID_CONFIGURATION, match='is not a FastAPI app'):
+            build_deploy_bundle('my-env')

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -184,7 +184,7 @@ class TestDeploy:
         # No deployments configured
         config_path.write_text('')
         Config.init({}, reinit=True)
-        with pxt_raises(excs.ErrorCode.ENVIRONMENT_NOT_FOUND, match='No deployments found'):
+        with pxt_raises(excs.ErrorCode.DEPLOYMENT_NOT_FOUND, match='No deployments found'):
             build_deploy_bundle('nonexistent')
 
         # Deployment name not found among configured deployments
@@ -197,7 +197,7 @@ class TestDeploy:
             """)
         )
         Config.init({}, reinit=True)
-        with pxt_raises(excs.ErrorCode.ENVIRONMENT_NOT_FOUND, match="Deployment 'nonexistent' not found"):
+        with pxt_raises(excs.ErrorCode.DEPLOYMENT_NOT_FOUND, match="Deployment 'nonexistent' not found"):
             build_deploy_bundle('nonexistent')
 
         # Service referenced by deployment not found (no services configured)

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import sys
 import tarfile
 import textwrap
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import toml
@@ -13,15 +15,34 @@ import toml
 import pixeltable as pxt
 from pixeltable import exceptions as excs, metadata
 from pixeltable.config import Config
+from pixeltable.env import Env
 from pixeltable.serving.deploy import build_deploy_bundle
-from tests.utils import pxt_raises
+
+from ..utils import pxt_raises
 
 
 class TestDeploy:
     def test_deploy_bundle(self, uses_db: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Build a deploy bundle from a TOML config and verify its contents."""
+        Env.get().require_package('fastapi')
+        from fastapi import FastAPI
+
+        from pixeltable.serving import FastAPIRouter
+
         _ = pxt.create_table('table1', {'id': pxt.Int, 'name': pxt.String})
-        _ = pxt.create_table('table2', {'id': pxt.Int, 'value': pxt.Float})
+        pxt.create_dir('dir1')
+        _ = pxt.create_table('dir1.table2', {'id': pxt.Int, 'value': pxt.Float})
+        tbl3 = pxt.create_table('dir1.table3', {'id': pxt.Int, 'description': pxt.String})
+
+        app = FastAPI(title='Pixeltable Test Service', version='0.42')
+        router = FastAPIRouter()
+        router.add_insert_route(tbl3, path='/insert3')
+        app.include_router(router)
+
+        # Monkeypatch a new module with the test service so that config can find it
+        test_service_module = MagicMock()
+        test_service_module.test_service = app
+        monkeypatch.setitem(sys.modules, 'pxttest', test_service_module)
 
         config_path = tmp_path / 'pixeltable.toml'
         config_contents = textwrap.dedent(
@@ -30,7 +51,7 @@ class TestDeploy:
             name = "test-deploy"
             include = ["*.toml", "a*.txt"]
             exclude = ["a_exclude.txt"]
-            services = ["myservice1", "myservice2"]
+            services = ["myservice1", "myservice2", "pxttest:test_service"]
 
             [[service]]
             name = "myservice1"
@@ -38,15 +59,15 @@ class TestDeploy:
             [[service.routes]]
             type = "insert"
             table = "table1"
-            path = "/insert"
+            path = "/insert1"
 
             [[service]]
             name = "myservice2"
 
             [[service.routes]]
             type = "insert"
-            table = "table2"
-            path = "/insert"
+            table = "dir1.table2"
+            path = "/insert2"
             """
         )
         config_path.write_text(config_contents)
@@ -86,7 +107,7 @@ class TestDeploy:
                 assert content['service'][0]['name'] == 'myservice1'
                 assert content['service'][0]['routes'][0]['table'] == 'table1'
                 assert content['service'][1]['name'] == 'myservice2'
-                assert content['service'][1]['routes'][0]['table'] == 'table2'
+                assert content['service'][1]['routes'][0]['table'] == 'dir1.table2'
 
             # Verify the contents of metadata.json
             metadata_member = tar.getmember('metadata.json')
@@ -94,7 +115,7 @@ class TestDeploy:
                 content = json.loads(f.read().decode('utf-8'))
                 assert content['pxt_version'] == pxt.__version__
                 assert content['pxt_md_version'] == metadata.VERSION
-                assert len(content['tables_md']) == 2  # 2 tables referenced in services
+                assert len(content['tables_md']) == 3  # 3 tables referenced in services
                 assert len(content['tables_md'][0]) == 3  # TableVersionMd structure
 
             # Verify the contents of conda-env.yml

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -35,7 +35,7 @@ class TestDeploy:
 
         app = FastAPI(title='Pixeltable Test Service', version='0.42')
         router = FastAPIRouter()
-        router.add_insert_route(tbl3, path='/insert3')
+        router.add_compute_route(tbl3, path='/compute3')
         app.include_router(router)
 
         # Monkeypatch a new module with the test service so that config can find it
@@ -58,7 +58,7 @@ class TestDeploy:
             [[service.routes]]
             type = "compute"
             table = "table1"
-            path = "/insert1"
+            path = "/compute1"
 
             [[service]]
             name = "myservice2"
@@ -66,7 +66,7 @@ class TestDeploy:
             [[service.routes]]
             type = "compute"
             table = "dir1.table2"
-            path = "/insert2"
+            path = "/compute2"
             """
         )
         config_path.write_text(config_contents)
@@ -185,9 +185,9 @@ class TestDeploy:
             name = "my-service"
 
             [[service.routes]]
-            type = "insert"
+            type = "compute"
             table = "no_such_table"
-            path = "/insert"
+            path = "/compute"
             """)
         )
         Config.init({}, reinit=True)

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -126,6 +126,9 @@ class TestDeploy:
     def test_deploy_bundle_errors(self, uses_db: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test error paths in build_deploy_bundle()."""
         skip_test_if_not_installed('fastapi')
+        from fastapi import FastAPI
+
+        from pixeltable.serving import FastAPIRouter
 
         config_path = tmp_path / 'pixeltable.toml'
         monkeypatch.chdir(tmp_path)
@@ -173,6 +176,28 @@ class TestDeploy:
         Config.init({}, reinit=True)
         with pxt_raises(excs.ErrorCode.SERVICE_NOT_FOUND, match="Service 'missing-service' not found"):
             build_deploy_bundle('my-env')
+
+        # TOML-defined service: route type is not 'compute' (e.g. 'insert')
+        _ = pxt.create_table('deploy_err_toml_tbl', {'id': pxt.Int})
+        for route_type in ('insert', 'update', 'delete'):
+            config_path.write_text(
+                textwrap.dedent(f"""\
+                [[environment]]
+                name = "my-env"
+                services = ["my-service"]
+
+                [[service]]
+                name = "my-service"
+
+                [[service.routes]]
+                type = "{route_type}"
+                table = "deploy_err_toml_tbl"
+                path = "/invalid"
+                """)
+            )
+            Config.init({}, reinit=True)
+            with pxt_raises(excs.ErrorCode.INVALID_CONFIGURATION, match="only 'compute' routes are supported"):
+                build_deploy_bundle('my-env')
 
         # Table referenced in route does not exist
         config_path.write_text(
@@ -235,3 +260,25 @@ class TestDeploy:
         Config.init({}, reinit=True)
         with pxt_raises(excs.ErrorCode.INVALID_CONFIGURATION, match='is not a FastAPI app'):
             build_deploy_bundle('my-env')
+
+        # Code-defined service: route is not a 'compute' route (e.g. 'insert')
+        t = pxt.create_table('deploy_err_tbl', {'id': pxt.Required[pxt.Int], 'name': pxt.String}, primary_key='id')
+        for route_type in ('insert', 'update', 'delete'):
+            insert_app = FastAPI()
+            insert_router = FastAPIRouter()
+            add_route_fn = getattr(insert_router, f'add_{route_type}_route')
+            add_route_fn(t, path='/invalid')
+            insert_app.include_router(insert_router)
+            test_module = MagicMock()
+            test_module.app = insert_app
+            monkeypatch.setitem(sys.modules, 'pxttest', test_module)
+            config_path.write_text(
+                textwrap.dedent("""\
+                [[environment]]
+                name = "my-env"
+                services = ["pxttest:app"]
+                """)
+            )
+            Config.init({}, reinit=True)
+            with pxt_raises(excs.ErrorCode.INVALID_CONFIGURATION, match="only 'compute' routes are supported"):
+                build_deploy_bundle('my-env')

--- a/tests/serving/test_deploy.py
+++ b/tests/serving/test_deploy.py
@@ -47,10 +47,18 @@ class TestDeploy:
         config_contents = textwrap.dedent(
             """\
             [[deployment]]
-            name = "test-deploy"
+            name = "deploy-svc1"
             include = ["*.toml", "a*.txt"]
             exclude = ["a_exclude.txt"]
-            services = ["myservice1", "myservice2", "pxttest:test_service"]
+            service = "myservice1"
+
+            [[deployment]]
+            name = "deploy-svc2"
+            service = "myservice2"
+
+            [[deployment]]
+            name = "deploy-code"
+            service = "pxttest:test_service"
 
             [[service]]
             name = "myservice1"
@@ -78,9 +86,8 @@ class TestDeploy:
 
         Config.init({}, reinit=True)  # pick up the new configuration
 
-        bundle_path = build_deploy_bundle('test-deploy')
-
-        # Extract the bundle and verify contents
+        # deploy-svc1: TOML-defined service with file include/exclude
+        bundle_path = build_deploy_bundle('deploy-svc1')
         with tarfile.open(bundle_path, 'r:bz2') as tar:
             members = tar.getnames()
             assert 'config.toml' in members
@@ -101,12 +108,10 @@ class TestDeploy:
             config_member = tar.getmember('config.toml')
             with tar.extractfile(config_member) as f:
                 content = toml.loads(f.read().decode('utf-8'))
-                assert content['deployment'][0]['name'] == 'test-deploy'
-                assert len(content['service']) == 2
+                assert content['deployment'][0]['name'] == 'deploy-svc1'
+                assert len(content['service']) == 1
                 assert content['service'][0]['name'] == 'myservice1'
                 assert content['service'][0]['routes'][0]['table'] == 'table1'
-                assert content['service'][1]['name'] == 'myservice2'
-                assert content['service'][1]['routes'][0]['table'] == 'dir1.table2'
 
             # Verify the contents of metadata.json
             metadata_member = tar.getmember('metadata.json')
@@ -114,7 +119,7 @@ class TestDeploy:
                 content = json.loads(f.read().decode('utf-8'))
                 assert content['pxt_version'] == pxt.__version__
                 assert content['pxt_md_version'] == metadata.VERSION
-                assert len(content['tables_md']) == 3  # 3 tables referenced in services
+                assert len(content['tables_md']) == 1
                 assert len(content['tables_md'][0]) == 3  # TableVersionMd structure
 
             # Verify the contents of conda-env.yml
@@ -122,6 +127,34 @@ class TestDeploy:
             with tar.extractfile(env_member) as f:
                 text = f.read().decode('utf-8')
                 assert 'pixeltable==' in text, text
+
+        # deploy-svc2: second TOML-defined service
+        bundle_path = build_deploy_bundle('deploy-svc2')
+        with tarfile.open(bundle_path, 'r:bz2') as tar:
+            config_member = tar.getmember('config.toml')
+            with tar.extractfile(config_member) as f:
+                content = toml.loads(f.read().decode('utf-8'))
+                assert content['deployment'][0]['name'] == 'deploy-svc2'
+                assert len(content['service']) == 1
+                assert content['service'][0]['name'] == 'myservice2'
+                assert content['service'][0]['routes'][0]['table'] == 'dir1.table2'
+            metadata_member = tar.getmember('metadata.json')
+            with tar.extractfile(metadata_member) as f:
+                content = json.loads(f.read().decode('utf-8'))
+                assert len(content['tables_md']) == 1
+
+        # deploy-code: code-defined service (pxttest:test_service)
+        bundle_path = build_deploy_bundle('deploy-code')
+        with tarfile.open(bundle_path, 'r:bz2') as tar:
+            config_member = tar.getmember('config.toml')
+            with tar.extractfile(config_member) as f:
+                content = toml.loads(f.read().decode('utf-8'))
+                assert content['deployment'][0]['name'] == 'deploy-code'
+                assert 'service' not in content or len(content.get('service', [])) == 0
+            metadata_member = tar.getmember('metadata.json')
+            with tar.extractfile(metadata_member) as f:
+                content = json.loads(f.read().decode('utf-8'))
+                assert len(content['tables_md']) == 1
 
     def test_deploy_bundle_errors(self, uses_db: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test error paths in build_deploy_bundle()."""
@@ -138,6 +171,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "123bad"
+            service = "x"
             """)
         )
         with pytest.raises(pxt.Error, match='not a valid Pixeltable identifier'):
@@ -154,6 +188,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "other-env"
+            service = "x"
             """)
         )
         Config.init({}, reinit=True)
@@ -165,7 +200,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "my-env"
-            services = ["missing-service"]
+            service = "missing-service"
             """)
         )
         Config.init({}, reinit=True)
@@ -177,7 +212,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "my-env"
-            services = ["missing-service"]
+            service = "missing-service"
 
             [[service]]
             name = "other-service"
@@ -194,7 +229,7 @@ class TestDeploy:
                 textwrap.dedent(f"""\
                 [[deployment]]
                 name = "my-env"
-                services = ["my-service"]
+                service = "my-service"
 
                 [[service]]
                 name = "my-service"
@@ -214,7 +249,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "my-env"
-            services = ["my-service"]
+            service = "my-service"
 
             [[service]]
             name = "my-service"
@@ -234,7 +269,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "my-env"
-            services = ["no_such_module:app"]
+            service = "no_such_module:app"
             """)
         )
         Config.init({}, reinit=True)
@@ -249,7 +284,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "my-env"
-            services = ["pxttest_noattr:missing_app"]
+            service = "pxttest_noattr:missing_app"
             """)
         )
         Config.init({}, reinit=True)
@@ -264,7 +299,7 @@ class TestDeploy:
             textwrap.dedent("""\
             [[deployment]]
             name = "my-env"
-            services = ["pxttest_bad:not_a_fastapi"]
+            service = "pxttest_bad:not_a_fastapi"
             """)
         )
         Config.init({}, reinit=True)
@@ -286,7 +321,7 @@ class TestDeploy:
                 textwrap.dedent("""\
                 [[deployment]]
                 name = "my-env"
-                services = ["pxttest:app"]
+                service = "pxttest:app"
                 """)
             )
             Config.init({}, reinit=True)

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -1195,14 +1195,10 @@ class TestFastAPI:
         eng.dispose()
 
         with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match="column 'id'"):
-            add_route_fn(
-                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_bad')
-            )
+            add_route_fn(t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_bad'))
 
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="column 'id' not in table"):
-            add_route_fn(
-                t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_missing')
-            )
+            add_route_fn(t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_missing'))
 
         # method='update' validation: target needs a PK
         make_sqlite_target(tmp_path / 'export.db', 'no_pk', {'id': sql.Integer, 'text_upper': sql.VARCHAR})

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -1142,7 +1142,8 @@ class TestFastAPI:
         router = FastAPIRouter()
         add_route_fn = router.add_insert_route if route_type == 'insert' else router.add_compute_route
 
-        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match='cannot insert into'):
+        verb = 'insert into' if route_type == 'insert' else 'compute'
+        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match=f'cannot {verb}'):
             v = pxt.create_view('test_serve.errors_view', t)
             add_route_fn(v, path='/v')
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="unknown input column 'doesnotexist'"):

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -2,7 +2,7 @@ import json
 import os
 import pathlib
 import time
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 import pytest
 import sqlalchemy as sql
@@ -134,7 +134,10 @@ def assert_sqlite_row(connect: str, table_name: str, where: dict[str, Any], expe
 
 
 class TestFastAPI:
-    def test_add_insert_route_scalars(self, uses_db: None, tmp_path: pathlib.Path) -> None:
+    @pytest.mark.parametrize('route_type', ['insert', 'compute'])
+    def test_add_insert_route_scalars(
+        self, uses_db: None, tmp_path: pathlib.Path, route_type: Literal['insert', 'compute']
+    ) -> None:
         """Test insert routes with all scalar types and various input/output combinations."""
         skip_test_if_not_installed('fastapi')
         from pixeltable.serving import FastAPIRouter, SqlExport
@@ -186,14 +189,15 @@ class TestFastAPI:
         eng.dispose()
 
         router = FastAPIRouter()
+        add_route_fn = router.add_insert_route if route_type == 'insert' else router.add_compute_route
         # default inputs and outputs; with export_sql to out_all
-        router.add_insert_route(t, path='/all', export_sql=SqlExport(db_connect=db_connect, table='out_all'))
+        add_route_fn(t, path='/all', export_sql=SqlExport(db_connect=db_connect, table='out_all'))
         # subset of inputs, all outputs
-        router.add_insert_route(t, path='/partial-in', inputs=['id', 'str_col', 'int_col'])
+        add_route_fn(t, path='/partial-in', inputs=['id', 'str_col', 'int_col'])
         # all inputs, subset of outputs
-        router.add_insert_route(t, path='/partial-out', outputs=['id', 'str_upper', 'int_plus1'])
+        add_route_fn(t, path='/partial-out', outputs=['id', 'str_upper', 'int_plus1'])
         # minimal inputs and outputs; with export_sql to out_minimal (same db_connect)
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/minimal',
             inputs=['id', 'int_col'],
@@ -201,7 +205,7 @@ class TestFastAPI:
             export_sql=SqlExport(db_connect=db_connect, table='out_minimal'),
         )
         # update-mode export: pxt insert triggers a UPDATE on the target keyed on id
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/update',
             inputs=['id', 'str_col', 'int_col'],
@@ -291,8 +295,11 @@ class TestFastAPI:
         router._shutdown()
         assert router._engine_cache == {}
 
+    @pytest.mark.parametrize('route_type', ['insert', 'compute'])
     @pytest.mark.parametrize('use_uploadfile', [True, False])
-    def test_add_insert_route_video(self, uses_db: None, use_uploadfile: bool) -> None:
+    def test_add_insert_route_video(
+        self, uses_db: None, use_uploadfile: bool, route_type: Literal['insert', 'compute']
+    ) -> None:
         """Test insert routes with video data, including FileResponse."""
         skip_test_if_not_installed('fastapi')
         from pixeltable.serving import FastAPIRouter
@@ -306,14 +313,15 @@ class TestFastAPI:
         t.add_computed_column(thumbnail=t.video.extract_frame(timestamp=0.0))
 
         router = FastAPIRouter()
+        add_route_fn = router.add_insert_route if route_type == 'insert' else router.add_compute_route
         # When uploading, 'video' moves from inputs into uploadfile_inputs. Other inputs
         # (defaulted for /all, explicit for /resize and /thumbnail) become Form fields
         # automatically once any upload is present.
         uploadfile_inputs = ['video'] if use_uploadfile else None
         # /all: defaults for inputs/outputs (uploadfile_inputs still moves `video` into File)
-        router.add_insert_route(t, path='/all', uploadfile_inputs=uploadfile_inputs)
+        add_route_fn(t, path='/all', uploadfile_inputs=uploadfile_inputs)
         # /resize: id + video + width, only resized video output
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/resize',
             inputs=['id', 'width'] if use_uploadfile else ['id', 'video', 'width'],
@@ -322,7 +330,7 @@ class TestFastAPI:
             return_fileresponse=True,
         )
         # /thumbnail: id + video + height, only thumbnail output
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/thumbnail',
             inputs=['id', 'height'] if use_uploadfile else ['id', 'video', 'height'],
@@ -367,8 +375,11 @@ class TestFastAPI:
         thumbnail_path = t.where(t.id == 3).select(p=t.thumbnail.localpath).collect()[0]['p']
         assert_fileresponse_ok(resp, thumbnail_path, 'image/')
 
+    @pytest.mark.parametrize('route_type', ['insert', 'compute'])
     @pytest.mark.parametrize('use_uploadfile', [True, False])
-    def test_add_insert_route_image(self, uses_db: None, use_uploadfile: bool, tmp_path: pathlib.Path) -> None:
+    def test_add_insert_route_image(
+        self, uses_db: None, use_uploadfile: bool, tmp_path: pathlib.Path, route_type: Literal['insert', 'compute']
+    ) -> None:
         """Image counterpart of test_add_insert_route_video. Structurally parallel so the two
         tests can later be generalized over a media-kind fixture."""
         skip_test_if_not_installed('fastapi')
@@ -403,20 +414,21 @@ class TestFastAPI:
         )
 
         router = FastAPIRouter()
+        add_route_fn = router.add_insert_route if route_type == 'insert' else router.add_compute_route
         # When uploading, 'image' moves from inputs into uploadfile_inputs. Other inputs
         # (defaulted for /all, explicit for /resize and /rotate) become Form fields
         # automatically once any upload is present.
         uploadfile_inputs = ['image'] if use_uploadfile else None
         # /all: defaults for inputs/outputs (uploadfile_inputs still moves `image` into File);
         # exports to sqlite to exercise the media->String coercion for both raw and computed media
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/all',
             uploadfile_inputs=uploadfile_inputs,
             export_sql=SqlExport(db_connect=db_connect, table='img_out'),
         )
         # /resize: id + image + width + height, only resized image output
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/resize',
             inputs=['id', 'width', 'height'] if use_uploadfile else ['id', 'image', 'width', 'height'],
@@ -427,7 +439,7 @@ class TestFastAPI:
         # /rotate: id + image + width + height, only rotated image output.
         # width/height are unused by the rotate computation but still required by the schema,
         # since every insert evaluates the `resized` computed column.
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/rotate',
             inputs=['id', 'width', 'height'] if use_uploadfile else ['id', 'image', 'width', 'height'],
@@ -487,8 +499,11 @@ class TestFastAPI:
         rotated_path = t.where(t.id == 3).select(p=t.rotated.localpath).collect()[0]['p']
         assert_fileresponse_ok(resp, rotated_path, 'image/')
 
+    @pytest.mark.parametrize('route_type', ['insert', 'compute'])
     @pytest.mark.parametrize('use_uploadfile', [True, False])
-    def test_add_insert_route_audio(self, uses_db: None, use_uploadfile: bool) -> None:
+    def test_add_insert_route_audio(
+        self, uses_db: None, use_uploadfile: bool, route_type: Literal['insert', 'compute']
+    ) -> None:
         """Audio counterpart of test_add_insert_route_video/_image. Structurally parallel so the
         three tests can later be generalized over a media-kind fixture. Uses the audio UDFs
         `multiply_volume` (two scalar inputs) and `normalize` (no scalar inputs)."""
@@ -510,14 +525,15 @@ class TestFastAPI:
         t.add_computed_column(normalized=t.audio.normalize())
 
         router = FastAPIRouter()
+        add_route_fn = router.add_insert_route if route_type == 'insert' else router.add_compute_route
         # When uploading, 'audio' moves from inputs into uploadfile_inputs. Other inputs
         # (defaulted for /all, explicit for /scale and /normalize) become Form fields
         # automatically once any upload is present.
         uploadfile_inputs = ['audio'] if use_uploadfile else None
         # /all: defaults for inputs/outputs (uploadfile_inputs still moves `audio` into File)
-        router.add_insert_route(t, path='/all', uploadfile_inputs=uploadfile_inputs)
+        add_route_fn(t, path='/all', uploadfile_inputs=uploadfile_inputs)
         # /scale: id + audio + factor + end_time, only the multiply_volume output
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/scale',
             inputs=['id', 'factor', 'end_time'] if use_uploadfile else ['id', 'audio', 'factor', 'end_time'],
@@ -528,7 +544,7 @@ class TestFastAPI:
         # /normalize: id + audio + factor + end_time, only the normalize output.
         # factor/end_time are unused by the normalize computation but still required by the
         # schema, since every insert evaluates the `scaled` computed column.
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/normalize',
             inputs=['id', 'factor', 'end_time'] if use_uploadfile else ['id', 'audio', 'factor', 'end_time'],
@@ -574,8 +590,11 @@ class TestFastAPI:
         normalized_path = t.where(t.id == 3).select(p=t.normalized.localpath).collect()[0]['p']
         assert_fileresponse_ok(resp, normalized_path, 'audio/')
 
+    @pytest.mark.parametrize('route_type', ['insert', 'compute'])
     @pytest.mark.parametrize('use_uploadfile', [True, False])
-    def test_add_insert_route_video_bg(self, uses_db: None, use_uploadfile: bool, tmp_path: pathlib.Path) -> None:
+    def test_add_insert_route_video_bg(
+        self, uses_db: None, use_uploadfile: bool, tmp_path: pathlib.Path, route_type: Literal['insert', 'compute']
+    ) -> None:
         """Background variant of test_add_insert_route_video: POST returns a job id/url, the
         work runs in FastAPIRouter._executor, and the result is fetched via /jobs/{id}."""
         skip_test_if_not_installed('fastapi')
@@ -598,12 +617,13 @@ class TestFastAPI:
         db_connect = make_sqlite_target(tmp_path / 'export.db', 'bg_resize', {'resized': sql.VARCHAR})
 
         router = FastAPIRouter()
+        add_route_fn = router.add_insert_route if route_type == 'insert' else router.add_compute_route
         uploadfile_inputs = ['video'] if use_uploadfile else None
         # /all: defaults for inputs/outputs, all columns in the response
-        router.add_insert_route(t, path='/all', uploadfile_inputs=uploadfile_inputs, background=True)
+        add_route_fn(t, path='/all', uploadfile_inputs=uploadfile_inputs, background=True)
         # /resize: single-output JSON response (no FileResponse - mutually exclusive with background);
         # also exports to sqlite to cover the background + export_sql combination
-        router.add_insert_route(
+        add_route_fn(
             t,
             path='/resize',
             inputs=['id', 'width'] if use_uploadfile else ['id', 'video', 'width'],
@@ -1101,7 +1121,10 @@ class TestFastAPI:
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='GET endpoints cannot have uploadfile_inputs'):
             router.add_query_route(path='/e', query=by_image, uploadfile_inputs=['img'], method='get')
 
-    def test_add_insert_route_errors(self, uses_db: None, tmp_path: pathlib.Path) -> None:
+    @pytest.mark.parametrize('route_type', ['insert', 'compute'])
+    def test_add_insert_route_errors(
+        self, uses_db: None, tmp_path: pathlib.Path, route_type: Literal['insert', 'compute']
+    ) -> None:
         skip_test_if_not_installed('fastapi')
         import sqlalchemy as sql
 
@@ -1117,42 +1140,43 @@ class TestFastAPI:
         t.add_computed_column(frame=t.video.extract_frame(timestamp=0.0))
 
         router = FastAPIRouter()
+        add_route_fn = router.add_insert_route if route_type == 'insert' else router.add_compute_route
 
         with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match='cannot insert into'):
             v = pxt.create_view('test_serve.errors_view', t)
-            router.add_insert_route(v, path='/v')
+            add_route_fn(v, path='/v')
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="unknown input column 'doesnotexist'"):
-            router.add_insert_route(t, path='/e', inputs=['doesnotexist'])
+            add_route_fn(t, path='/e', inputs=['doesnotexist'])
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="unknown uploadfile input column 'doesnotexist'"):
-            router.add_insert_route(t, path='/e', uploadfile_inputs=['doesnotexist'])
+            add_route_fn(t, path='/e', uploadfile_inputs=['doesnotexist'])
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match="'text_upper' is a computed column"):
-            router.add_insert_route(t, path='/e', inputs=['text_upper'])
+            add_route_fn(t, path='/e', inputs=['text_upper'])
         with pxt_raises(
             pxt.ErrorCode.UNSUPPORTED_OPERATION, match="uploadfile input column 'text' is not a media column"
         ):
-            router.add_insert_route(t, path='/e', uploadfile_inputs=['text'])
+            add_route_fn(t, path='/e', uploadfile_inputs=['text'])
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match="'frame' is a computed column"):
-            router.add_insert_route(t, path='/e', uploadfile_inputs=['frame'])
+            add_route_fn(t, path='/e', uploadfile_inputs=['frame'])
         with pxt_raises(
             pxt.ErrorCode.INVALID_ARGUMENT, match="'image' appears in both `inputs` and `uploadfile_inputs`"
         ):
-            router.add_insert_route(t, path='/e', inputs=['image'], uploadfile_inputs=['image'])
+            add_route_fn(t, path='/e', inputs=['image'], uploadfile_inputs=['image'])
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="unknown output column 'doesnotexist'"):
-            router.add_insert_route(t, path='/e', outputs=['doesnotexist'])
+            add_route_fn(t, path='/e', outputs=['doesnotexist'])
         with pxt_raises(
             pxt.ErrorCode.INVALID_ARGUMENT, match='return_fileresponse and background are mutually exclusive'
         ):
-            router.add_insert_route(t, path='/e', outputs=['frame'], return_fileresponse=True, background=True)
+            add_route_fn(t, path='/e', outputs=['frame'], return_fileresponse=True, background=True)
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='exactly one media-typed output column'):
-            router.add_insert_route(t, path='/e', outputs=['id', 'frame'], return_fileresponse=True)
+            add_route_fn(t, path='/e', outputs=['id', 'frame'], return_fileresponse=True)
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='exactly one media-typed output column'):
-            router.add_insert_route(t, path='/e', outputs=['text_upper'], return_fileresponse=True)
+            add_route_fn(t, path='/e', outputs=['text_upper'], return_fileresponse=True)
 
         # export_sql validation
         db_connect = f'sqlite:///{tmp_path / "export.db"}'
 
         with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match="'merge' is not yet supported"):
-            router.add_insert_route(
+            add_route_fn(
                 t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out', method='merge')
             )
 
@@ -1160,9 +1184,9 @@ class TestFastAPI:
         with pxt_raises(
             pxt.ErrorCode.INVALID_ARGUMENT, match='export_sql and return_fileresponse are mutually exclusive'
         ):
-            router.add_insert_route(t, path='/e', outputs=['frame'], return_fileresponse=True, export_sql=spec_insert)
+            add_route_fn(t, path='/e', outputs=['frame'], return_fileresponse=True, export_sql=spec_insert)
         with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match="table 'out' does not exist"):
-            router.add_insert_route(t, path='/e', outputs=['id'], export_sql=spec_insert)
+            add_route_fn(t, path='/e', outputs=['id'], export_sql=spec_insert)
 
         # pre-create incompatible target tables for the remaining cases
         eng = sql.create_engine(db_connect)
@@ -1171,19 +1195,19 @@ class TestFastAPI:
         eng.dispose()
 
         with pxt_raises(pxt.ErrorCode.TYPE_MISMATCH, match="column 'id'"):
-            router.add_insert_route(
+            add_route_fn(
                 t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_bad')
             )
 
         with pxt_raises(pxt.ErrorCode.COLUMN_NOT_FOUND, match="column 'id' not in table"):
-            router.add_insert_route(
+            add_route_fn(
                 t, path='/e', outputs=['id'], export_sql=SqlExport(db_connect=db_connect, table='out_missing')
             )
 
         # method='update' validation: target needs a PK
         make_sqlite_target(tmp_path / 'export.db', 'no_pk', {'id': sql.Integer, 'text_upper': sql.VARCHAR})
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='has no primary key'):
-            router.add_insert_route(
+            add_route_fn(
                 t,
                 path='/e',
                 outputs=['id', 'text_upper'],
@@ -1195,7 +1219,7 @@ class TestFastAPI:
             tmp_path / 'export.db', 'with_pk', {'id': sql.Integer, 'text_upper': sql.VARCHAR}, pk_cols=['id']
         )
         with pxt_raises(pxt.ErrorCode.MISSING_REQUIRED, match=r"missing: \['id'\]"):
-            router.add_insert_route(
+            add_route_fn(
                 t,
                 path='/e',
                 outputs=['text_upper'],
@@ -1204,7 +1228,7 @@ class TestFastAPI:
 
         # method='update' validation: at least one non-PK column must be present
         with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match='at least one non-primary-key column'):
-            router.add_insert_route(
+            add_route_fn(
                 t,
                 path='/e',
                 outputs=['id'],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -389,10 +389,10 @@ class TestCLI:
             assert data['url'] == 'http://[::1]:8000'
 
     def test_deploy(self, capsys: pytest.CaptureFixture) -> None:
-        # missing environment arg
+        # missing deployment arg
         _run_cli(['pxt', 'deploy'], capsys, exit_code=2, stderr='error')
 
-        # happy path: environment arg is forwarded to build_deploy_bundle
+        # happy path: deployment arg is forwarded to build_deploy_bundle
         with patch('pixeltable.cli.deploy.build_deploy_bundle') as mock_build:
             _run_cli(['pxt', 'deploy', 'staging'], capsys)
             mock_build.assert_called_once_with('staging')


### PR DESCRIPTION
- Allows services to be specified in environment configs via a `module:attr` reference to a `FastAPI` app instance
- Introduces a `PxtEndpoint` class that functions as the route endpoint callable, in order to encapsulate additional metadata such as the referencing `Table` instance
- Adds add_compute_route(), which is currently just an alias for add_insert_route() but will eventually map onto Table.compute()