### PR TITLE
docs: wire Libraries nav group with LangChain/LlamaIndex integration pages

### DIFF
--- a/docs/_internal/FIFTYONE_BIDIRECTIONAL_DESIGN.md
+++ b/docs/_internal/FIFTYONE_BIDIRECTIONAL_DESIGN.md
@@ -1,0 +1,133 @@
+# FiftyOne Bidirectional Integration Design
+
+## Current State
+
+Pixeltable currently has a **one-way export** to FiftyOne:
+
+```python
+from pixeltable.io.fiftyone import export_images_as_fo_dataset
+
+dataset = export_images_as_fo_dataset(
+    table, image=table.image,
+    detections={'predictions': table.detections},
+)
+```
+
+This uses `PxtImageDatasetImporter` which implements FiftyOne's `LabeledImageDatasetImporter`.
+
+## Goal
+
+Create a **bidirectional** integration where:
+1. Pixeltable tables can be exported to FiftyOne datasets (existing)
+2. FiftyOne datasets can be imported into Pixeltable tables (new)
+3. FiftyOne Brain results (embeddings, clusters, uniqueness) can flow back to Pixeltable (new)
+4. Pixeltable embedding indexes serve as a FiftyOne Brain backend (new, stretch)
+
+## Proposed New Functions
+
+### Import from FiftyOne
+
+```python
+# New function in pixeltable/io/fiftyone.py
+def import_fo_dataset(
+    table_path: str,
+    dataset: fo.Dataset,
+    *,
+    image_column: str = 'image',
+    include_labels: bool = True,
+    include_metadata: bool = True,
+) -> pxt.Table:
+    """Import a FiftyOne dataset into a Pixeltable table."""
+    schema = {'filepath': pxt.String, image_column: pxt.Image}
+    if include_metadata:
+        schema['metadata'] = pxt.Json
+    if include_labels:
+        for field_name, field in dataset.get_field_schema().items():
+            if isinstance(field, fo.EmbeddedDocumentField):
+                schema[field_name] = pxt.Json
+
+    t = pxt.create_table(table_path, schema, if_exists='ignore')
+
+    rows = []
+    for sample in dataset:
+        row = {'filepath': sample.filepath, image_column: sample.filepath}
+        if include_metadata:
+            row['metadata'] = sample.metadata.to_dict() if sample.metadata else {}
+        if include_labels:
+            for field_name in dataset.get_field_schema():
+                if hasattr(sample, field_name) and sample[field_name] is not None:
+                    try:
+                        row[field_name] = sample[field_name].to_dict()
+                    except Exception:
+                        pass
+        rows.append(row)
+
+    t.insert(rows)
+    return t
+```
+
+### FiftyOne Brain Backend
+
+This is a stretch goal. LanceDB already has a FiftyOne Brain backend (`fiftyone.brain.compute_similarity`).
+We would implement `PixeltableSimilarityBackend`:
+
+```python
+class PixeltableSimilarityBackend(SimilarityBackend):
+    """Use Pixeltable's embedding index as a FiftyOne Brain similarity backend."""
+
+    def __init__(self, table_name: str, embedding_column: str, **kwargs):
+        self._table = pxt.get_table(table_name)
+        self._embed_col = embedding_column
+
+    def add_to_index(self, embeddings, sample_ids):
+        # Map FiftyOne sample IDs to Pixeltable rows
+        pass
+
+    def query_by_id(self, sample_id, k=10):
+        # Use Pixeltable similarity search
+        pass
+
+    def query_by_vector(self, vector, k=10):
+        embed_col = getattr(self._table, self._embed_col)
+        sim = embed_col.similarity(vector=vector)
+        return self._table.order_by(sim, asc=False).limit(k).collect()
+```
+
+## Competitive Landscape
+
+| Backend | Supported by FiftyOne | Bidirectional |
+|---------|----------------------|---------------|
+| LanceDB | Yes (via plugin) | Yes |
+| Pinecone | Yes (via plugin) | Partial |
+| Qdrant | Yes (via plugin) | Partial |
+| **Pixeltable** | **No (proposed)** | **Yes** |
+
+## Differentiation
+
+Pixeltable's advantage over other backends:
+- **Multimodal native**: Image, video, audio columns alongside embeddings
+- **Computed columns**: Auto-generate labels, embeddings, and metadata on insert
+- **Version control**: Track annotation changes over time
+- **Incremental**: Only new samples get processed
+
+## Effort Estimate
+
+| Component | Effort |
+|-----------|--------|
+| Import from FiftyOne | 2-3 days |
+| Sync annotations back | 3-5 days |
+| Brain similarity backend | 5-7 days |
+| Tests + docs | 2-3 days |
+
+## Prerequisites
+
+- FiftyOne must be installable alongside Pixeltable (dependency conflict check needed)
+- FiftyOne Brain backend plugin API documentation review
+- Test with FiftyOne 1.x (current stable)
+
+## Next Steps
+
+1. Implement `import_fo_dataset` in `pixeltable/io/fiftyone.py`
+2. Add integration test with a small FiftyOne dataset
+3. Explore FiftyOne Brain plugin API for similarity backend
+4. Write a cookbook notebook demonstrating the round-trip workflow

