### PR TITLE
Typed JSON return values for audio.get_metadata() and video.get_metadata()

### DIFF
--- a/docs/public_api.opml
+++ b/docs/public_api.opml
@@ -348,6 +348,9 @@
           <outline text="func|pixeltable.functions.vision.bboxes_resize_canvas" />
           <outline text="func|pixeltable.functions.vision.overlay_segmentation" />
         </outline>
+        <outline text="class|pixeltable.functions.CodecContextMetadata" />
+        <outline text="class|pixeltable.functions.ContainerMetadata" />
+        <outline text="class|pixeltable.functions.StreamMetadata" />
       </outline>
 
       <!-- AI Integrations group -->

--- a/pixeltable/func/signature.py
+++ b/pixeltable/func/signature.py
@@ -247,8 +247,17 @@ class Signature:
                 param_strs.append(f'{p.name}: pxt.{p.col_type}')
         return ', '.join(param_strs)
 
+    def return_str(self, pretty_print_json: bool = False) -> str:
+        return_type = self.get_return_type()
+        if pretty_print_json and isinstance(return_type, ts.JsonType) and return_type.pretty_print_name is not None:
+            return return_type.pretty_print_name
+        return f'pxt.{return_type}'
+
+    def _to_str(self, pretty_print_json: bool = False) -> str:
+        return f'({self.params_str()}) -> {self.return_str(pretty_print_json)}'
+
     def __str__(self) -> str:
-        return f'({self.params_str()}) -> pxt.{self.get_return_type()}'
+        return self._to_str()
 
     @classmethod
     def _infer_type(cls, annotation: type | None) -> tuple[ts.ColumnType | None, bool | None]:

--- a/pixeltable/functions/__init__.py
+++ b/pixeltable/functions/__init__.py
@@ -6,6 +6,7 @@ This parent module contains general-purpose UDFs that apply to multiple data typ
 
 # ruff: noqa: F401
 
