### PR TITLE
[docs] quickstart guide update

### DIFF
--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -224,7 +224,7 @@ In about 5 minutes, you'll have a multimodal table, a few computed columns, and 
   <Step title="Add a Computed Column">
     Computed columns let you declare transformations that run automatically whenever data is inserted or updated.
     Pixeltable ships with built-in functions for common multimodal operations.
-    Here we [extract image metadata via Pillow](https://docs.pixeltable.com/sdk/latest/image), using `.get_metadata()`
+    Here we [extract image metadata via Pillow](https://docs.pixeltable.com/sdk/latest/image), using `.get_metadata()`.
 
     ```python
     # `get_metadata` works directly on the image object
@@ -346,7 +346,7 @@ In about 5 minutes, you'll have a multimodal table, a few computed columns, and 
 Pixeltable automatically:
 
 1. Created a persistent multimodal table
-2. Image downloads cached on disk
+2. Downloaded and cached your images on disk
 3. Every computed column applied to every row, in order
 4. Stored all results (including computed columns) for instant retrieval
 5. Incrementally process any new images you insert

--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -316,8 +316,8 @@ In about 5 minutes, you'll have a multimodal table, a few computed columns, and 
 
     ```python
     t.insert([
-      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000001.jpg'},
-      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000025.jpg'},
+      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000034.jpg'},
+      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000057.jpg'}
     ])
     ```
 

--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -229,7 +229,7 @@ In about 5 minutes, you'll have a multimodal table, a few computed columns, and 
     ```python
     # `get_metadata` works directly on the image object
     # you do not need to pass in an image path or URL
-    t.add_computed_column(metadata=t.image.get_metadata())
+    t.add_computed_column(metadata=t.image.get_metadata(), if_exists='replace')
     ```
 
     **Output:**

--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -92,140 +92,252 @@ It is recommended that you install Pixeltable in a virtual environment.
 - Report issues on [GitHub](https://github.com/pixeltable/pixeltable/issues)
 - Contact [support@pixeltable.com](mailto:support@pixeltable.com)
 
-## Build an image analysis app
+## Build your first image table
 
 <Tip>
-This guide will help you spin up a functioning AI workload in 5 minutes.
+In about 5 minutes, you'll have a multimodal table, a few computed columns, and your first UDF.
 </Tip>
 
 <Steps>
-  <Step title="Install Required Packages">
-    Pixeltable requires only a minimal set of Python packages by default. To use AI models, you'll need to install
-    additional dependencies.
-    ```bash
-    pip install torch transformers openai
-    ```
-  </Step>
-
   <Step title="Create a Table">
+    Tables in Pixeltable hold structured and unstructured data side by side.
+    Here we declare a single `image` column of type `pxt.Image`.
+
+    <Note>
+    The import command may take a while the first time you `import pixeltable`.
+    Pixeltable creates a local PostgreSQL database.
+    </Note>
+
     ```python
     import pixeltable as pxt
 
-    # Create a namespace and table
+    # Create a namespace and a table.
+    # `if_exists='replace_force'` lets you re-run this script cleanly.
     pxt.create_dir('quickstart', if_exists='replace_force')
-    t = pxt.create_table('quickstart/images', {'image': pxt.Image})
+    ```
+
+    **Output:**
+
+    ```
+    Connected to Pixeltable database at: postgresql+psycopg://postgres:@/pixeltable?host=~/.pixeltable/pgdata
+    Pixeltable dashboard available at: http://localhost:22089
+    Created directory 'quickstart'.
+    <pixeltable.catalog.dir.Dir at 0x122aade00>
+    ```
+
+    ```python
+    t = pxt.create_table(
+        'quickstart/images',
+        {'image': pxt.Image},
+        if_exists='replace_force',
+    )
+    ```
+
+    **Output:**
+
+    ```
+    Created table 'images'.
     ```
 
     <Note>
     Tables are persistent: your data survives restarts and can be queried anytime.
+    But you have to remove the `if_exists='replace_force'` calls!
     </Note>
   </Step>
 
-  <Step title="Add AI Object Detection">
+  <Step title="Inspect the Table">
+    The table has no rows yet, but you can still query it and inspect the schema.
+
     ```python
-    from pixeltable.functions import huggingface
-
-    # Add DETR object detection as a computed column
-    t.add_computed_column(
-        detections=huggingface.detr_for_object_detection(
-            t.image,
-            model_id='facebook/detr-resnet-50'
-        )
-    )
-
-    # Extract labels from detections
-    t.add_computed_column(labels=t.detections.label_text)
+    # No rows yet, but the table is queryable
+    t.head()
     ```
 
-    <Note>
-    Computed columns run automatically whenever new data is inserted.
-    </Note>
+    **Output:**
+
+    ```
+    image
+
+    ```
+
+    ```python
+    # `describe` shows the schema and computed-column definitions
+    t.describe()
+    ```
+
+    **Output:**
+
+    ```
+    table 'quickstart/images'
+    Column Name	Type	Source	Computed With	Comment
+    image	Image	images		
+    ```
+
+    ```python
+    # In a notebook, evaluating the table object is the same as t.describe()
+    t
+    ```
+
+    **Output:**
+
+    ```
+    table 'quickstart/images'
+    Column Name	Type	Source	Computed With	Comment
+    image	Image	images	
+    ```
   </Step>
 
   <Step title="Insert Data">
+    Insert two images directly from public URLs.
+    Pixeltable will download and cache them automatically.
+
     ```python
-    # Insert a few images
     t.insert([
       {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000001.jpg'},
-      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000025.jpg'}
+      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000025.jpg'},
     ])
+    ```
+
+    **Output:**
+
+    ```
+    Inserted 2 rows with 0 errors in 0.03 s (64.16 rows/s)
+    2 rows inserted.
     ```
 
     <Note>
     You can insert images from URLs and/or local paths in any combination.
     </Note>
-  </Step>
 
-  <Step title="Query Results">
     ```python
-    # Query results
-    t.select(t.image, t.labels).collect()
+    # The schema is unchanged, but the table now has rows
+    t.head()
     ```
 
-    **Expected output:**
+    **Output:**
 
-    | image      | labels              |
-    |------------|---------------------|
-    | [Image]    | [car, parking meter, truck, car, car, truck]   |
-    | [Image]    | [giraffe, giraffe] |
-
+    ```
+    # TODO: how to insert a table with image here
+    ```
   </Step>
 
-  <Step title="(Optional) Add LLM Vision">
-    <Tip>
-    You'll need an OpenAI API key to use this step. If you don't have one, you can
-    safely skip this step.
-    </Tip>
+  <Step title="Add a Computed Column">
+    Computed columns let you declare transformations that run automatically whenever data is inserted or updated.
+    Pixeltable ships with built-in functions for common multimodal operations.
+    Here we [extract image metadata via Pillow](https://docs.pixeltable.com/sdk/latest/image), using `.get_metadata()`
 
     ```python
-    import os
-    from pixeltable.functions import openai
+    # `get_metadata` works directly on the image object
+    # you do not need to pass in an image path or URL
+    t.add_computed_column(metadata=t.image.get_metadata())
+    ```
 
-    # Set your API key
-    os.environ['OPENAI_API_KEY'] = 'your-key-here'
+    **Output:**
 
-    messages = [
-        {
-            'role': 'user',
-            'content': [
-                {'type': 'text', 'text': 'Describe this image in one sentence.'},
-                {'type': 'image_url', 'image_url': t.image},
-            ],
-        }
-    ]
-    t.add_computed_column(
-        response=openai.chat_completions(messages, model='gpt-4o-mini')
-    )
-
-    t.select(t.image, t.labels, t.response.choices[0].message.content).collect()
+    ```
+    Added 2 column values with 0 errors in 0.06 s (33.12 rows/s)
+    2 rows updated.
     ```
 
     ```python
-    # See the full text of the response in row 0
-    t.select(t.response.choices[0].message.content).collect()[0]
+    t.head()
+    ```
+
+    **Output:**
+
+    ```
+    <!-- TODO: paste t.head() output here -->
     ```
 
     <Note>
-    Pixeltable orchestrates LLM calls for optimized throughput, handling
-    rate limiting, retries, and caching automatically.
+    Think of `.add_computed_column()` as mapping a function across a column,
+    except the result is persisted and incrementally maintained.
     </Note>
   </Step>
 
-  <Step title="Insert More Data">
+  <Step title="Chain Computed Columns">
+    Computed columns can reference earlier computed columns.
+    Here we pull individual fields out of the JSON `metadata` column and combine them with normal Python arithmetic.
+
+    ```python
+    # Cast to pxt.Int so the values flow through Pixeltable's type system
+    t.add_computed_column(
+        width=t.metadata.width.astype(pxt.Int),
+        if_exists='replace',
+    )
+    t.add_computed_column(
+        height=t.metadata.height.astype(pxt.Int),
+        if_exists='replace',
+    )
+
+    # Arithmetic between columns is itself an expression
+    t.add_computed_column(area=(t.height * t.width), if_exists='replace')
+
+    t.head()
+    ```
+
+    **Output:**
+
+    ```
+    <!-- TODO: paste t.head() output here -->
+    ```
+  </Step>
+
+  <Step title="Write a User-Defined Function">
+    For anything Pixeltable doesn't provide out of the box you can write a user-defined function (UDF).
+    This is a normal Python function with the `@pxt.udf` decorator and type hints.
+
+    ```python
+    from PIL import Image
+
+    # The decorator registers this function with Pixeltable.
+    # Type hints are required so Pixeltable knows how to store the result.
+    @pxt.udf
+    def get_dims(image: Image.Image) -> str:
+        return f'{image.size}'
+
+    # The UDF runs automatically on every existing and future row
+    t.add_computed_column(pil_size=get_dims(t.image), if_exists='replace')
+
+    t.head()
+    ```
+
+    **Output:**
+
+    ```
+    <!-- TODO: paste t.head() output here -->
+    ```
+  </Step>
+
+  <Step title="Re-insert to See Incremental Computation">
+    Insert the same two images again.
+    Pixeltable appends the new rows and runs every computed column you've defined
+    (`metadata`, `width`, `height`, `area`, `pil_size`) on just the new rows.
+
     ```python
     t.insert([
-      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000034.jpg'},
-      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000057.jpg'}
+      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000001.jpg'},
+      {'image': 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images/000000000025.jpg'},
     ])
+    ```
 
-    t.select(t.image, t.labels).collect()
+    ```python
+    # Four rows now: the original two plus the two we just appended,
+    # all with every computed column populated.
+    t.head()
+    ```
+
+    **Output:**
+
+    ```
+    <!-- TODO: paste t.head() output here -->
     ```
 
     <Note>
-    When new data is inserted into tables, Pixeltable incrementally runs all
-    computed columns against the new data, ensuring the table is up to date.
-    If you completed the optional LLM Vision step, the descriptions will also
-    be generated automatically for these new images.
+    Pixeltable doesn't re-run computed columns over rows that already have values.
+    Only the newly inserted rows are processed.
+    The same applies when you add a new computed column later:
+    it backfills existing rows and runs on every future insert.
     </Note>
   </Step>
 </Steps>
@@ -234,10 +346,10 @@ This guide will help you spin up a functioning AI workload in 5 minutes.
 Pixeltable automatically:
 
 1. Created a persistent multimodal table
-2. Downloaded and cached the DETR model
-3. Ran inference on your image
+2. Image downloads cached on disk
+3. Every computed column applied to every row, in order
 4. Stored all results (including computed columns) for instant retrieval
-5. Will incrementally process any new images you insert
+5. Incrementally process any new images you insert
 </Accordion>
 
 ## Next Steps


### PR DESCRIPTION
fixes #1354 - Doing a pass of a new quickstart guide for pixel table.

Currently, I don't have a good idea on how best to insert the `.head()` output into the quickstart.
I think this would be important to show so people scrolling through the guide can *see* what makes pixeltable different.


- [ ] Need to insert missing output results (mostly table `.head()` output.


Note the first commit is a first pass of getting the prose through. I'm personally having issues getting all the environment setup for `make docs` working.