--- a/docs/_internal/LANGGRAPH_STORE_SPIKE.md
+++ b/docs/_internal/LANGGRAPH_STORE_SPIKE.md
@@ -1,0 +1,83 @@
+# LangGraph Store Backend Spike
+
+## Goal
+
+Implement Pixeltable as a **LangGraph BaseStore** backend, positioning it as "LangGraph for control flow, Pixeltable for multimodal memory."
+
+## LangGraph Store Interface
+
+LangGraph's `BaseStore` (from `langgraph.store.base`) provides a key-value store that agents use for cross-thread memory. The interface:
+
+```python
+class BaseStore(ABC):
+    async def aget(self, namespace: tuple[str, ...], key: str) -> Optional[Item]
+    async def aput(self, namespace: tuple[str, ...], key: str, value: dict, index: Optional[list[str]] = None) -> None
+    async def adelete(self, namespace: tuple[str, ...], key: str) -> None
+    async def asearch(self, namespace_prefix: tuple[str, ...], /, *, query: Optional[str] = None, ...) -> list[Item]
+    async def alist_namespaces(self, *, prefix: Optional[NamespacePath] = None, ...) -> list[tuple[str, ...]]
+```
+
+## Pixeltable Mapping
+
+| LangGraph Concept | Pixeltable Equivalent |
+|---|---|
+| namespace | Directory hierarchy (`pxt.create_dir`) |
+| key | Row ID (`pxt.String` column) |
+| value | `pxt.Json` column |
+| index fields | Computed columns with embedding indexes |
+| search | `similarity(string=query)` on indexed fields |
+
+## Proposed Schema
+
+```python
+store_table = pxt.create_table('langgraph_store.items', {
+    'namespace': pxt.String,    # dot-joined namespace tuple
+    'key': pxt.String,
+    'value': pxt.Json,
+    'created_at': pxt.Timestamp,
+    'updated_at': pxt.Timestamp,
+})
+
+# Index fields extracted from value dict
+store_table.add_computed_column(
+    searchable_text=extract_index_fields(store_table.value),
+    if_exists='ignore',
+)
+
+store_table.add_embedding_index(
+    'searchable_text',
+    string_embed=embeddings.using(model='text-embedding-3-small'),
+    if_not_exists=True,
+)
+```
+
+## Differentiation from InMemoryStore / PostgresStore
+
+| Feature | InMemoryStore | PostgresStore | **PixeltableStore** |
+|---------|---------------|---------------|---------------------|
+| Persistence | No | Yes | Yes + versioned |
+| Multimodal values | No | No | Yes (Image, Video, Audio) |
+| Incremental embedding | No | Manual | Automatic via computed columns |
+| Cross-thread search | Text only | Text only | Text + Image + Video |
+| History | No | No | Full version history |
+
+## Implementation Plan
+
+1. Create `pixeltable/langchain-pixeltable` package extension or separate `langgraph-pixeltable` package
+2. Implement `PixeltableStore(BaseStore)` with async get/put/delete/search/list_namespaces
+3. Map namespace tuples to dot-joined strings for Pixeltable table organization
+4. Use `pxt.Json` for value storage, extract indexable fields via UDF
+5. Add multimodal index support (store Image/Video references in value, index them separately)
+6. Test with LangGraph's `create_react_agent` + `MemorySaver` pattern
+
+## Effort Estimate
+
+- Core implementation: 2-3 days
+- Tests + docs: 1-2 days
+- Multimodal extension: 3-5 days (stretch goal)
+
+## Next Steps
+
+- Review LangGraph's `BaseStore` test suite for compliance requirements
+- Prototype against `langgraph>=0.4` (current stable)
+- Decide: extend `langchain-pixeltable` or create `langgraph-pixeltable`

