### PR TITLE
Pre-download HuggingFace models in CI and run tests in offline mode

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -220,6 +220,8 @@ jobs:
           coverage report -m
       - name: Download HF models for notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
+        env:
+          HF_HUB_OFFLINE: 0
         run: |
           ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L6-v2 --revision 1110a243fdf4706b3f48f1d95db1a4f5529b4d41
           ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L12-v2 --revision a50ef00143b4d5391434df20ae11632588ac25be

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -220,13 +220,13 @@ jobs:
       - name: Download HF models for notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
         run: |
-          ./scripts/retry.sh 5 60 huggingface-cli download sentence-transformers/all-MiniLM-L6-v2
-          ./scripts/retry.sh 5 60 huggingface-cli download sentence-transformers/all-MiniLM-L12-v2
-          ./scripts/retry.sh 5 60 huggingface-cli download facebook/detr-resnet-50
-          ./scripts/retry.sh 5 60 huggingface-cli download openai/clip-vit-base-patch32
-          ./scripts/retry.sh 5 60 huggingface-cli download intfloat/e5-large-v2
-          ./scripts/retry.sh 5 60 huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct-GGUF --include '*q5_k_m.gguf'
-          ./scripts/retry.sh 5 60 huggingface-cli download bartowski/Llama-3.2-1B-Instruct-GGUF --include '*Q5_K_M.gguf'
+          ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L6-v2
+          ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L12-v2
+          ./scripts/retry.sh 5 60 hf download facebook/detr-resnet-50
+          ./scripts/retry.sh 5 60 hf download openai/clip-vit-base-patch32
+          ./scripts/retry.sh 5 60 hf download intfloat/e5-large-v2
+          ./scripts/retry.sh 5 60 hf download Qwen/Qwen2.5-0.5B-Instruct-GGUF --include '*q5_k_m.gguf'
+          ./scripts/retry.sh 5 60 hf download bartowski/Llama-3.2-1B-Instruct-GGUF --include '*Q5_K_M.gguf'
           ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('cornell-movie-review-data/rotten_tomatoes', trust_remote_code=True)"
           ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('stanfordnlp/imdb', trust_remote_code=True)"
           ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('ylecun/mnist', trust_remote_code=True)"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -232,7 +232,8 @@ jobs:
           ./scripts/retry.sh 5 60 hf download microsoft/speecht5_tts --revision 30fcde30f19b87502b8435427b5f5068e401d5f6
           ./scripts/retry.sh 5 60 hf download microsoft/speecht5_hifigan --revision bb6f429406e86a9992357a972c0698b22043307d
           ./scripts/retry.sh 5 60 hf download Qwen/Qwen2-0.5B-Instruct-GGUF --revision 198f08841147e5196a6a69bd0053690fb1fd3857 --include '*q3_k_m.gguf'
-          ./scripts/retry.sh 5 60 hf download --repo-type dataset Cohere/wikipedia-2023-11-embed-multilingual-v3 --revision ade45fb52bd549f5e8c065636fe4160a43c2af36 --include 'cr/*' --include 'mi/*'
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('Cohere/wikipedia-2023-11-embed-multilingual-v3', 'cr', trust_remote_code=True)"
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('Cohere/wikipedia-2023-11-embed-multilingual-v3', 'mi', trust_remote_code=True)"
       - name: Run the unit tests
         if: ${{ matrix.test-category == 'py' }}
         env:
@@ -258,9 +259,9 @@ jobs:
           ./scripts/retry.sh 5 60 hf download intfloat/e5-large-v2 --revision f169b11e22de13617baa190a028a32f3493550b6
           ./scripts/retry.sh 5 60 hf download Qwen/Qwen2.5-0.5B-Instruct-GGUF --revision 9217f5db79a29953eb74d5343926648285ec7e67 --include '*q5_k_m.gguf'
           ./scripts/retry.sh 5 60 hf download bartowski/Llama-3.2-1B-Instruct-GGUF --revision 067b946cf014b7c697f3654f621d577a3e3afd1c --include '*Q5_K_M.gguf'
