### PR TITLE
Fix main

### DIFF
--- a/docs/release/howto/cookbooks/core/multimodal_backend.ipynb
+++ b/docs/release/howto/cookbooks/core/multimodal_backend.ipynb
@@ -9,7 +9,7 @@
    },
    "source": [
     "---\n",
-    "title: 'Pixeltable: Your Backend for Multimodal AI Applications'\n",
+    "title: 'Your Backend for Multimodal AI Applications'\n",
     "---"
    ]
   },

--- a/docs/release/howto/cookbooks/core/multimodal_backend.ipynb
+++ b/docs/release/howto/cookbooks/core/multimodal_backend.ipynb
@@ -9,7 +9,7 @@
    },
    "source": [
     "---\n",
-    "title: 'Your Backend for Multimodal AI Applications'\n",
+    "title: 'Pixeltable: Your Backend for Multimodal AI Applications'\n",
     "---"
    ]
   },
@@ -1038,9 +1038,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pxt (Python 3.10)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "pxt"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/release/howto/providers/working-with-openai.ipynb
+++ b/docs/release/howto/providers/working-with-openai.ipynb
@@ -503,7 +503,7 @@
    "source": [
     "image_t = pxt.create_table('openai_demo/images', {'input': pxt.String})\n",
     "image_t.add_computed_column(\n",
-    "    img=openai.image_generations(image_t.input, model='dall-e-2')\n",
+    "    img=openai.image_generations(image_t.input, model='gpt-image-2')\n",
     ")"
    ]
   },
@@ -599,7 +599,7 @@
        "      <td id=\"T_05ebf_row1_col0\" class=\"data row1 col0\" >img</td>\n",
        "      <td id=\"T_05ebf_row1_col1\" class=\"data row1 col1\" >Json</td>\n",
        "      <td id=\"T_05ebf_row1_col2\" class=\"data row1 col2\" >images</td>\n",
-       "      <td id=\"T_05ebf_row1_col3\" class=\"data row1 col3\" >image_generations(input, model='dall-e-2')</td>\n",
+       "      <td id=\"T_05ebf_row1_col3\" class=\"data row1 col3\" >image_generations(input, model='gpt-image-2')</td>\n",
        "      <td id=\"T_05ebf_row1_col4\" class=\"data row1 col4\" ></td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -611,7 +611,7 @@
        " Column Name    Type  Source                               Computed With Comment\n",
        "--------------------------------------------------------------------------------\n",
        "       input  String  images                                                    \n",
-       "         img    Json  images  image_generations(input, model='dall-e-2')        "
+       "         img    Json  images  image_generations(input, model='gpt-image-2')        "
       ]
      },
      "execution_count": 14,

--- a/tests/functions/test_openai.py
+++ b/tests/functions/test_openai.py
@@ -396,28 +396,6 @@ class TestOpenai:
         _ = t.head()
 
     @pytest.mark.expensive
-    def test_image_generations(self, uses_db: None) -> None:
-        skip_test_if_not_installed('openai')
-        skip_test_if_no_client('openai')
-        from pixeltable.functions.openai import image_generations
-
-        t = pxt.create_table('test_tbl', {'input': pxt.String})
-        t.add_computed_column(img=image_generations(t.input, model='dall-e-2'))
-        # Test dall-e-2 options
-        t.add_computed_column(
-            img_2=image_generations(
-                t.input, model='dall-e-2', model_kwargs={'size': '512x512', 'user': 'pixeltable', 'n': 2}
-            )
-        )
-
-        validate_update_status(t.insert(input='A friendly dinosaur playing tennis in a cornfield'), 1)
-        assert t.collect()['img'][0]['data'][0].size == (1024, 1024)
-
-        # Also check that multiple images can be generated and returned in the same results dict
-        assert t.collect()['img_2'][0]['data'][0].size == (512, 512)
-        assert t.collect()['img_2'][0]['data'][1].size == (512, 512)
-
-    @pytest.mark.expensive
     def test_image_generations_gpt_image(self, uses_db: None) -> None:
         skip_test_if_not_installed('openai')
         skip_test_if_no_client('openai')
@@ -492,31 +470,6 @@ class TestOpenai:
         validate_update_status(t.insert(img=src_img, mask=mask_img), 1)
         result = t.collect()
         assert isinstance(result['edited'][0]['data'][0], PIL.Image.Image)
-
-    @pytest.mark.expensive
-    def test_image_edits_dall_e_2(self, uses_db: None) -> None:
-        """Test image_edits with dall-e-2, which requires a square RGBA PNG."""
-        skip_test_if_not_installed('openai')
-        skip_test_if_no_client('openai')
-        import numpy as np
-
-        from pixeltable.functions.openai import image_edits
-
-        # dall-e-2 requires RGBA — the alpha channel marks which pixels to edit (alpha=0 means edit here)
-        arr = np.full((512, 512, 4), fill_value=[70, 130, 180, 255], dtype=np.uint8)  # fully opaque steel blue
-        src_img = PIL.Image.fromarray(arr, mode='RGBA')
-
-        t = pxt.create_table('test_tbl', {'img': pxt.Image})
-        t.add_computed_column(
-            edited=image_edits(
-                t.img, prompt='Add a blue sky background', model='dall-e-2', model_kwargs={'size': '512x512'}
-            )
-        )
-
-        validate_update_status(t.insert(img=src_img), 1)
-        result = t.collect()
-        assert isinstance(result['edited'][0]['data'][0], PIL.Image.Image)
-        assert result['edited'][0]['data'][0].size == (512, 512)
 
     @pytest.mark.skip(
         reason='[PXT-1115] Image variation endpoint is restricted until Pixeltable org is verified by OpenAI.'


### PR DESCRIPTION
This should fix the following issues with notebooks:

```
FAILED tests/target/nb-tests/multimodal_backend.ipynb::multimodal_backend.ipynb - Error - No such kernel: 'pxt'
FAILED tests/target/nb-tests/working-with-openai.ipynb::working-with-openai.ipynb - image_generations(input, model='dall-e-2')
```

It also deletes tests for image operations with OpenAI Dall-e. There are separate test cases for image generation and edits with gpt-image.