### PR TITLE
Fix Catalog lock ordering

### DIFF
--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -492,16 +492,11 @@ class Catalog:
         updates self._x_locked_tbl_ids accordingly.
 
         Refreshes the metadata cache for the read targets.
+
+        The order matters: TVPs are processed before tbl_ids in both groups so that ancestor-first validation
+        (write_tvps -> write_tbl_ids -> read_tvps -> read_tbl_ids) is established before any unordered ID pass runs.
         """
         x_locked_ids: set[UUID] = set()
-        for tbl_id in write_tbl_ids:
-            if tbl_id in x_locked_ids:
-                continue
-            x_locked_ids.update(
-                self._acquire_write_lock(
-                    tbl_id=tbl_id, lock_mutable_tree=lock_mutable_tree, check_pending_ops=finalize_pending_ops
-                )
-            )
         for tvp in write_tvps:
             if tvp.tbl_id in x_locked_ids:
                 continue
@@ -510,10 +505,18 @@ class Catalog:
                     tbl=tvp, for_write=True, lock_mutable_tree=lock_mutable_tree, check_pending_ops=finalize_pending_ops
                 )
             )
-        for tbl_id in read_tbl_ids:
-            self._refresh_tbl_cache(tbl_id=tbl_id, check_pending_ops=finalize_pending_ops)
+        for tbl_id in write_tbl_ids:
+            if tbl_id in x_locked_ids:
+                continue
+            x_locked_ids.update(
+                self._acquire_write_lock(
+                    tbl_id=tbl_id, lock_mutable_tree=lock_mutable_tree, check_pending_ops=finalize_pending_ops
+                )
+            )
         for tvp in read_tvps:
             self._acquire_path_locks(tbl=tvp, for_write=False, check_pending_ops=finalize_pending_ops)
+        for tbl_id in read_tbl_ids:
+            self._refresh_tbl_cache(tbl_id=tbl_id, check_pending_ops=finalize_pending_ops)
 
         self._x_locked_tbl_ids = x_locked_ids
 

--- a/scripts/stress-tests.sh
+++ b/scripts/stress-tests.sh
@@ -34,8 +34,8 @@ echo "Running random-ops ($WORKERS workers for $DURATION seconds) ..."
 if [ -n "$PXT_STRESS_TESTS_READ_ONLY" ]; then
     echo "Read-only mode enabled: only Worker 0 will perform write operations."
     # In read-only mode, all operations are enabled.
-    python tool/random_ops.py "$WORKERS" "$DURATION" --read-only-workers $(( WORKERS - 1 ))
+    python -u tool/random_ops.py "$WORKERS" "$DURATION" --read-only-workers $(( WORKERS - 1 ))
 else
     # In read/write mode, we disable certain operations and data types that have known concurrency bugs.
-    python tool/random_ops.py "$WORKERS" "$DURATION" --exclude rename_view -Drandom_img_freq=0 -Drandom_json_freq=0 -Drandom_array_freq=0
+    python -u tool/random_ops.py "$WORKERS" "$DURATION" --exclude rename_view -Drandom_img_freq=0 -Drandom_json_freq=0 -Drandom_array_freq=0
 fi


### PR DESCRIPTION
Fix the order in which Catalog acquires table locks:
* writes before reads
* whole tvps before individual tables

Writes-before-reads is by convention, right now Catalog does not depend on it for correctness.

But it's crucial to cache/lock the table paths before individual tables in order to guarantee the ancestor-first ordering of locking.

Without this fix, the following scenario is possible:
1. There exist a base table, a mid_view on it, and a leaf_view on mid_view. Thread 0 has all 3 cached.
2. Thread 0 starts to validate its cache for a read in the following order: leaf_view individually, then base table's whole path (base table, mid_view, leaf_view)
3. Thread 1 drops leaf_view concurrently
4. When Thread 0 reaches mid_view in its validation loop, it notices that mid_view's view_sn changed, and reloads mid_view. mid_view no longer lists leaf_view in its mutable_views.
5. Thread 0 skips leaf_view validation the second time since it was validated first.
6. Thread 0's Catalog is in an inconsistent state: both leaf_view and mid_view are validated, yet mid_view does not list leaf_view as its mutable view.

This scenario is very hard to deterministically reproduce and validate in a test without messing too much with Pixeltable internals, so not including a test.