### PR TITLE
Catalog bug: create view failed to mark base table as modified

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -841,12 +841,12 @@ class Catalog:
                         # For now, just assert that we don't.
                         # assert not tv.is_replica
 
+                        if tv is not None:
+                            self.mark_modified_tvs(tv.handle)
                         if is_rollback:
                             op.undo(tv)
                         else:
                             op.exec(tv)
-                        if tv is not None:
-                            self.mark_modified_tvs(tv.handle)
 
                         _logger.debug(f'Finalize pending ops({tbl_id}): op {op!s} done, updating status')
                         if self._set_pending_op_status(tbl_id, op, new_op_status, is_final_op=is_final_op):
@@ -1478,6 +1478,7 @@ class Catalog:
                 base_id = base.tbl_id
                 assert self._acquire_write_lock(tbl_id=base_id), base_id
                 base_tv = self._get_tbl_version(TableVersionKey(base.tbl_id, None, None), validate_initialized=True)
+                self.mark_modified_tvs(base_tv.handle)
                 base_tv.tbl_md.view_sn += 1
                 result = get_runtime().conn.execute(
                     sql.update(schema.Table)
@@ -1510,6 +1511,7 @@ class Catalog:
             tbl_id = UUID(md.tbl_md.tbl_id)
             md.tbl_md.pending_stmt = schema.TableStatement.CREATE_VIEW
             self.write_tbl_md(tbl_id, dir._id, md.tbl_md, md.version_md, md.schema_version_md, ops)
+            fault_injection.process_fault(FaultLocation.CATALOG_CREATE_VIEW_BEFORE_MD_PERSISTED)
             return tbl_id
 
         self._roll_forward_ids.clear()
@@ -1888,6 +1890,7 @@ class Catalog:
         if isinstance(tbl, View) and tvp.is_mutable() and tvp.base.is_mutable():
             base_id = tvp.base.tbl_id
             base_tv = self._get_tbl_version(TableVersionKey(base_id, None, None), validate_initialized=True)
+            self.mark_modified_tvs(base_tv.handle)
             base_tv.tbl_md.view_sn += 1
             result = get_runtime().conn.execute(
                 sql.update(schema.Table.__table__)

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -841,6 +841,8 @@ class Catalog:
                         # For now, just assert that we don't.
                         # assert not tv.is_replica
 
+                        # Mark TableVersion as modified before it is actually modified to make sure that cache is
+                        # cleared properly if an error occurs during op execution.
                         if tv is not None:
                             self.mark_modified_tvs(tv.handle)
                         if is_rollback:

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -1511,7 +1511,7 @@ class Catalog:
             tbl_id = UUID(md.tbl_md.tbl_id)
             md.tbl_md.pending_stmt = schema.TableStatement.CREATE_VIEW
             self.write_tbl_md(tbl_id, dir._id, md.tbl_md, md.version_md, md.schema_version_md, ops)
-            fault_injection.process_fault(FaultLocation.CATALOG_CREATE_VIEW_BEFORE_MD_PERSISTED)
+            fault_injection.process_fault(FaultLocation.CATALOG_CREATE_VIEW_BEFORE_MD_COMMITTED)
             return tbl_id
 
         self._roll_forward_ids.clear()

--- a/pixeltable/utils/fault_injection.py
+++ b/pixeltable/utils/fault_injection.py
@@ -9,7 +9,7 @@ from typing import Any
 class FaultLocation(Enum):
     """Instrumented locations in the codebase where faults can be injected."""
 
-    CATALOG_CREATE_VIEW_BEFORE_MD_PERSISTED = auto()
+    CATALOG_CREATE_VIEW_BEFORE_MD_COMMITTED = auto()
     CATALOG_FINALIZE_PENDING_OPS_NON_XACT = auto()
     CATALOG_LOAD_VIEW_OP_EXEC = auto()
     SCHEDULER_RATE_LIMITS_AEXEC = auto()

--- a/pixeltable/utils/fault_injection.py
+++ b/pixeltable/utils/fault_injection.py
@@ -9,6 +9,7 @@ from typing import Any
 class FaultLocation(Enum):
     """Instrumented locations in the codebase where faults can be injected."""
 
+    CATALOG_CREATE_VIEW_BEFORE_MD_PERSISTED = auto()
     CATALOG_FINALIZE_PENDING_OPS_NON_XACT = auto()
     CATALOG_LOAD_VIEW_OP_EXEC = auto()
     SCHEDULER_RATE_LIMITS_AEXEC = auto()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -333,7 +333,7 @@ class TestCatalog:
                 thread_id=0,
                 name='inject fault',
                 fn=lambda: get_runtime().fault_manager.inject_fault(
-                    FaultLocation.CATALOG_CREATE_VIEW_BEFORE_MD_PERSISTED, ExceptionFault(injected_exc)
+                    FaultLocation.CATALOG_CREATE_VIEW_BEFORE_MD_COMMITTED, ExceptionFault(injected_exc)
                 ),
             )
             # Thread 0: Run create_view (va) that fails. Before the fix, base_tv was not added to _modified_tvs, so it

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -351,5 +351,6 @@ class TestCatalog:
             .execute()
         )
 
