### PR TITLE
[PXT-1155] random_ops fix for: ValueError: sleep length must be non-n…

### DIFF
--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import random
-import subprocess
 import sys
 import time
 from argparse import ArgumentParser
@@ -411,22 +410,12 @@ class RandomTableOps:
 
 
 def run(
-    worker_id: int,
-    read_only: bool,
-    include_only_ops: list[str] | None,
-    exclude_ops: list[str] | None,
-    config_str: str,
-    *,
-    init_only: bool = False,
+    worker_id: int, read_only: bool, include_only_ops: list[str] | None, exclude_ops: list[str] | None, config_str: str
 ) -> None:
     """Entrypoint for a worker process."""
     os.environ['PIXELTABLE_VERBOSITY'] = '0'
     os.environ['PXTTEST_RANDOM_TBL_OPS'] = str(worker_id)
     config = RandomTableOpsConfig(**json.loads(config_str))
-
-    if init_only:
-        pxt.init()
-        return
 
     try:
         RandomTableOps(worker_id, read_only, include_only_ops or [], exclude_ops or [], config).run()
@@ -504,13 +493,7 @@ def main() -> None:
 
     # Initialize Pixeltable before the actual test
     print('Running pxt.init()...')
-    result = subprocess.run(
-        ['python', '-c', f'from tool.random_ops import run; run(0, False, None, None, {config_str}, init_only=True)'],
-        check=False,
-    )
-    if result.returncode != 0:
-        print('Init failed')
-        sys.exit(result.returncode)
+    pxt.init()
 
     worker_args = [
         [

--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import random
+import subprocess
 import sys
 import time
 from argparse import ArgumentParser
@@ -416,22 +417,22 @@ def init(config: RandomTableOpsConfig) -> None:
 
 
 def run(
-    worker_id: int, read_only: bool, include_only_ops: list[str] | None, exclude_ops: list[str] | None, config_str: str
+    worker_id: int,
+    read_only: bool,
+    include_only_ops: list[str] | None,
+    exclude_ops: list[str] | None,
+    config_str: str,
+    *,
+    init_only: bool = False,
 ) -> None:
     """Entrypoint for a worker process."""
     os.environ['PIXELTABLE_VERBOSITY'] = '0'
     os.environ['PXTTEST_RANDOM_TBL_OPS'] = str(worker_id)
     config = RandomTableOpsConfig(**json.loads(config_str))
 
-    # In order to localize initialization to a single process, we call pxt.init() only from worker 0. The timings are
-    # adjusted so that all workers start issuing operations at approximately the same time.
-    # TODO: Do we want pxt.init() to be concurrency-safe (the first time it is called, when setting up the DB)?
-    if worker_id == 0:
-        t = time.monotonic()
+    if init_only:
         init(config)
-        time.sleep(5 - time.monotonic() + t)  # Sleep until 5 seconds after init
-    else:
-        time.sleep(5)
+        return
 
     try:
         RandomTableOps(worker_id, read_only, include_only_ops or [], exclude_ops or [], config).run()
@@ -504,6 +505,15 @@ def main() -> None:
                 sys.exit(1)
 
     config_str = repr(json.dumps(dataclasses.asdict(config)))
+
+    # Initialize Pixeltable before the actual test
+    print('Running pxt.init()...')
+    result = subprocess.run(
+        ['python', '-c', f'from tool.random_ops import run; run(0, False, None, None, {config_str}, init_only=True)'], check=False
+    )
+    if result.returncode != 0:
+        print('Init failed')
+        sys.exit(result.returncode)
 
     worker_args = [
         [

--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -410,12 +410,6 @@ class RandomTableOps:
             time.sleep(random.uniform(0.1, 0.5))
 
 
-def init(config: RandomTableOpsConfig) -> None:
-    """Initialization. This will only be run once before test workers are started."""
-    print(json.dumps(dataclasses.asdict(config), indent=4))
-    pxt.init()
-
-
 def run(
     worker_id: int,
     read_only: bool,
@@ -431,7 +425,7 @@ def run(
     config = RandomTableOpsConfig(**json.loads(config_str))
 
     if init_only:
-        init(config)
+        pxt.init()
         return
 
     try:
@@ -504,7 +498,9 @@ def main() -> None:
                 )
                 sys.exit(1)
 
-    config_str = repr(json.dumps(dataclasses.asdict(config)))
+    config_dict = dataclasses.asdict(config)
+    print(json.dumps(config_dict, indent=4))
+    config_str = repr(json.dumps(config_dict))
 
     # Initialize Pixeltable before the actual test
     print('Running pxt.init()...')

--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -509,7 +509,8 @@ def main() -> None:
     # Initialize Pixeltable before the actual test
     print('Running pxt.init()...')
     result = subprocess.run(
-        ['python', '-c', f'from tool.random_ops import run; run(0, False, None, None, {config_str}, init_only=True)'], check=False
+        ['python', '-c', f'from tool.random_ops import run; run(0, False, None, None, {config_str}, init_only=True)'],
+        check=False,
     )
     if result.returncode != 0:
         print('Init failed')

--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -411,7 +411,7 @@ class RandomTableOps:
 
 
 def init(config: RandomTableOpsConfig) -> None:
-    """Initialization. This will ONLY be run once (globally), on Worker 0."""
+    """Initialization. This will only be run once before test workers are started."""
     print(json.dumps(dataclasses.asdict(config), indent=4))
     pxt.init()
 

--- a/tool/worker_harness.py
+++ b/tool/worker_harness.py
@@ -21,6 +21,7 @@ def run_workers(
     if script is not None:
         worker_args = [[script, str(i)] for i in range(num_workers)]
 
+    print(f'Starting {num_workers} workers to run for {duration}s...')
     processes: list[subprocess.Popen] = []
     for i in range(num_workers):
         p = subprocess.Popen(['python', *worker_args[i]])


### PR DESCRIPTION
…egative

The fix is to initialize Pixeltable synchronously, before staring the random-ops workers.