### PR TITLE
[PXT-1172] Table load can raise AssertionError if the table is dropped concurrently

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -893,7 +893,7 @@ class Catalog:
                     raise
 
             except Exception as e:
-                if excs.is_table_not_found(e):
+                if excs.is_table_not_found_error(e):
                     _logger.error(f'Finalize pending ops({tbl_id}): table not found', exc_info=True)
                     raise
 

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -894,7 +894,7 @@ class Catalog:
 
             except Exception as e:
                 if excs.is_table_not_found(e):
-                    _logger.error(f'Finalize pending ops({tbl_id}): table was dropped', exc_info=True)
+                    _logger.error(f'Finalize pending ops({tbl_id}): table not found', exc_info=True)
                     raise
 
                 if not is_rollback and tbl_md is not None and tbl_md.pending_stmt.can_abort():

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -260,9 +260,6 @@ class Catalog:
             clause = sql.and_(schema.Table.md['name'].astext == tbl_name, clause)
         return clause
 
-    def _dropped_tbl_error_msg(self, tbl_id: UUID) -> str:
-        return f'Table was dropped (no record found for {tbl_id})'
-
     def validate(self) -> None:
         """Validate structural consistency of cached metadata"""
         for (tbl_id, effective_version, anchor_tbl_id), tbl_version in self._tbl_versions.items():
@@ -551,10 +548,7 @@ class Catalog:
             if tbl is not None:
                 tbl_name = tbl.get().name
             _logger.debug(f'Exception: undefined table {(tbl_name or "<unknown>")!r}: Caught {type(e.orig)}: {e!r}')