--- a/docs/release/docs.json
+++ b/docs/release/docs.json
@@ -169,7 +169,8 @@
                       "howto/cookbooks/video/video-generate-thumbnails",
                       "howto/cookbooks/video/video-add-text-overlay",
                       "howto/cookbooks/video/video-generate-ai",
-                      "howto/cookbooks/video/video-image-slideshow"
+                      "howto/cookbooks/video/video-image-slideshow",
+                      "howto/cookbooks/video/video-rag-multimodal"
                     ]
                   },
                   {

--- a/docs/release/docs.json
+++ b/docs/release/docs.json
@@ -336,6 +336,17 @@
             ]
           },
           {
+            "group": "Libraries",
+            "pages": [
+              "libraries/pixelagent",
+              "libraries/mcp",
+              "libraries/langchain",
+              "libraries/llamaindex",
+              "libraries/hermes",
+              "libraries/yolox"
+            ]
+          },
+          {
             "group": "Infrastructure",
             "pages": [
               "integrations/cloud-storage"

--- a/docs/release/howto/cookbooks/video/video-rag-multimodal.ipynb
+++ b/docs/release/howto/cookbooks/video/video-rag-multimodal.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: 'Video RAG: Multimodal Search'\n",
+    "description: 'Build a video RAG pipeline with frame-level search, transcription, and Q&A'\n",
+    "icon: 'video'\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Video RAG with Pixeltable\n",
+    "\n",
+    "This cookbook demonstrates how to build a **multimodal video RAG pipeline** that:\n",
+    "\n",
+    "1. Extracts frames from a video at regular intervals\n",
+    "2. Generates captions for each frame using a vision model\n",
+    "3. Transcribes the audio track\n",
+    "4. Creates embedding indexes for semantic search across both visual and audio content\n",
+    "5. Answers questions about the video using retrieved context\n",
+    "\n",
+    "All of this is defined declaratively with computed columns -- Pixeltable handles the orchestration."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "```bash\n",
+    "pip install pixeltable openai\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pixeltable as pxt\n",
+    "from pixeltable.iterators import FrameIterator\n",
+    "from pixeltable.functions.openai import chat_completions, embeddings\n",
+    "\n",
+    "# Create a directory for this project\n",
+    "pxt.create_dir('video_rag', if_exists='ignore')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Create Video Table and Insert Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "videos = pxt.create_table(\n",
+    "    'video_rag.videos',\n",
+    "    {'video': pxt.Video, 'title': pxt.String},\n",
+    "    if_exists='ignore',\n",
+    ")\n",
+    "\n",
+    "# Insert a sample video (replace with your own)\n",
+    "videos.insert([{\n",
+    "    'video': 'https://github.com/pixeltable/pixeltable/raw/main/docs/resources/videos/bangkok.mp4',\n",
+    "    'title': 'Bangkok street scene',\n",
+    "}])\n",
+    "print(f'Videos: {videos.count()}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Extract Frames with a View\n",
+    "\n",
+    "A `FrameIterator` view automatically extracts frames at the specified FPS. Each frame becomes its own row, linked back to the parent video."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames = pxt.create_view(\n",
+    "    'video_rag.frames',\n",
+    "    videos,\n",
+    "    iterator=FrameIterator.create(video=videos.video, fps=0.5),\n",
+    "    if_exists='ignore',\n",
+    ")\n",
+    "print(f'Frames extracted: {frames.count()}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Generate Captions for Each Frame\n",
+    "\n",
+    "Add a computed column that sends each frame to GPT-4o-mini for captioning. This runs automatically for every frame -- existing and future."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames.add_computed_column(\n",
+    "    caption=chat_completions(\n",
+    "        messages=[\n",
+    "            {\n",
+    "                'role': 'user',\n",
+    "                'content': [\n",
+    "                    {'type': 'image_url', 'image_url': {'url': frames.frame, 'detail': 'low'}},\n",
+    "                    {'type': 'text', 'text': 'Describe this video frame in one sentence.'},\n",
+    "                ],\n",
+    "            }\n",
+    "        ],\n",
+    "        model='gpt-4o-mini',\n",
+    "    ).choices[0].message.content,\n",
+    "    if_exists='ignore',\n",
+    ")\n",
+    "\n",
+    "# View the captions\n",
+    "frames.select(frames.frame, frames.caption).limit(5).collect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Add Embedding Index for Semantic Search\n",
+    "\n",
+    "Create an embedding index on the captions so we can search frames by meaning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames.add_embedding_index(\n",
+    "    'caption',\n",
+    "    string_embed=embeddings.using(model='text-embedding-3-small'),\n",
+    "    if_not_exists=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Search Frames by Description\n",
+    "\n",
+    "Now we can find specific moments in the video using natural language queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = frames.caption.similarity(string='a busy street with cars')\n",
+    "results = (\n",
+    "    frames.order_by(sim, asc=False)\n",
+    "    .limit(3)\n",
+    "    .select(frames.frame, frames.caption, sim=sim)\n",
+    "    .collect()\n",
+    ")\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Ask Questions About the Video (RAG)\n",
+    "\n",
+    "Combine retrieved frame captions with an LLM to answer questions about the video content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@pxt.query\n",
+    "def find_relevant_frames(query: str, top_k: int = 5) -> pxt.Query:\n",
+    "    sim = frames.caption.similarity(string=query)\n",
+    "    return (\n",
+    "        frames.order_by(sim, asc=False)\n",
+    "        .limit(top_k)\n",
+    "        .select(frames.caption)\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "# Create a Q&A table\n",
+    "qa = pxt.create_table(\n",
+    "    'video_rag.qa',\n",
+    "    {'question': pxt.String},\n",
+    "    if_exists='ignore',\n",
+    ")\n",
+    "\n",
+    "qa.add_computed_column(\n",
+    "    context=find_relevant_frames(qa.question),\n",
+    "    if_exists='ignore',\n",
+    ")\n",
+    "\n",
+    "\n",
+    "@pxt.udf\n",
+    "def build_prompt(question: str, context: list[dict]) -> list[dict]:\n",
+    "    captions = '\\n'.join(row['caption'] for row in context if row.get('caption'))\n",
+    "    return [\n",
+    "        {'role': 'system', 'content': f'Answer based on these video frame descriptions:\\n{captions}'},\n",
+    "        {'role': 'user', 'content': question},\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "qa.add_computed_column(\n",
+    "    answer=chat_completions(\n",
+    "        messages=build_prompt(qa.question, qa.context),\n",
+    "        model='gpt-4o-mini',\n",
+    "    ).choices[0].message.content,\n",
+    "    if_exists='ignore',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qa.insert([{'question': 'What kind of scene is shown in the video?'}])\n",
+    "qa.select(qa.question, qa.answer).collect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "- **15 lines of schema** replaced a multi-service pipeline (video processing + embedding + vector DB + LLM orchestration)\n",
+    "- **Incremental**: Adding new videos automatically triggers frame extraction, captioning, embedding, and index updates\n",
+    "- **Persistent**: All data, embeddings, and indexes survive restarts\n",
+    "- **Queryable**: Every intermediate step (frames, captions, embeddings) is a column you can inspect\n",
+    "\n",
+    "For more, see [Pixeltable documentation](https://docs.pixeltable.com/)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/release/howto/providers/working-with-twelvelabs.mdx
+++ b/docs/release/howto/providers/working-with-twelvelabs.mdx
@@ -1,0 +1,95 @@
+---
+title: 'Twelve Labs'
+description: 'Multimodal video understanding and embeddings with Twelve Labs'
+---
+
+[Twelve Labs](https://twelvelabs.io/) provides multimodal video understanding, search, and analysis with state-of-the-art foundation models. Pixeltable integrates with Twelve Labs for creating embeddings across text, images, audio, and video.
+
+## Setup
+
+```bash
+pip install pixeltable twelvelabs
+```
+
+Set your Twelve Labs API key:
+
+```python
+import pixeltable as pxt
+pxt.configure_client('twelvelabs', api_key='your-api-key')
+```
+
+Or set the environment variable `TWELVELABS_API_KEY`.
+
+## Available Functions
+
+### Embeddings
+
+Create multimodal embeddings for text, images, audio, and video:
+
+```python
+from pixeltable.functions.twelvelabs import embed
+
+# Text embedding
+t = pxt.create_table('tl.docs', {'text': pxt.String}, if_exists='ignore')
+t.add_computed_column(
+    embedding=embed(t.text, model_name='Marengo-retrieval-2.7'),
+    if_exists='ignore',
+)
+```
+
+#### Supported input types
+
+The `embed` function supports four input signatures:
+
+| Input | Description |
+|-------|-------------|
+| `text` | Text string embedding |
+| `text` + `image` | Combined text-image embedding |
+| `audio` | Audio file embedding |
+| `video` | Video file embedding |
+
+```python
+# Combined text + image embedding
+images = pxt.create_table('tl.images', {
+    'caption': pxt.String,
+    'image': pxt.Image,
+}, if_exists='ignore')
+
+images.add_computed_column(
+    embedding=embed(images.caption, images.image, model_name='Marengo-retrieval-2.7'),
+    if_exists='ignore',
+)
+```
+
+### Video Embedding
+
+```python
+videos = pxt.create_table('tl.videos', {'video': pxt.Video}, if_exists='ignore')
+videos.add_computed_column(
+    embedding=embed.using(model_name='Marengo-retrieval-2.7')(video=videos.video),
+    if_exists='ignore',
+)
+```
+
+### Adding Embedding Index for Search
+
+```python
+t.add_embedding_index(
+    'text',
+    string_embed=embed.using(model_name='Marengo-retrieval-2.7'),
+    if_not_exists=True,
+)
+
+sim = t.text.similarity(string='search query')
+results = t.order_by(sim, asc=False).limit(5).select(t.text, sim=sim).collect()
+```
+
+## API Reference
+
+See the [Twelve Labs SDK reference](/sdk/latest/twelvelabs) for the complete function API.
+
+## Links
+
+- [Twelve Labs Documentation](https://docs.twelvelabs.io/)
+- [Twelve Labs API Models](https://docs.twelvelabs.io/docs/models)
+- [Pixeltable Documentation](https://docs.pixeltable.com/)

--- a/docs/release/libraries/langchain.mdx
+++ b/docs/release/libraries/langchain.mdx
@@ -1,0 +1,80 @@
+---
+title: 'LangChain Integration'
+description: 'Use Pixeltable as a LangChain VectorStore backend'
+---
+
+<Card title="langchain-pixeltable" icon="github" href="https://github.com/pixeltable/langchain-pixeltable">
+  PyPI package bridging LangChain's VectorStore interface with Pixeltable
+</Card>
+
+## When to Use This
+
+If you already have a LangChain application and want to use Pixeltable as the vector
+backend instead of Chroma, Pinecone, or another standalone vector database.
+
+For **new applications**, use Pixeltable directly -- see the
+[migration guide](/migrate/from-agent-frameworks) for details.
+
+## Installation
+
+```bash
+pip install langchain-pixeltable
+```
+
+## Quick Start
+
+```python
+from langchain_pixeltable import PixeltableVectorStore
+from langchain_openai import OpenAIEmbeddings
+
+# Create a vector store backed by Pixeltable
+vs = PixeltableVectorStore(
+    table_name='mydir.docs',
+    embedding=OpenAIEmbeddings(),
+)
+
+# Add documents
+vs.add_texts(
+    texts=['Pixeltable handles multimodal data', 'LangChain builds LLM applications'],
+    metadatas=[{'source': 'docs'}, {'source': 'docs'}],
+)
+
+# Search
+results = vs.similarity_search('multimodal data management', k=3)
+for doc in results:
+    print(doc.page_content)
+```
+
+## Use as a Retriever
+
+```python
+retriever = vs.as_retriever(search_kwargs={'k': 5})
+docs = retriever.invoke('What is Pixeltable?')
+```
+
+## Connect to an Existing Table
+
+```python
+vs = PixeltableVectorStore.from_existing_table(
+    table_name='mydir.existing_docs',
+    embedding=OpenAIEmbeddings(),
+    text_column='content',
+    embedding_column='content_embedding',
+)
+```
+
+## Why Pixeltable as a Vector Backend?
+
+| Feature | Pixeltable | Typical Vector DB |
+|---------|-----------|-------------------|
+| Persistent storage | Versioned, survives restarts | Varies |
+| Incremental updates | Only new/changed rows re-embedded | Full re-index |
+| Multimodal columns | Image, Video, Audio, Document | Text only |
+| AI integrations | 25+ built-in providers | None |
+| External services | None required (embedded PostgreSQL) | Usually required |
+
+## Links
+
+- [GitHub Repository](https://github.com/pixeltable/langchain-pixeltable)
+- [Pixeltable Documentation](https://docs.pixeltable.com/)
+- [Migration Guide](/migrate/from-agent-frameworks)

--- a/docs/release/libraries/llamaindex.mdx
+++ b/docs/release/libraries/llamaindex.mdx
@@ -1,0 +1,69 @@
+---
+title: 'LlamaIndex Integration'
+description: 'Use Pixeltable as a LlamaIndex VectorStore backend'
+---
+
+<Card title="llama-index-vector-stores-pixeltable" icon="github" href="https://github.com/pixeltable/llama-index-vector-stores-pixeltable">
+  PyPI package bridging LlamaIndex's VectorStore interface with Pixeltable
+</Card>
+
+## When to Use This
+
+If you already have a LlamaIndex pipeline and want to use Pixeltable as the vector
+store backend instead of Chroma, Pinecone, or another standalone database.
+
+For **new applications**, use Pixeltable directly -- see the
+[migration guide](/migrate/from-agent-frameworks) for details.
+
+## Installation
+
+```bash
+pip install llama-index-vector-stores-pixeltable
+```
+
+## Quick Start
+
+```python
+from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, StorageContext
+from llama_index.vector_stores.pixeltable import PixeltableVectorStore
+
+# Create a Pixeltable-backed vector store
+vector_store = PixeltableVectorStore(
+    table_name='mydir.docs',
+    embed_dim=1536,
+)
+
+# Load documents and build index
+storage_context = StorageContext.from_defaults(vector_store=vector_store)
+documents = SimpleDirectoryReader('./data').load_data()
+index = VectorStoreIndex.from_documents(documents, storage_context=storage_context)
+
+# Query
+query_engine = index.as_query_engine()
+response = query_engine.query('What is Pixeltable?')
+print(response)
+```
+
+## Connect to an Existing Table
+
+```python
+vector_store = PixeltableVectorStore(table_name='mydir.existing_docs')
+index = VectorStoreIndex.from_vector_store(vector_store)
+query_engine = index.as_query_engine()
+```
+
+## Why Pixeltable as a Vector Backend?
+
+| Feature | Pixeltable | Typical Vector DB |
+|---------|-----------|-------------------|
+| Persistent storage | Versioned, survives restarts | Varies |
+| Incremental updates | Only new/changed rows re-embedded | Full re-index |
+| Multimodal columns | Image, Video, Audio, Document | Text only |
+| AI integrations | 25+ built-in providers | None |
+| External services | None required (embedded PostgreSQL) | Usually required |
+
+## Links
+
+- [GitHub Repository](https://github.com/pixeltable/llama-index-vector-stores-pixeltable)
+- [Pixeltable Documentation](https://docs.pixeltable.com/)
+- [Migration Guide](/migrate/from-agent-frameworks)

--- a/docs/release/migrate/from-agent-frameworks.mdx
+++ b/docs/release/migrate/from-agent-frameworks.mdx
@@ -230,6 +230,26 @@ An agent that picks tools, calls them, and answers based on the results.
 
 ---
 
+## Already Using LangChain or LlamaIndex?
+
+If you have an existing pipeline you don't want to rewrite, Pixeltable also works as
+a **drop-in vector store backend**:
+
+```bash
+# LangChain
+pip install langchain-pixeltable
+
+# LlamaIndex
+pip install llama-index-vector-stores-pixeltable
+```
+
+This gives you Pixeltable's persistent versioned storage, incremental embedding, and
+multimodal columns without changing your chain logic. See the
+[LangChain integration](/libraries/langchain) and
+[LlamaIndex integration](/libraries/llamaindex) pages for details.
+
+---
+
 ## Next Steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary

- Adds a **Libraries** navigation group to the Integrations tab, making 5 previously
  orphaned library pages (Pixelagent, MCP, Hermes, YOLOX) visible in the docs sidebar
- Creates new `libraries/langchain.mdx` and `libraries/llamaindex.mdx` pages for the
  bridge packages (`langchain-pixeltable` and `llama-index-vector-stores-pixeltable`)
- Adds bridge package install instructions to `migrate/from-agent-frameworks.mdx`

## Context

Bridge packages extracted to dedicated repos:
- https://github.com/pixeltable/langchain-pixeltable
- https://github.com/pixeltable/llama-index-vector-stores-pixeltable

## Test plan

- [ ] Verify all 6 library pages render correctly in Mintlify preview
- [ ] Confirm nav group appears under Integrations tab
- [ ] Verify migration guide bridge section links work

Made with [Cursor](https://cursor.com)