### PR TITLE
Update HF cache clearing after tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,12 @@ def _clear_hf_caches() -> None:
                 revision.commit_hash
                 for repo in cache_info.repos
                 # Keep around models that are used by multiple tests
-                if repo.repo_id not in ('openai/clip-vit-base-patch32', 'intfloat/e5-large-v2', 'sentence-transformers/all-mpnet-base-v2')
+                if repo.repo_id
+                not in (
+                    'openai/clip-vit-base-patch32',
+                    'intfloat/e5-large-v2',
+                    'sentence-transformers/all-mpnet-base-v2',
+                )
                 for revision in repo.revisions
             ]
             cache_info.delete_revisions(*revisions_to_delete).execute()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,7 @@ def _clear_hf_caches() -> None:
                 revision.commit_hash
                 for repo in cache_info.repos
                 # Keep around models that are used by multiple tests
-                if repo.repo_id not in ('openai/clip-vit-base-patch32', 'intfloat/e5-large-v2')
+                if repo.repo_id not in ('openai/clip-vit-base-patch32', 'intfloat/e5-large-v2', 'sentence-transformers/all-mpnet-base-v2')
                 for revision in repo.revisions
             ]
             cache_info.delete_revisions(*revisions_to_delete).execute()


### PR DESCRIPTION
`all-mpnet-base-v2` is used by a number of tests. This change should lower the pressure on our HF quota and speed up tests.