-            raise excs.NotFoundError(
-                excs.ErrorCode.TABLE_NOT_FOUND,
-                f'Table was dropped: {tbl_name}' if tbl_name is not None else 'Table was dropped',
-            ) from None
+            raise excs.table_was_dropped(tbl_name) from None
         elif (
             # TODO: Investigate whether DeadlockDetected points to a bug in our locking protocol,
             #     which is supposed to be deadlock-free.
@@ -672,7 +666,7 @@ class Catalog:
         conn = get_runtime().conn
         row = conn.execute(sql.select(schema.Table).where(where_clause).with_for_update(nowait=True)).one_or_none()
         if row is None:
-            raise excs.NotFoundError(excs.ErrorCode.TABLE_NOT_FOUND, self._dropped_tbl_error_msg(tbl_id))
+            raise excs.table_was_dropped(tbl_id)
         tbl_md = schema.md_from_dict(schema.TableMd, row.md)
         locked: set[UUID] = set()
         if tbl_md.is_mutable:
@@ -713,7 +707,7 @@ class Catalog:
         conn = get_runtime().conn
         row = conn.execute(sql.select(schema.Table).where(schema.Table.id == tbl_id)).one_or_none()
         if row is None:
-            raise excs.NotFoundError(excs.ErrorCode.TABLE_NOT_FOUND, self._dropped_tbl_error_msg(tbl_id))
+            raise excs.table_was_dropped(tbl_id)
         tbl_md = schema.md_from_dict(schema.TableMd, row.md)
 
         if check_pending_ops:
@@ -899,9 +893,7 @@ class Catalog:
                     raise
 
             except Exception as e:
-                if 'Table was dropped' in str(e):
-                    # TODO 'Table was dropped' should be a separate exception type, or there should be some other, less
-                    # brittle way to detect this error.
+                if excs.is_table_not_found(e):
                     _logger.error(f'Finalize pending ops({tbl_id}): table was dropped', exc_info=True)
                     raise
 
@@ -2036,7 +2028,7 @@ class Catalog:
         q = sql.select(sql.func.count()).select_from(schema.Table).where(self._active_tbl_clause(tbl_id=tbl_id))
         tbl_count = conn.execute(q).scalar()
         if tbl_count == 0:
-            raise excs.NotFoundError(excs.ErrorCode.TABLE_NOT_FOUND, self._dropped_tbl_error_msg(tbl_id))
+            raise excs.table_was_dropped(tbl_id)
         q = (
             sql.select(schema.Table.id)
             .where(schema.Table.md['view_md']['base_versions'][0][0].astext == tbl_id.hex)
@@ -2095,7 +2087,7 @@ class Catalog:
             q = sql.select(schema.Table.md).where(where_clause)
             row = conn.execute(q).one_or_none()
             if row is None:
-                raise excs.NotFoundError(excs.ErrorCode.TABLE_NOT_FOUND, self._dropped_tbl_error_msg(key.tbl_id))
+                raise excs.table_was_dropped(key.tbl_id)
 
             reload = False
 
@@ -2129,7 +2121,7 @@ class Catalog:
                 )
                 row = conn.execute(q).one_or_none()
                 if row is None:
-                    raise excs.NotFoundError(excs.ErrorCode.TABLE_NOT_FOUND, self._dropped_tbl_error_msg(key.tbl_id))
+                    raise excs.table_was_dropped(key.tbl_id)
                 version = row.md['version']
                 if version != tv.version:  # TODO: How will view_sn work for replicas?
                     _logger.debug(
@@ -2491,7 +2483,7 @@ class Catalog:
 
         row = conn.execute(q).one_or_none()
         if row is None:
-            raise excs.NotFoundError(excs.ErrorCode.TABLE_NOT_FOUND, self._dropped_tbl_error_msg(key.tbl_id))
+            raise excs.table_was_dropped(key.tbl_id)
         tbl_record, version_record, schema_version_record = _unpack_row(
             row, [schema.Table, schema.TableVersion, schema.TableSchemaVersion]
         )
@@ -2752,7 +2744,7 @@ class Catalog:
         if check_pending_ops:
             # if we care about pending ops, we also care whether the table is in the process of getting dropped
             if tbl_md.pending_stmt == schema.TableStatement.DROP_TABLE:
-                raise excs.NotFoundError(excs.ErrorCode.TABLE_NOT_FOUND, self._dropped_tbl_error_msg(key.tbl_id))
+                raise excs.table_was_dropped(key.tbl_id)
 
             pending_ops_q = (
                 sql.select(sql.func.count())

--- a/pixeltable/exceptions.py
+++ b/pixeltable/exceptions.py
@@ -256,6 +256,6 @@ def table_was_dropped(identifier: Any = None) -> NotFoundError:
     return NotFoundError(ErrorCode.TABLE_NOT_FOUND, msg)
 
 
-def is_table_not_found(e: BaseException) -> bool:
+def is_table_not_found_error(e: BaseException) -> bool:
     """Returns True if the exception signals that a table was not found."""
     return isinstance(e, Error) and e.error_code == ErrorCode.TABLE_NOT_FOUND

--- a/pixeltable/exceptions.py
+++ b/pixeltable/exceptions.py
@@ -244,3 +244,18 @@ class PixeltableWarning(Warning):
 
 class PixeltableDeprecationWarning(DeprecationWarning, PixeltableWarning):
     pass
+
+
+def table_was_dropped(identifier: Any = None) -> NotFoundError:
+    """
+    Creates an error to indicate that a table is not found (was dropped).
+
+    identifier (optional) can be a table ID or name
+    """
+    msg = 'Table was dropped' if identifier is None else f'Table was dropped (no record found for {identifier})'
+    return NotFoundError(ErrorCode.TABLE_NOT_FOUND, msg)
+
+
+def is_table_not_found(e: BaseException) -> bool:
+    """Returns True if the exception signals that a table was not found."""
+    return isinstance(e, Error) and e.error_code == ErrorCode.TABLE_NOT_FOUND

--- a/pixeltable/store.py
+++ b/pixeltable/store.py
@@ -18,6 +18,7 @@ from pixeltable.index.btree import BtreeIndex
 from pixeltable.metadata import schema
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.exception_handler import run_cleanup
+from pixeltable.utils.fault_injection import FaultLocation, process_fault
 from pixeltable.utils.sql import log_explain, log_stmt
 from pixeltable.utils.uuid import uuid7
 
@@ -124,6 +125,7 @@ class StoreBase:
         """Create and return system columns"""
         rowid_cols: list[sql.Column]
         if self._store_tbl_exists():
+            process_fault(FaultLocation.STORE_CREATE_SA_TBL_AFTER_EXISTS_CHECK)
             # derive our rowid Columns from the existing table, without having to access self.base.store_tbl:
             # self.base may not exist anymore (both this table and our base got dropped in the same transaction, and
             # the base was finalized before this table)
@@ -136,6 +138,10 @@ class StoreBase:
                 # System columns on an unversioned table: rowid, [pos_0, pos_1, ...]
                 # System columns are always followed by at least one user column
                 col_names = [row[0] for row in conn.execute(sql.text(q)).fetchall()]
+                if len(col_names) == 0:
+                    # We can get here if another process dropped this table between the existence
+                    # check above and the select from info schema.
+                    raise excs.table_was_dropped(self.tbl_version.id)
                 assert len(col_names) > 1, col_names
                 assert not col_names[-1].startswith('pos_'), col_names
 

--- a/pixeltable/utils/fault_injection.py
+++ b/pixeltable/utils/fault_injection.py
@@ -13,6 +13,7 @@ class FaultLocation(Enum):
     CATALOG_FINALIZE_PENDING_OPS_NON_XACT = auto()
     CATALOG_LOAD_VIEW_OP_EXEC = auto()
     SCHEDULER_RATE_LIMITS_AEXEC = auto()
+    STORE_CREATE_SA_TBL_AFTER_EXISTS_CHECK = auto()
     TEST = auto()
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -354,3 +354,36 @@ class TestCatalog:
         assert pxt.get_table('base').count() == 1
         # Verify that the insert was propagated to vb.
         assert pxt.get_table('vb').count() == 1
+
+    def test_load_table_concurrent_drop_store_tbl(self, uses_db: None, fault_injection: None) -> None:
+        """
+        Verifies a bug fix: one thread is loading a table while the other is dropping it.
+        """
+        pxt.create_table('test', {'a': pxt.Int})
+        block_in_store_base = BlockFault()
+
+        def get_table_expect_not_found() -> None:
+            with pxt_raises(excs.ErrorCode.TABLE_NOT_FOUND, match='Table was dropped'):
+                pxt.get_table('test')
+
+        (
+            MultiThreadedScenario()
+            # Thread 0: arm the fault that blocks right after _store_tbl_exists() returns True
+            .then_run(
+                thread_id=0,
+                name='inject fault',
+                fn=lambda: get_runtime().fault_manager.inject_fault(
+                    FaultLocation.STORE_CREATE_SA_TBL_AFTER_EXISTS_CHECK, block_in_store_base
+                ),
+            )
+            # Thread 0: load the table with a cold cache; this will block in StoreBase. When it unblocks later, expect
+            # a "Table was dropped" error. Before the fix, this would raise an AssertionError.
+            .then_run_until(
+                thread_id=0, name='get table', event=block_in_store_base.reached, fn=get_table_expect_not_found
+            )
+            # Thread 1: drop the table while Thread 0 is frozen. This drops store table as well.
+            .then_run(thread_id=1, name='drop table', fn=lambda: pxt.drop_table('test'))
+            # Thread 1: unblock Thread 0 inside StoreBase
+            .then_run(thread_id=1, name='unblock thread 0', fn=lambda: block_in_store_base.unblock())
+            .execute()
+        )


### PR DESCRIPTION
One process drops the table while the other is inside `StoreBase` to load it.

Found by random ops test:

```
Traceback (most recent call last):
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/catalog.py", line 422, in begin_xact
    yield conn
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/catalog.py", line 118, in loop
    return op(*args, **kwargs)
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/table.py", line 271, in op
    return [t._path() for t in self._get_views(recursive=recursive)]
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/table.py", line 278, in _get_views
    views = [cat.get_table_by_id(id) for id in view_ids]
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/table.py", line 278, in <listcomp>
    views = [cat.get_table_by_id(id) for id in view_ids]
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/catalog.py", line 1396, in get_table_by_id
    return self._load_tbl(tbl_id, ignore_pending_drop=ignore_if_dropped)
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/catalog.py", line 2268, in _load_tbl
    _ = self._load_tbl_version(key)
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/catalog.py", line 2809, in _load_tbl_version
    tbl_version.init()
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/table_version.py", line 457, in init
    self._init_schema()
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/catalog/table_version.py", line 556, in _init_schema
    self.store_tbl = StoreView(self)
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/store.py", line 751, in __init__
    super().__init__(catalog_view)
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/store.py", line 88, in __init__
    self.create_sa_tbl(tbl_version)
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/store.py", line 171, in create_sa_tbl
    system_cols = self._create_system_columns()
  File "/home/runner/work/pixeltable/pixeltable/pixeltable/store.py", line 139, in _create_system_columns
    assert len(col_names) > 1, col_names
AssertionError: []
```