### PR TITLE
explicitly prohibit the unsupported pk col operations

### DIFF
--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -766,7 +766,8 @@ class TableVersion:
         assert all(is_valid_identifier(col.name) for col in cols if col.name is not None)
         assert all(col.stored is not None for col in cols)
         assert all(col.name not in self.cols_by_name for col in cols if col.name is not None)
-        row_count = self.store_tbl.count()
+        # row count computed on demand
+        row_count: int | None = None
         for col in cols:
             if col.is_pk:
                 raise excs.RequestError(
@@ -774,11 +775,14 @@ class TableVersion:
                     f'Cannot add primary key column {col.name!r} after table creation',
                 )
             # TODO: check this elsewhere?
-            if not col.col_type.nullable and not col.is_computed and row_count > 0:
-                raise excs.RequestError(
-                    excs.ErrorCode.UNSUPPORTED_OPERATION,
-                    f'Cannot add non-nullable column {col.name!r} to table {self.name!r} with existing rows',
-                )
+            if not col.col_type.nullable and not col.is_computed:
+                if row_count is None:
+                    row_count = self.store_tbl.count()
+                if row_count > 0:
+                    raise excs.RequestError(
+                        excs.ErrorCode.UNSUPPORTED_OPERATION,
+                        f'Cannot add non-nullable column {col.name!r} to table {self.name!r} with existing rows',
+                    )
             col.tbl_handle = self.handle
             col.id = self.next_col_id()
 

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -768,6 +768,11 @@ class TableVersion:
         assert all(col.name not in self.cols_by_name for col in cols if col.name is not None)
         row_count = self.store_tbl.count()
         for col in cols:
+            if col.is_pk:
+                raise excs.RequestError(
+                    excs.ErrorCode.UNSUPPORTED_OPERATION,
+                    f'Cannot add primary key column {col.name!r} after table creation',
+                )
             # TODO: check this elsewhere?
             if not col.col_type.nullable and not col.is_computed and row_count > 0:
                 raise excs.RequestError(
@@ -848,6 +853,11 @@ class TableVersion:
         assert all(col.stored is not None for col in cols)
         assert all(col.name not in self.cols_by_name for col in cols if col.name is not None)
         for col in cols:
+            if col.is_pk:
+                raise excs.RequestError(
+                    excs.ErrorCode.UNSUPPORTED_OPERATION,
+                    f'Cannot add primary key column {col.name!r} after table creation',
+                )
             col.tbl_handle = self.handle
             col.id = self.next_col_id()
 
@@ -964,6 +974,11 @@ class TableVersion:
 
         assert self.is_mutable
         assert self.is_versioned, 'TODO: implement for unversioned tables [PXT-1101]'
+
+        if col.is_pk:
+            raise excs.RequestError(
+                excs.ErrorCode.UNSUPPORTED_OPERATION, f'Cannot drop primary key column {col.name!r}'
+            )
 
         # we're creating a new schema version
         self.bump_version(bump_schema_version=True)

--- a/tests/test_primary_key_index.py
+++ b/tests/test_primary_key_index.py
@@ -107,3 +107,13 @@ class TestPrimaryKeyIndex:
         # The PK is still taken by the live row
         with pxt_raises(pxt.ErrorCode.CONSTRAINT_VIOLATION, match='Duplicate primary key'):
             t.insert([{'id': 1, 'val': 50}])
+
+    def test_prohibited_pk_col_ops(self, uses_db: None) -> None:
+        t = pxt.create_table(
+            'test', {'id0': pxt.Required[pxt.Int], 'id1': pxt.Required[pxt.Int]}, primary_key=['id0', 'id1']
+        )
+        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match='Cannot drop primary key column'):
+            t.drop_column(t.id0)
+
+        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match='Cannot add primary key column'):
+            t.add_column(new={'type': pxt.Required[pxt.Int], 'primary_key': True})


### PR DESCRIPTION
Currently, we do not implement pk column add and drop correctly. Doing so requires updating the underlying store index, which today is not happening. We should prohibit these operations on pk columns until we properly implement them.