### PR TITLE
new pull_request action should cancel the previous test run on the pr

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,6 +23,10 @@ name: tests
 # Github Actions secrets are unavailable on PRs; hence any tests that require API keys will be skipped.
 # Secrets are available on all other triggers.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Right now if a commit is pushed to the pr, a new test run is started without aborting the previously running one. Example:
https://github.com/pixeltable/pixeltable/actions/runs/27221551290
https://github.com/pixeltable/pixeltable/actions/runs/27222349528