+        assert pxt.get_table('base').count() == 1
         # Verify that the insert was propagated to vb.
         assert pxt.get_table('vb').count() == 1

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -351,5 +351,5 @@ class TestCatalog:
             .execute()
         )
 
-        # verify that the inserted was propagated to vb.
+        # Verify that the insert was propagated to vb.
         assert pxt.get_table('vb').count() == 1

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -309,3 +309,47 @@ class TestCatalog:
         result = t.select(t.a, t.b).collect()
         assert len(result) == 1
         assert result[0] == {'a': 1, 'b': 2}
+
+    def test_create_view_stale_base_tv_after_txn_failure(self, uses_db: None, fault_injection: None) -> None:
+        """
+        Verifies bug fix: due to an error in view creation, Catalog would fail to invalidate a modified but not
+        persisted TableVersion. Later that would result in Pixeltable acting on that stale TableVersion, which can cause
+        various sorts of issues including a data corruption.
+        """
+        pxt.create_table('base', {'a': pxt.Int})
+
+        injected_exc = Exception('injected error')
+
+        def create_view() -> None:
+            with pytest.raises(Exception, match='injected'):
+                pxt.create_view('va', pxt.get_table('base'))
+
+        (
+            MultiThreadedScenario()
+            # Thread 0: Warm up its catalog so base's tv is cached.
+            .then_run(thread_id=0, name='warm up cache', fn=lambda: pxt.get_table('base'))
+            # Thread 0: Arm a non-retriable exception fault inside create_view.
+            .then_run(
+                thread_id=0,
+                name='inject fault',
+                fn=lambda: get_runtime().fault_manager.inject_fault(
+                    FaultLocation.CATALOG_CREATE_VIEW_BEFORE_MD_PERSISTED, ExceptionFault(injected_exc)
+                ),
+            )
+            # Thread 0: Run create_view (va) that fails. Before the fix, base_tv was not added to _modified_tvs, so it
+            # stays in cache with stale in-memory state, i.e. with view_sn=v+1
+            .then_run(thread_id=0, name='create view that fails', fn=create_view)
+            # Thread 1: Create view vb on the same base. This also advances the persisted view_sn to v+1, which
+            # automatically matches thread 0's stale cached value.
+            .then_run(thread_id=1, name='create view', fn=lambda: pxt.create_view('vb', pxt.get_table('base')))
+            # Thread 0: insert into base table. Before the fix, Catalog would observe that the cached TableVersion's
+            # version and view_sn match the stored values, and based on that decide to skip reloading the table.
+            # The outcome of that is the write is not propagated to vb.
+            .then_run(
+                thread_id=0, name='insert into base (stale cache)', fn=lambda: pxt.get_table('base').insert([{'a': 42}])
+            )
+            .execute()
+        )
+
+        # verify that the inserted was propagated to vb.
+        assert pxt.get_table('vb').count() == 1


### PR DESCRIPTION
Due to an error in view creation, Catalog would fail to invalidate a modified but not persisted `TableVersion`. Later that would result in Pixeltable acting on that stale `TableVersion`, which can cause various sorts of issues including a data corruption or the following assertion error found by random_ops test.

For more details and repro, see the new test case.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 467, in run
    ops.run()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 436, in run
    self.random_op()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 430, in random_op
    self.run_op(op)
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 423, in run_op
    raise fatal
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 406, in run_op
    result = op()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/tool/random_ops.py", line 258, in query
    res = t.sample(n=num_rows).collect()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/_query.py", line 797, in collect
    return self._collect()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/_query.py", line 801, in _collect
    return ResultSet(list(self.cursor()), self.schema)
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/_query.py", line 339, in __iter__
    for data in self._row_iterator:
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/_query.py", line 784, in _output_row_iterator
    with get_runtime().catalog.begin_xact(for_write=False, read_tvps=self._from_clause.tbls):
  File "/Users/sergeymkhitaryan/miniforge3/envs/pxt/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/catalog/catalog.py", line 396, in begin_xact
    self.validate()
  File "/Users/sergeymkhitaryan/work/pixeltable-wt-catalog/pixeltable/catalog/catalog.py", line 290, in validate
    raise AssertionError(
AssertionError: view_2 (4d75c5ef-47c2-4587-8c35-622317e9e486) missing in  ()
```

Also updates `_finalize_pending_ops()` and `_drop_tbl()` to mark tv as modified before actually modifying in order to avoid similar issues.