### PR TITLE
Serving config updates

### DIFF
--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -117,7 +117,6 @@ class ServiceConfig(pydantic.BaseModel):
     host: str = '0.0.0.0'
     port: int = 8000
     routes: list[RouteConfig] = pydantic.Field(default_factory=list)
-    modules: list[str] = pydantic.Field(default_factory=list)  # List of user modules to import
 
     @pydantic.field_validator('prefix')
     @classmethod

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -96,7 +96,7 @@ class DeleteRouteConfig(RouteConfigBase):
 
 class QueryRouteConfig(RouteConfigBase):
     type: Literal['query']
-    query: str  # dotted Python path to a @pxt.query or retrieval_udf
+    query: str  # module:attr path to a @pxt.query or retrieval_udf
     inputs: list[str] | None = None
     uploadfile_inputs: list[str] | None = None
     one_row: bool = False

--- a/pixeltable/serving/_config.py
+++ b/pixeltable/serving/_config.py
@@ -24,11 +24,12 @@ def _resolve_dotted_path(dotted: str) -> Any:
 
     For example, 'myapp.queries.search_docs' imports myapp.queries and returns its search_docs attribute.
     """
-    module_path, _, attr_name = dotted.rpartition('.')
-    if not module_path:
+    split_path = dotted.split(':', 1)
+    if len(split_path) != 2:
         raise excs.RequestError(
-            excs.ErrorCode.INVALID_ARGUMENT, f'invalid query reference {dotted!r}: expected module.attribute'
+            excs.ErrorCode.INVALID_ARGUMENT, f'invalid query reference {dotted!r}: expected module:attribute'
         )
+    module_path, attr_name = split_path
     try:
         module = importlib.import_module(module_path)
     except Exception as e:

--- a/pixeltable/serving/_config.py
+++ b/pixeltable/serving/_config.py
@@ -81,16 +81,6 @@ def create_service_from_config(cfg: config.ServiceConfig) -> 'fastapi.FastAPI':
 
     from pixeltable.serving import FastAPIRouter
 
-    # import user modules so @pxt.query / retrieval_udf definitions are registered
-    for mod_path in cfg.modules:
-        _logger.info(f'importing module: {mod_path}')
-        try:
-            importlib.import_module(mod_path)
-        except Exception as e:
-            raise excs.RequestError(
-                excs.ErrorCode.INVALID_CONFIGURATION, f'could not import module {mod_path!r} listed in `modules`: {e}'
-            ) from e
-
     app = fastapi.FastAPI(title=cfg.name)
     router = FastAPIRouter()
 

--- a/pixeltable/serving/_config.py
+++ b/pixeltable/serving/_config.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger('pixeltable')
 
 
-def _resolve_dotted_path(dotted: str) -> Any:
+def _resolve_module_attr(dotted: str) -> Any:
     """Import a module and resolve an attribute by dotted path.
 
     For example, 'myapp.queries.search_docs' imports myapp.queries and returns its search_docs attribute.
@@ -112,7 +112,7 @@ def create_service_from_config(cfg: config.ServiceConfig) -> 'fastapi.FastAPI':
             t = pxt.get_table(route.table)
             router.add_delete_route(t, path=route.path, match_columns=route.match_columns, background=route.background)
         elif isinstance(route, config.QueryRouteConfig):
-            query_fn = _resolve_dotted_path(route.query)
+            query_fn = _resolve_module_attr(route.query)
             if not isinstance(query_fn, func.QueryTemplateFunction):
                 raise excs.RequestError(
                     excs.ErrorCode.INVALID_CONFIGURATION,

--- a/tests/serving/test_config.py
+++ b/tests/serving/test_config.py
@@ -161,7 +161,7 @@ class TestConfig:
                 {
                     'name': 'query-service',
                     'modules': ['_test_query_mod'],
-                    'routes': [{'type': 'query', 'path': '/search', 'query': '_test_query_mod.search'}],
+                    'routes': [{'type': 'query', 'path': '/search', 'query': '_test_query_mod:search'}],
                 }
             ]
         }
@@ -281,21 +281,21 @@ class TestConfig:
 
         # query module not importable
         with pytest.raises(pxt.Error, match='could not import module'):
-            create_service_from_config(_query_app('definitely_not_a_real_module_xyz.search'))
+            create_service_from_config(_query_app('definitely_not_a_real_module_xyz:search'))
 
         # query module exists but attribute is missing
         with pytest.raises(pxt.Error, match='has no attribute'):
-            create_service_from_config(_query_app('os.this_attr_does_not_exist'))
+            create_service_from_config(_query_app('os:this_attr_does_not_exist'))
 
         # query resolves to something that isn't a @pxt.query
         with pytest.raises(pxt.Error, match=r'expected a @pxt\.query'):
-            create_service_from_config(_query_app('os.getcwd'))
+            create_service_from_config(_query_app('os:getcwd'))
 
         # `modules` entry that fails to import
         bad_modules_app = config.ServiceConfig(
             name='test',
             modules=['definitely_not_a_real_module_xyz'],
-            routes=[config.QueryRouteConfig(type='query', path='/x', query='os.getcwd')],
+            routes=[config.QueryRouteConfig(type='query', path='/x', query='os:getcwd')],
         )
         with pytest.raises(pxt.Error, match='listed in `modules`'):
             create_service_from_config(bad_modules_app)

--- a/tests/serving/test_config.py
+++ b/tests/serving/test_config.py
@@ -160,7 +160,6 @@ class TestConfig:
             'service': [
                 {
                     'name': 'query-service',
-                    'modules': ['_test_query_mod'],
                     'routes': [{'type': 'query', 'path': '/search', 'query': '_test_query_mod:search'}],
                 }
             ]
@@ -290,12 +289,3 @@ class TestConfig:
         # query resolves to something that isn't a @pxt.query
         with pytest.raises(pxt.Error, match=r'expected a @pxt\.query'):
             create_service_from_config(_query_app('os:getcwd'))
-
-        # `modules` entry that fails to import
-        bad_modules_app = config.ServiceConfig(
-            name='test',
-            modules=['definitely_not_a_real_module_xyz'],
-            routes=[config.QueryRouteConfig(type='query', path='/x', query='os:getcwd')],
-        )
-        with pytest.raises(pxt.Error, match='listed in `modules`'):
-            create_service_from_config(bad_modules_app)


### PR DESCRIPTION
- Use standard `module:attr` pattern for query specs in config
- Remove boilerplate `modules` config section