### PR TITLE
random ops: disable stdout buffering on workers

### DIFF
--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -601,7 +601,7 @@ def main() -> None:
 
         worker_args = [
             [
-                '-u',  # flush every line to stdout immediately so that logs from workers appear in the right order
+                '-u',  # run workers with unbuffered stdio to reduce buffering-related log reordering
                 '-c',
                 'from tool.random_ops import run; '
                 f'run({i}, {i >= args.workers - args.read_only_workers}, '

--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -601,6 +601,7 @@ def main() -> None:
 
         worker_args = [
             [
+                '-u',  # flush every line to stdout immediately so that logs from workers appear in the right order
                 '-c',
                 'from tool.random_ops import run; '
                 f'run({i}, {i >= args.workers - args.read_only_workers}, '


### PR DESCRIPTION
Workers will flush more frequenly, and stress test log (when runs on github) will be properly ordered by timestamp.