-          ./scripts/retry.sh 5 60 hf download --repo-type dataset cornell-movie-review-data/rotten_tomatoes --revision aa13bc287fa6fcab6daf52f0dfb9994269ffea28
-          ./scripts/retry.sh 5 60 hf download --repo-type dataset stanfordnlp/imdb --revision e6281661ce1c48d982bc483cf8a173c1bbeb5d31
-          ./scripts/retry.sh 5 60 hf download --repo-type dataset ylecun/mnist --revision 77f3279092a1c1579b2250db8eafed0ad422088c
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('cornell-movie-review-data/rotten_tomatoes', trust_remote_code=True)"
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('stanfordnlp/imdb', trust_remote_code=True)"
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('ylecun/mnist', trust_remote_code=True)"
       - name: Run the notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -217,8 +217,23 @@ jobs:
           ${{ matrix.pre-test-cmd }}
           coverage run -m --source=pixeltable pytest -v --strict-markers ${{ matrix.pytest-options }}
           coverage report -m
+      - name: Download HF models for notebook tests
+        if: ${{ matrix.test-category == 'ipynb' }}
+        run: |
+          ./scripts/retry.sh 5 60 huggingface-cli download sentence-transformers/all-MiniLM-L6-v2
+          ./scripts/retry.sh 5 60 huggingface-cli download sentence-transformers/all-MiniLM-L12-v2
+          ./scripts/retry.sh 5 60 huggingface-cli download facebook/detr-resnet-50
+          ./scripts/retry.sh 5 60 huggingface-cli download openai/clip-vit-base-patch32
+          ./scripts/retry.sh 5 60 huggingface-cli download intfloat/e5-large-v2
+          ./scripts/retry.sh 5 60 huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct-GGUF --include '*q5_k_m.gguf'
+          ./scripts/retry.sh 5 60 huggingface-cli download bartowski/Llama-3.2-1B-Instruct-GGUF --include '*Q5_K_M.gguf'
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('cornell-movie-review-data/rotten_tomatoes', trust_remote_code=True)"
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('stanfordnlp/imdb', trust_remote_code=True)"
+          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('ylecun/mnist', trust_remote_code=True)"
       - name: Run the notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
+        env:
+          HF_HUB_OFFLINE: 1
         run: |
           ./scripts/prepare-nb-tests.sh --no-pip $NB_TEST_OPTS tests/target/nb-tests docs/release tests
           set +e  # don't exit immediately on error, so that we can retry

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -220,16 +220,16 @@ jobs:
       - name: Download HF models for notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
         run: |
-          ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L6-v2
-          ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L12-v2
-          ./scripts/retry.sh 5 60 hf download facebook/detr-resnet-50
-          ./scripts/retry.sh 5 60 hf download openai/clip-vit-base-patch32
-          ./scripts/retry.sh 5 60 hf download intfloat/e5-large-v2
-          ./scripts/retry.sh 5 60 hf download Qwen/Qwen2.5-0.5B-Instruct-GGUF --include '*q5_k_m.gguf'
-          ./scripts/retry.sh 5 60 hf download bartowski/Llama-3.2-1B-Instruct-GGUF --include '*Q5_K_M.gguf'
-          ./scripts/retry.sh 5 60 hf download --repo-type dataset cornell-movie-review-data/rotten_tomatoes
-          ./scripts/retry.sh 5 60 hf download --repo-type dataset stanfordnlp/imdb
-          ./scripts/retry.sh 5 60 hf download --repo-type dataset ylecun/mnist
+          ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L6-v2 --revision 1110a243fdf4706b3f48f1d95db1a4f5529b4d41
+          ./scripts/retry.sh 5 60 hf download sentence-transformers/all-MiniLM-L12-v2 --revision a50ef00143b4d5391434df20ae11632588ac25be
+          ./scripts/retry.sh 5 60 hf download facebook/detr-resnet-50 --revision 1d5f47bd3bdd2c4bbfa585418ffe6da5028b4c0b
+          ./scripts/retry.sh 5 60 hf download openai/clip-vit-base-patch32 --revision 3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268
+          ./scripts/retry.sh 5 60 hf download intfloat/e5-large-v2 --revision f169b11e22de13617baa190a028a32f3493550b6
+          ./scripts/retry.sh 5 60 hf download Qwen/Qwen2.5-0.5B-Instruct-GGUF --revision 9217f5db79a29953eb74d5343926648285ec7e67 --include '*q5_k_m.gguf'
+          ./scripts/retry.sh 5 60 hf download bartowski/Llama-3.2-1B-Instruct-GGUF --revision 067b946cf014b7c697f3654f621d577a3e3afd1c --include '*Q5_K_M.gguf'
+          ./scripts/retry.sh 5 60 hf download --repo-type dataset cornell-movie-review-data/rotten_tomatoes --revision aa13bc287fa6fcab6daf52f0dfb9994269ffea28
+          ./scripts/retry.sh 5 60 hf download --repo-type dataset stanfordnlp/imdb --revision e6281661ce1c48d982bc483cf8a173c1bbeb5d31
+          ./scripts/retry.sh 5 60 hf download --repo-type dataset ylecun/mnist --revision 77f3279092a1c1579b2250db8eafed0ad422088c
       - name: Run the notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
         env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -205,6 +205,34 @@ jobs:
         run: uv cache clean
       - name: Set up credentials
         run: ./scripts/set-up-ci-credentials.sh
