### PR TITLE
[PXT-1159] simplify GroqTest::test_tool_invocations to make it more reliable

### DIFF
--- a/tests/functions/test_groq.py
+++ b/tests/functions/test_groq.py
@@ -3,7 +3,7 @@ import pytest
 import pixeltable as pxt
 
 from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
-from .tool_utils import run_tool_invocations_test
+from .tool_utils import stock_price
 
 
 @pytest.mark.remote_api
@@ -40,15 +40,15 @@ class TestGroq:
         skip_test_if_no_client('groq')
         from pixeltable.functions import groq
 
-        def make_table(tools: pxt.Tools, tool_choice: pxt.ToolChoice) -> pxt.Table:
-            t = pxt.create_table('test_tbl', {'prompt': pxt.String}, if_exists='replace')
-            messages = [{'role': 'user', 'content': t.prompt}]
-            t.add_computed_column(
-                response=groq.chat_completions(
-                    model='llama-3.1-8b-instant', messages=messages, tools=tools, tool_choice=tool_choice
-                )
+        tools = pxt.tools(stock_price)
+        t = pxt.create_table('test_tbl', {'prompt': pxt.String})
+        messages = [{'role': 'user', 'content': t.prompt}]
+        t.add_computed_column(
+            response=groq.chat_completions(
+                model='llama-3.1-8b-instant', messages=messages, tools=tools, tool_choice=None
             )
-            t.add_computed_column(tool_calls=groq.invoke_tools(tools, t.response))
-            return t
+        )
+        t.add_computed_column(tool_calls=groq.invoke_tools(tools, t.response))
 
-        run_tool_invocations_test(make_table, test_non_tool_question=False)
+        tool_calls = t.insert(prompt='What is the stock price of NVDA today?', return_rows=True).rows[0]['tool_calls']
+        assert tool_calls == {'stock_price': [131.17]}, tool_calls


### PR DESCRIPTION
In my experiments while fixing this test, tool calling with Groq is simply unreliable regardless of models and parameters used, which makes the test flaky even with 3 reruns. To address that, I'm reducing the scope of the test to bare minimum with just one tool invocation call, to make sure tool calling is not completely broken.