+from pixeltable.functions.util import CodecContextMetadata, ContainerMetadata, StreamMetadata
 from pixeltable.utils.code import local_public_names
 
 from . import (

--- a/pixeltable/functions/audio.py
+++ b/pixeltable/functions/audio.py
@@ -11,17 +11,19 @@ import av
 import numpy as np
 
 import pixeltable as pxt
-import pixeltable.utils.av as av_utils
 from pixeltable import exceptions as excs
 from pixeltable.env import Env
+from pixeltable.utils import av as av_utils
 from pixeltable.utils.code import local_public_names
 from pixeltable.utils.local_store import TempStore
+
+from . import util
 
 _logger = logging.getLogger('pixeltable')
 
 
 @pxt.udf(is_method=True)
-def get_metadata(audio: pxt.Audio) -> av_utils.ContainerMetadata:
+def get_metadata(audio: pxt.Audio) -> util.ContainerMetadata:
     """
     Gets various metadata associated with an audio file and returns it as a dictionary.
 
@@ -61,7 +63,7 @@ def get_metadata(audio: pxt.Audio) -> av_utils.ContainerMetadata:
 
         >>> tbl.select(tbl.audio_col.get_metadata()).collect()
     """
-    return av_utils.get_metadata(audio)
+    return util.get_metadata(audio)
 
 
 @pxt.udf()

--- a/pixeltable/functions/audio.py
+++ b/pixeltable/functions/audio.py
@@ -25,13 +25,14 @@ _logger = logging.getLogger('pixeltable')
 @pxt.udf(is_method=True)
 def get_metadata(audio: pxt.Audio) -> util.ContainerMetadata:
     """
-    Gets various metadata associated with an audio file and returns it as a dictionary.
+    Gets various metadata associated with an audio file and returns it as
+    a [`ContainerMetadata`][pixeltable.functions.ContainerMetadata] dictionary.
 
     Args:
         audio: The audio to get metadata for.
 
     Returns:
-        A `dict` such as the following:
+        A [`ContainerMetadata`][pixeltable.functions.ContainerMetadata] with typical structure:
 
             ```json
             {

--- a/pixeltable/functions/audio.py
+++ b/pixeltable/functions/audio.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger('pixeltable')
 
 
 @pxt.udf(is_method=True)
-def get_metadata(audio: pxt.Audio) -> dict:
+def get_metadata(audio: pxt.Audio) -> av_utils.ContainerMetadata:
     """
     Gets various metadata associated with an audio file and returns it as a dictionary.
 

--- a/pixeltable/functions/util.py
+++ b/pixeltable/functions/util.py
@@ -1,3 +1,8 @@
+from typing import TypedDict
+
+import av
+import av.container
+import av.stream
 import PIL.Image
 
 from pixeltable.config import Config
@@ -31,3 +36,96 @@ def normalize_image_mode(image: PIL.Image.Image) -> PIL.Image.Image:
     if image.mode == 'LA':
         return image.convert('RGBA')
     return image
+
+
+class CodecContextMetadata(TypedDict, total=False):
+    name: str
+    codec_tag: str
+    profile: str | None
+    channels: int | None  # audio only
+    pix_fmt: str | None  # video only
+
+
+class StreamMetadata(TypedDict, total=False):
+    type: str
+    duration: int | None
+    time_base: float | None
+    duration_seconds: float | None
+    frames: int
+    metadata: dict[str, str]
+    codec_context: CodecContextMetadata
+    width: int  # video only
+    height: int  # video only
+    average_rate: float | None  # video only
+    base_rate: float | None  # video only
+    guessed_rate: float | None  # video only
+
+
+class ContainerMetadata(TypedDict):
+    bit_exact: bool
+    bit_rate: int | None
+    size: int | None
+    metadata: dict[str, str]
+    streams: list[StreamMetadata]
+
+
+def get_metadata(path: str) -> ContainerMetadata:
+    with av.open(path) as container:
+        assert isinstance(container, av.container.InputContainer)
+        streams_info = [__get_stream_metadata(stream) for stream in container.streams]
+        result: ContainerMetadata = {
+            'bit_exact': getattr(container, 'bit_exact', False),
+            'bit_rate': container.bit_rate,
+            'size': container.size,
+            'metadata': container.metadata,
+            'streams': streams_info,
+        }
+    return result
+
+
+def __get_stream_metadata(stream: av.stream.Stream) -> StreamMetadata:
+    if stream.type not in ('audio', 'video'):
+        result_unsupported: StreamMetadata = {'type': stream.type}
+        return result_unsupported
+
+    codec_context = stream.codec_context
+    codec_tag = codec_context.codec_tag.encode('unicode-escape').decode('utf-8')
+
+    # Compute duration_seconds from stream-level duration.
+    # We intentionally don't fall back to container.duration here because it's ambiguous —
+    # it may reflect a different stream's duration (e.g. audio vs video).
+    duration_seconds: float | None = None
+    if stream.duration is not None and stream.time_base is not None:
+        duration_seconds = float(stream.duration * stream.time_base)
+
+    codec_context_md: CodecContextMetadata = {
+        'name': codec_context.name,
+        'codec_tag': codec_tag,
+        'profile': codec_context.profile,
+    }
+
+    result: StreamMetadata = {
+        'type': stream.type,
+        'duration': stream.duration,
+        'time_base': float(stream.time_base) if stream.time_base is not None else None,
+        'duration_seconds': duration_seconds,
+        'frames': stream.frames,
+        'metadata': stream.metadata,
+        'codec_context': codec_context_md,
+    }
+
+    if stream.type == 'audio':
+        assert isinstance(stream.codec_context, av.AudioCodecContext)
+        channels = stream.codec_context.channels
+        codec_context_md['channels'] = int(channels) if channels is not None else None
+    else:
+        assert stream.type == 'video'
+        assert isinstance(stream, av.VideoStream)
+        codec_context_md['pix_fmt'] = getattr(stream.codec_context, 'pix_fmt', None)
+        result['width'] = stream.width
+        result['height'] = stream.height
+        result['average_rate'] = float(stream.average_rate) if stream.average_rate is not None else None
+        result['base_rate'] = float(stream.base_rate) if stream.base_rate is not None else None
+        result['guessed_rate'] = float(stream.guessed_rate) if stream.guessed_rate is not None else None
+
+    return result

--- a/pixeltable/functions/util.py
+++ b/pixeltable/functions/util.py
@@ -39,34 +39,65 @@ def normalize_image_mode(image: PIL.Image.Image) -> PIL.Image.Image:
 
 
 class CodecContextMetadata(TypedDict, total=False):
+    """Metadata about a stream's codec."""
+
     name: str
+    """Codec name (e.g. `'h264'`, `'aac'`)."""
     codec_tag: str
+    """Four-character codec tag, unicode-escaped."""
     profile: str | None
-    channels: int | None  # audio only
-    pix_fmt: str | None  # video only
+    """Codec profile (e.g. `'High'`, `'LC'`), or `None` if unavailable."""
+    channels: int | None
+    """Number of audio channels. Present only for audio streams."""
+    pix_fmt: str | None
+    """Pixel format (e.g. `'yuv420p'`). Present only for video streams."""
 
 
 class StreamMetadata(TypedDict, total=False):
+    """Metadata for a stream within a media container."""
+
     type: str
+    """Stream type: typically `'audio'` or `'video'`. Other stream types (e.g. subtitles) will have a
+    `StreamMetadata` entry, but with no metadata other than `type`."""
     duration: int | None
+    """Stream duration in `time_base` units, or `None` if unknown."""
     time_base: float | None
+    """Time base of the stream as a float (seconds per tick), or `None` if unknown."""
     duration_seconds: float | None
+    """Stream duration in seconds, computed from `duration` and `time_base`."""
     frames: int
+    """Number of frames in the stream (may be 0 if unknown)."""
     metadata: dict[str, str]
+    """Additional stream-specific metadata tags (e.g. language, title)."""
     codec_context: CodecContextMetadata
-    width: int  # video only
-    height: int  # video only
-    average_rate: float | None  # video only
-    base_rate: float | None  # video only
-    guessed_rate: float | None  # video only
+    """Codec information for this stream."""
+    width: int
+    """Frame width in pixels. Present only for video streams."""
+    height: int
+    """Frame height in pixels. Present only for video streams."""
+    average_rate: float | None
+    """Average frame rate in FPS (frames per second). Present only for video streams."""
+    base_rate: float | None
+    """Base (constant) frame rate in FPS. Present only for video streams."""
+    guessed_rate: float | None
+    """Guessed frame rate in FPS. Present only for video streams."""
 
 
 class ContainerMetadata(TypedDict):
+    """Metadata for a media container, as returned by
+    [`audio.get_metadata()`][pixeltable.functions.audio.get_metadata]
+    or [`video.get_metadata()`][pixeltable.functions.video.get_metadata]."""
+
     bit_exact: bool
+    """Whether the container was opened in bit-exact mode."""
     bit_rate: int | None
+    """Overall bit rate of the container in bits per second, or `None` if unknown."""
     size: int | None
+    """Size of the container in bytes, or `None` if unknown."""
     metadata: dict[str, str]
+    """Additional container-level metadata tags (e.g. title, encoder)."""
     streams: list[StreamMetadata]
+    """Per-stream metadata for each stream in the container."""
 
 
 def get_metadata(path: str) -> ContainerMetadata:

--- a/pixeltable/functions/video.py
+++ b/pixeltable/functions/video.py
@@ -140,13 +140,14 @@ def extract_audio(
 @pxt.udf(is_method=True)
 def get_metadata(video: pxt.Video) -> util.ContainerMetadata:
     """
-    Gets various metadata associated with a video file and returns it as a dictionary.
+    Gets various metadata associated with a video file and returns it as
+    a [`ContainerMetadata`][pixeltable.functions.ContainerMetadata] dictionary.
 
     Args:
         video: The video for which to get metadata.
 
     Returns:
-        A `dict` such as the following:
+        A [`ContainerMetadata`][pixeltable.functions.ContainerMetadata] with typical structure:
 
             ```json
             {

--- a/pixeltable/functions/video.py
+++ b/pixeltable/functions/video.py
@@ -25,6 +25,8 @@ from pixeltable.functions.math import abs as pxt_abs, floor as pxt_floor
 from pixeltable.utils.code import local_public_names
 from pixeltable.utils.local_store import TempStore
 
+from . import util
+
 if TYPE_CHECKING:
     from scenedetect.detectors import SceneDetector  # type: ignore[import-untyped]
 
@@ -136,7 +138,7 @@ def extract_audio(
 
 
 @pxt.udf(is_method=True)
-def get_metadata(video: pxt.Video) -> av_utils.ContainerMetadata:
+def get_metadata(video: pxt.Video) -> util.ContainerMetadata:
     """
     Gets various metadata associated with a video file and returns it as a dictionary.
 
@@ -186,7 +188,7 @@ def get_metadata(video: pxt.Video) -> av_utils.ContainerMetadata:
 
         >>> tbl.select(tbl.video_col.get_metadata()).collect()
     """
-    return av_utils.get_metadata(video)
+    return util.get_metadata(video)
 
 
 @pxt.udf(is_method=True)
@@ -511,7 +513,7 @@ def _concat_videos(
     # Check that all videos have the same resolution
     resolutions: list[tuple[int, int]] = []
     for video in videos:
-        metadata = av_utils.get_metadata(str(video))
+        metadata = util.get_metadata(str(video))
         video_stream = next((stream for stream in metadata['streams'] if stream['type'] == 'video'), None)
         if video_stream is None:
             raise pxt.RequestError(
@@ -1272,7 +1274,7 @@ def overlay_image(
 
     overlay_label: str
     if scale is not None:
-        md = av_utils.get_metadata(str(video))
+        md = util.get_metadata(str(video))
         video_height = next(s for s in md['streams'] if s['type'] == 'video')['height']
         filters.append(f'[1:v]scale=-2:trunc({video_height}*{scale}/2)*2[ovr_scaled]')
         overlay_label = '[ovr_scaled]'
@@ -1774,10 +1776,10 @@ def transition(
         raise pxt.RequestError(pxt.ErrorCode.INVALID_ARGUMENT, f'duration must be positive, got {duration}')
 
     # xfade requires both inputs to have the same resolution
-    md1 = av_utils.get_metadata(str(video1))
+    md1 = util.get_metadata(str(video1))
     v1_stream = next(s for s in md1['streams'] if s['type'] == 'video')
     w1, h1 = v1_stream['width'], v1_stream['height']
-    md2 = av_utils.get_metadata(str(video2))
+    md2 = util.get_metadata(str(video2))
     v2_stream = next(s for s in md2['streams'] if s['type'] == 'video')
     w2, h2 = v2_stream['width'], v2_stream['height']
     if (w1, h1) != (w2, h2):

--- a/pixeltable/functions/video.py
+++ b/pixeltable/functions/video.py
@@ -136,7 +136,7 @@ def extract_audio(
 
 
 @pxt.udf(is_method=True)
-def get_metadata(video: pxt.Video) -> dict:
+def get_metadata(video: pxt.Video) -> av_utils.ContainerMetadata:
     """
     Gets various metadata associated with a video file and returns it as a dictionary.
 

--- a/pixeltable/share/packager.py
+++ b/pixeltable/share/packager.py
@@ -20,7 +20,6 @@ import pyarrow.parquet as pq
 import sqlalchemy as sql
 
 import pixeltable as pxt
-import pixeltable.utils.av as av_utils
 from pixeltable import catalog, exceptions as excs, metadata, type_system as ts
 from pixeltable.catalog.table_version import TableVersionKey, TableVersionMd
 from pixeltable.exprs.data_row import CellMd
@@ -366,8 +365,10 @@ class TablePackager:
             return base64.b64encode(buffer.getvalue()).decode()
 
     def __encode_audio(self, audio_path: str) -> str | None:
+        from pixeltable.functions.util import get_metadata
+
         try:
-            audio_md = av_utils.get_metadata(audio_path)
+            audio_md = get_metadata(audio_path)
             if 'streams' in audio_md:
                 duration = audio_md['streams'][0]['duration_seconds']
                 assert isinstance(duration, float)

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -502,7 +502,11 @@ class ColumnType:
                 )
             fields[name] = col_type
         optional_keys = frozenset(name for name, info in t.model_fields.items() if not info.is_required())
-        return JsonType(JsonType.TypeSchema(type_spec=fields, optional_keys=optional_keys), nullable=nullable_default, pretty_print_name=t.__name__)
+        return JsonType(
+            JsonType.TypeSchema(type_spec=fields, optional_keys=optional_keys),
+            nullable=nullable_default,
+            pretty_print_name=t.__name__,
+        )
 
     @classmethod
     def normalize_type(
@@ -964,7 +968,9 @@ class JsonType(ColumnType):
     # pretty_print_name is used only for generating clean documentation; it is not stored in the catalog.
     pretty_print_name: str | None
 
-    def __init__(self, type_schema: TypeSchema | None = None, nullable: bool = False, pretty_print_name: str | None = None):
+    def __init__(
+        self, type_schema: TypeSchema | None = None, nullable: bool = False, pretty_print_name: str | None = None
+    ):
         super().__init__(self.Type.JSON, nullable=nullable)
         self.type_schema = type_schema
         self.pretty_print_name = pretty_print_name

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -486,6 +486,7 @@ class ColumnType:
         return JsonType(
             JsonType.TypeSchema(type_spec=type_spec, optional_keys=getattr(t, '__optional_keys__', frozenset())),
             nullable=nullable_default,
+            pretty_print_name=t.__name__,
         )
 
     @classmethod
@@ -501,7 +502,7 @@ class ColumnType:
                 )
             fields[name] = col_type
         optional_keys = frozenset(name for name, info in t.model_fields.items() if not info.is_required())
-        return JsonType(JsonType.TypeSchema(type_spec=fields, optional_keys=optional_keys), nullable=nullable_default)
+        return JsonType(JsonType.TypeSchema(type_spec=fields, optional_keys=optional_keys), nullable=nullable_default, pretty_print_name=t.__name__)
 
     @classmethod
     def normalize_type(
@@ -960,9 +961,13 @@ class BinaryType(ColumnType):
 class JsonType(ColumnType):
     type_schema: TypeSchema | None
 
-    def __init__(self, type_schema: TypeSchema | None = None, nullable: bool = False):
+    # pretty_print_name is used only for generating clean documentation; it is not stored in the catalog.
+    pretty_print_name: str | None
+
+    def __init__(self, type_schema: TypeSchema | None = None, nullable: bool = False, pretty_print_name: str | None = None):
         super().__init__(self.Type.JSON, nullable=nullable)
         self.type_schema = type_schema
+        self.pretty_print_name = pretty_print_name
 
     @classmethod
     def from_json_type_arg(cls, json_type_arg: Any) -> JsonType:

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -966,6 +966,9 @@ class JsonType(ColumnType):
     type_schema: TypeSchema | None
 
     # pretty_print_name is used only for generating clean documentation; it is not stored in the catalog.
+    # It preserves the name of the `TypedDict` used to define this `JsonType` (if there is one), so that the
+    # `TypedDict` can be printed in the docs rather than the fully expanded Json type.
+    # (Compare: `MyTypedDict` vs `Json[{'field1': String, 'field2': Int, 'field3': {'subfield': Float}}]`, etc.)
     pretty_print_name: str | None
 
     def __init__(

--- a/pixeltable/utils/av.py
+++ b/pixeltable/utils/av.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import re
 import subprocess
@@ -7,7 +5,7 @@ from dataclasses import dataclass
 from fractions import Fraction
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Iterator, NoReturn
+from typing import Any, Iterator, NoReturn, TypedDict
 
 import av
 import av.stream
@@ -28,11 +26,42 @@ AUDIO_FORMATS: dict[str, tuple[str, str]] = {
 }
 
 
-def get_metadata(path: str) -> dict:
+class CodecContextMetadata(TypedDict, total=False):
+    name: str
+    codec_tag: str
+    profile: str | None
+    channels: int | None  # audio only
+    pix_fmt: str | None  # video only
+
+
+class StreamMetadata(TypedDict, total=False):
+    type: str
+    duration: int | None
+    time_base: float | None
+    duration_seconds: float | None
+    frames: int
+    metadata: dict[str, str]
+    codec_context: CodecContextMetadata
+    width: int  # video only
+    height: int  # video only
+    average_rate: float | None  # video only
+    base_rate: float | None  # video only
+    guessed_rate: float | None  # video only
+
+
+class ContainerMetadata(TypedDict):
+    bit_exact: bool
+    bit_rate: int | None
+    size: int | None
+    metadata: dict[str, str]
+    streams: list[StreamMetadata]
+
+
+def get_metadata(path: str) -> ContainerMetadata:
     with av.open(path) as container:
         assert isinstance(container, av.container.InputContainer)
         streams_info = [__get_stream_metadata(stream) for stream in container.streams]
-        result = {
+        result: ContainerMetadata = {
             'bit_exact': getattr(container, 'bit_exact', False),
             'bit_rate': container.bit_rate,
             'size': container.size,
@@ -42,16 +71,13 @@ def get_metadata(path: str) -> dict:
     return result
 
 
-def __get_stream_metadata(stream: av.stream.Stream) -> dict:
+def __get_stream_metadata(stream: av.stream.Stream) -> StreamMetadata:
     if stream.type not in ('audio', 'video'):
-        return {'type': stream.type}  # Currently unsupported
+        result_unsupported: StreamMetadata = {'type': stream.type}
+        return result_unsupported
 
     codec_context = stream.codec_context
-    codec_context_md: dict[str, Any] = {
-        'name': codec_context.name,
-        'codec_tag': codec_context.codec_tag.encode('unicode-escape').decode('utf-8'),
-        'profile': codec_context.profile,
-    }
+    codec_tag = codec_context.codec_tag.encode('unicode-escape').decode('utf-8')
 
     # Compute duration_seconds from stream-level duration.
     # We intentionally don't fall back to container.duration here because it's ambiguous —
@@ -60,7 +86,13 @@ def __get_stream_metadata(stream: av.stream.Stream) -> dict:
     if stream.duration is not None and stream.time_base is not None:
         duration_seconds = float(stream.duration * stream.time_base)
 
-    metadata = {
+    codec_context_md: CodecContextMetadata = {
+        'name': codec_context.name,
+        'codec_tag': codec_tag,
+        'profile': codec_context.profile,
+    }
+
+    result: StreamMetadata = {
         'type': stream.type,
         'duration': stream.duration,
         'time_base': float(stream.time_base) if stream.time_base is not None else None,
@@ -71,26 +103,20 @@ def __get_stream_metadata(stream: av.stream.Stream) -> dict:
     }
 
     if stream.type == 'audio':
-        # Additional metadata for audio
         assert isinstance(stream.codec_context, av.AudioCodecContext)
         channels = stream.codec_context.channels
         codec_context_md['channels'] = int(channels) if channels is not None else None
     else:
         assert stream.type == 'video'
-        assert isinstance(stream, av.video.stream.VideoStream)
-        # Additional metadata for video
+        assert isinstance(stream, av.VideoStream)
         codec_context_md['pix_fmt'] = getattr(stream.codec_context, 'pix_fmt', None)
-        metadata.update(
-            **{
-                'width': stream.width,
-                'height': stream.height,
-                'average_rate': float(stream.average_rate) if stream.average_rate is not None else None,
-                'base_rate': float(stream.base_rate) if stream.base_rate is not None else None,
-                'guessed_rate': float(stream.guessed_rate) if stream.guessed_rate is not None else None,
-            }
-        )
+        result['width'] = stream.width
+        result['height'] = stream.height
+        result['average_rate'] = float(stream.average_rate) if stream.average_rate is not None else None
+        result['base_rate'] = float(stream.base_rate) if stream.base_rate is not None else None
+        result['guessed_rate'] = float(stream.guessed_rate) if stream.guessed_rate is not None else None
 
-    return metadata
+    return result
 
 
 def get_video_duration(path: str) -> float | None:

--- a/pixeltable/utils/av.py
+++ b/pixeltable/utils/av.py
@@ -5,10 +5,9 @@ from dataclasses import dataclass
 from fractions import Fraction
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Iterator, NoReturn, TypedDict
+from typing import Any, Iterator, NoReturn
 
 import av
-import av.stream
 import PIL.Image
 from typing_extensions import Self
 
@@ -24,99 +23,6 @@ AUDIO_FORMATS: dict[str, tuple[str, str]] = {
     'flac': ('flac', 'flac'),
     'mp4': ('aac', 'm4a'),
 }
-
-
-class CodecContextMetadata(TypedDict, total=False):
-    name: str
-    codec_tag: str
-    profile: str | None
-    channels: int | None  # audio only
-    pix_fmt: str | None  # video only
-
-
-class StreamMetadata(TypedDict, total=False):
-    type: str
-    duration: int | None
-    time_base: float | None
-    duration_seconds: float | None
-    frames: int
-    metadata: dict[str, str]
-    codec_context: CodecContextMetadata
-    width: int  # video only
-    height: int  # video only
-    average_rate: float | None  # video only
-    base_rate: float | None  # video only
-    guessed_rate: float | None  # video only
-
-
-class ContainerMetadata(TypedDict):
-    bit_exact: bool
-    bit_rate: int | None
-    size: int | None
-    metadata: dict[str, str]
-    streams: list[StreamMetadata]
-
-
-def get_metadata(path: str) -> ContainerMetadata:
-    with av.open(path) as container:
-        assert isinstance(container, av.container.InputContainer)
-        streams_info = [__get_stream_metadata(stream) for stream in container.streams]
-        result: ContainerMetadata = {
-            'bit_exact': getattr(container, 'bit_exact', False),
-            'bit_rate': container.bit_rate,
-            'size': container.size,
-            'metadata': container.metadata,
-            'streams': streams_info,
-        }
-    return result
-
-
-def __get_stream_metadata(stream: av.stream.Stream) -> StreamMetadata:
-    if stream.type not in ('audio', 'video'):
-        result_unsupported: StreamMetadata = {'type': stream.type}
-        return result_unsupported
-
-    codec_context = stream.codec_context
-    codec_tag = codec_context.codec_tag.encode('unicode-escape').decode('utf-8')
-
-    # Compute duration_seconds from stream-level duration.
-    # We intentionally don't fall back to container.duration here because it's ambiguous —
-    # it may reflect a different stream's duration (e.g. audio vs video).
-    duration_seconds: float | None = None
-    if stream.duration is not None and stream.time_base is not None:
-        duration_seconds = float(stream.duration * stream.time_base)
-
-    codec_context_md: CodecContextMetadata = {
-        'name': codec_context.name,
-        'codec_tag': codec_tag,
-        'profile': codec_context.profile,
-    }
-
-    result: StreamMetadata = {
-        'type': stream.type,
-        'duration': stream.duration,
-        'time_base': float(stream.time_base) if stream.time_base is not None else None,
-        'duration_seconds': duration_seconds,
-        'frames': stream.frames,
-        'metadata': stream.metadata,
-        'codec_context': codec_context_md,
-    }
-
-    if stream.type == 'audio':
-        assert isinstance(stream.codec_context, av.AudioCodecContext)
-        channels = stream.codec_context.channels
-        codec_context_md['channels'] = int(channels) if channels is not None else None
-    else:
-        assert stream.type == 'video'
-        assert isinstance(stream, av.VideoStream)
-        codec_context_md['pix_fmt'] = getattr(stream.codec_context, 'pix_fmt', None)
-        result['width'] = stream.width
-        result['height'] = stream.height
-        result['average_rate'] = float(stream.average_rate) if stream.average_rate is not None else None
-        result['base_rate'] = float(stream.base_rate) if stream.base_rate is not None else None
-        result['guessed_rate'] = float(stream.guessed_rate) if stream.guessed_rate is not None else None
-
-    return result
 
 
 def get_video_duration(path: str) -> float | None:
@@ -209,8 +115,9 @@ def get_max_volume_db(path: str) -> float | None:
 
 def has_audio_stream(path: str) -> bool:
     """Check if video has audio stream using PyAV."""
-    md = get_metadata(path)
-    return any(stream['type'] == 'audio' for stream in md['streams'])
+    with av.open(path) as container:
+        assert isinstance(container, av.container.InputContainer)
+        return any(stream.type == 'audio' for stream in container.streams)
 
 
 # bytes of memory per pixel of decoded frames, by pixel format

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -6,8 +6,9 @@ import numpy as np
 import pytest
 
 import pixeltable as pxt
-import pixeltable.utils.av as av_utils
+from pixeltable.functions import util as functions_util
 from pixeltable.functions.audio import audio_splitter, encode_audio
+from pixeltable.utils import av as av_utils
 from pixeltable.utils.local_store import TempStore
 from pixeltable.utils.object_stores import ObjectOps
 
@@ -59,7 +60,7 @@ class TestAudio:
         # Directly count the number of videos with audio streams, without relying on the UDF
         videos_with_audio = 0
         for p in video_filepaths:
-            md = av_utils.get_metadata(p)
+            md = functions_util.get_metadata(p)
             if sum(1 for stream in md['streams'] if stream['type'] == 'audio') > 0:
                 videos_with_audio += 1
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -118,6 +118,12 @@ class TestAudio:
             'bit_exact': False,
         }
 
+        # get_metadata() returns correct type information
+        expr = base_t.audio.get_metadata().streams[0].duration_seconds
+        assert expr.col_type.is_float_type()
+        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match="cannot resolve 'not_an_attr'"):
+            _ = base_t.audio.get_metadata().streams[0].not_an_attr
+
     def __count_segments(
         self,
         start_time_sec: float,

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -311,6 +311,12 @@ class TestVideo:
         assert inline_res[0]['size'] == 2234371
         assert inline_res[0]['streams'][0]['width'] == 640
 
+        # get_metadata() returns correct type information
+        expr = base_t.video.get_metadata().streams[0].frames
+        assert expr.col_type.is_int_type()
+        with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match="cannot resolve 'not_an_attr'"):
+            _ = base_t.video.get_metadata().streams[0].not_an_attr
+
     # window function that simply passes through the frame
     @pxt.uda(requires_order_by=True, allows_std_agg=False, allows_window=True)
     class agg_fn(pxt.Aggregator):

--- a/uv.lock
+++ b/uv.lock
@@ -6110,7 +6110,7 @@ test = [
 [[package]]
 name = "pixeltable-doctools"
 version = "0.1.0"
-source = { git = "https://github.com/pixeltable/pixeltable-doctools#869124b498ba427cb4e05432ddc7363a44553155" }
+source = { git = "https://github.com/pixeltable/pixeltable-doctools#d69ae4ca2f5c7ca4dd58eb81e7f37286b5f098ed" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "griffe" },


### PR DESCRIPTION
- Introduces a `ContainerMetadata` typed dict for `audio.get_metadata()` and `video.get_metadata()`
- Relocates helper function to `pixeltable.functions.util`
- Docstrings for all new TypedDicts
- Doc update: pretty-print JSON return values when they're built from a TypedDict (to avoid massive doc clutter for complex JSON types)
- Fixes a related bug in doctools (signatures for UDFs with typed json parameters were not rendering properly)