+      - name: Download HF models for unit tests
+        if: ${{ matrix.test-category == 'py' }}
+        env:
+          HF_HUB_OFFLINE: 0
+        run: |
+          ./scripts/retry.sh 5 60 hf download intfloat/e5-large-v2 --revision f169b11e22de13617baa190a028a32f3493550b6
+          ./scripts/retry.sh 5 60 hf download facebook/detr-resnet-50 --revision 1d5f47bd3bdd2c4bbfa585418ffe6da5028b4c0b
+          ./scripts/retry.sh 5 60 hf download facebook/detr-resnet-50-panoptic --revision d53b52a799403a8867920f82c869e40732b47037
+          ./scripts/retry.sh 5 60 hf download openai/clip-vit-base-patch32 --revision 3d74acf9a28c67741b2f4f2ea7635f0aaf6f0268
+          ./scripts/retry.sh 5 60 hf download laion/CLIP-ViT-B-32-laion2B-s34B-b79K --revision 1a25a446712ba5ee05982a381eed697ef9b435cf
+          ./scripts/retry.sh 5 60 hf download google/vit-base-patch16-224 --revision 3f49326eb077187dfe1c2a2bb15fbd74e6ab91e3
+          ./scripts/retry.sh 5 60 hf download sentence-transformers/all-mpnet-base-v2 --revision e8c3b32edf5434bc2275fc9bab85f82640a19130
+          ./scripts/retry.sh 5 60 hf download BAAI/bge-reranker-base --revision 2cfc18c9415c912f9d8155881c133215df768a70
+          ./scripts/retry.sh 5 60 hf download cross-encoder/ms-marco-MiniLM-L-6-v2 --revision c5ee24cb16019beea0893ab7796b1df96625c6b8
+          ./scripts/retry.sh 5 60 hf download cross-encoder/ms-marco-TinyBERT-L-2-v2 --revision 81d1926f67cb8eee2c2be17ca9f793c7c3bd20cc
+          ./scripts/retry.sh 5 60 hf download facebook/s2t-small-librispeech-asr --revision 256e91a603c013ae09aa1e4c09cfc3f8acdf8d19
+          ./scripts/retry.sh 5 60 hf download facebook/s2t-medium-mustc-multilingual-st --revision 79cc4237d4495aea7863076900d2f23af77f3ddc
+          ./scripts/retry.sh 5 60 hf download Qwen/Qwen3-0.6B --revision c1899de289a04d12100db370d81485cdf75e47ca
+          ./scripts/retry.sh 5 60 hf download cardiffnlp/twitter-roberta-base-sentiment-latest --revision 3216a57f2a0d9c45a2e6c20157c20c49fb4bf9c7
+          ./scripts/retry.sh 5 60 hf download Falconsai/text_summarization --revision 6e505f907968c4a9360773ff57885cdc6dca4bfd
+          ./scripts/retry.sh 5 60 hf download distilbert/distilbert-base-cased-distilled-squad --revision 564e9b582944a57a3e586bbb98fd6f0a4118db7f
+          ./scripts/retry.sh 5 60 hf download Helsinki-NLP/opus-mt-en-fr --revision dd7f6540a7a48a7f4db59e5c0b9c42c8eea67f18
+          ./scripts/retry.sh 5 60 hf download dslim/bert-base-NER --revision d1a3e8f13f8c3566299d95fcfc9a8d2382a9affc
+          ./scripts/retry.sh 5 60 hf download openai/whisper-tiny --revision 169d4a4341b33bc18d8881c4b69c2e104e1cc0af
+          ./scripts/retry.sh 5 60 hf download microsoft/speecht5_tts --revision 30fcde30f19b87502b8435427b5f5068e401d5f6
+          ./scripts/retry.sh 5 60 hf download microsoft/speecht5_hifigan --revision bb6f429406e86a9992357a972c0698b22043307d
+          ./scripts/retry.sh 5 60 hf download Qwen/Qwen2-0.5B-Instruct-GGUF --revision 198f08841147e5196a6a69bd0053690fb1fd3857 --include '*q3_k_m.gguf'
+          ./scripts/retry.sh 5 60 hf download --repo-type dataset Cohere/wikipedia-2023-11-embed-multilingual-v3 --revision ade45fb52bd549f5e8c065636fe4160a43c2af36 --include 'cr/*' --include 'mi/*'
       - name: Run the unit tests
         if: ${{ matrix.test-category == 'py' }}
         env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,6 +55,7 @@ env:
   MINTLIFY_VERSION: 4.2.506
   NB_TEST_OPTS: ${{ (github.event_name == 'schedule' || inputs.run_on_all_platforms) && '--include-expensive' || '' }}
   UV_VERSION: 0.9.3
+  HF_HUB_OFFLINE: 1
 
   # The llama-cpp-python build fails in CI with LLaVA support enabled. If we ever want to test specific LLaVA
   # functionality in CI, we'll need to investigate further (it's likely due to a missing compiler dependency).
@@ -232,8 +233,6 @@ jobs:
           ./scripts/retry.sh 5 60 hf download --repo-type dataset ylecun/mnist --revision 77f3279092a1c1579b2250db8eafed0ad422088c
       - name: Run the notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
-        env:
-          HF_HUB_OFFLINE: 1
         run: |
           ./scripts/prepare-nb-tests.sh --no-pip $NB_TEST_OPTS tests/target/nb-tests docs/release tests
           set +e  # don't exit immediately on error, so that we can retry

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -227,9 +227,9 @@ jobs:
           ./scripts/retry.sh 5 60 hf download intfloat/e5-large-v2
           ./scripts/retry.sh 5 60 hf download Qwen/Qwen2.5-0.5B-Instruct-GGUF --include '*q5_k_m.gguf'
           ./scripts/retry.sh 5 60 hf download bartowski/Llama-3.2-1B-Instruct-GGUF --include '*Q5_K_M.gguf'
-          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('cornell-movie-review-data/rotten_tomatoes', trust_remote_code=True)"
-          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('stanfordnlp/imdb', trust_remote_code=True)"
-          ./scripts/retry.sh 5 60 python -c "from datasets import load_dataset; load_dataset('ylecun/mnist', trust_remote_code=True)"
+          ./scripts/retry.sh 5 60 hf download --repo-type dataset cornell-movie-review-data/rotten_tomatoes
+          ./scripts/retry.sh 5 60 hf download --repo-type dataset stanfordnlp/imdb
+          ./scripts/retry.sh 5 60 hf download --repo-type dataset ylecun/mnist
       - name: Run the notebook tests
         if: ${{ matrix.test-category == 'ipynb' }}
         env:

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -20,7 +20,7 @@ fi
 echo "Running command with $retries retries: $@"
 
 while (( retries-- > 0)); do
-    $@
+    "$@"
     RESULT="$?"
     if [[ "$RESULT" == 0 ]]; then
         break


### PR DESCRIPTION
Without an HF token, GitHub Actions runners are aggressively rate-limited by HuggingFace (429s), causing notebook and unit tests to fail intermittently. Since secrets are unavailable in fork PR workflows, a token-based fix isn't possible.

1. Download and prepare HF models, datasets, etc. before tests run.
2. Revision pinning is necessary to avoid metadata API calls to HF that happen to be the source of 429 errors.
3. `HF_HUB_OFFLINE=1` during tests stops HF library from calling home. If notebooks or tests are updated and require new models or datasets, `pytest.yml` needs to be updated.