### PR TITLE
[PXT-1169] rename FastAPIRouter._shutdown

### DIFF
--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -182,7 +182,7 @@ class FastAPIRouter(fastapi.APIRouter):
         self._register_jobs_route()
         # Shut down the worker pool when the parent app's lifespan ends. include_router()
         # merges this handler into the app's on_shutdown list, so it fires on app shutdown.
-        self.add_event_handler('shutdown', self._shutdown_worker_pool)
+        self.add_event_handler('shutdown', self.__shutdown)
 
     def add_api_route(self, path: str, *args: Any, **kwargs: Any) -> None:
         """Wrap FastAPI's add_api_route with a duplicate (path, method) check."""
@@ -201,7 +201,7 @@ class FastAPIRouter(fastapi.APIRouter):
             )
         super().add_api_route(path, *args, **kwargs)
 
-    def _shutdown_worker_pool(self) -> None:
+    def __shutdown(self) -> None:
         # wait until in-flight requests are done and won't access _engine_cache
         self._executor.shutdown(wait=True, cancel_futures=True)
         for eng in self._engine_cache.values():

--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -182,7 +182,7 @@ class FastAPIRouter(fastapi.APIRouter):
         self._register_jobs_route()
         # Shut down the worker pool when the parent app's lifespan ends. include_router()
         # merges this handler into the app's on_shutdown list, so it fires on app shutdown.
-        self.add_event_handler('shutdown', self._shutdown)
+        self.add_event_handler('shutdown', self._shutdown_worker_pool)
 
     def add_api_route(self, path: str, *args: Any, **kwargs: Any) -> None:
         """Wrap FastAPI's add_api_route with a duplicate (path, method) check."""
@@ -201,7 +201,7 @@ class FastAPIRouter(fastapi.APIRouter):
             )
         super().add_api_route(path, *args, **kwargs)
 
-    def _shutdown(self) -> None:
+    def _shutdown_worker_pool(self) -> None:
         # wait until in-flight requests are done and won't access _engine_cache
         self._executor.shutdown(wait=True, cancel_futures=True)
         for eng in self._engine_cache.values():

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -140,6 +140,7 @@ class TestFastAPI:
     ) -> None:
         """Test insert routes with all scalar types and various input/output combinations."""
         skip_test_if_not_installed('fastapi')
+
         from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')
@@ -215,84 +216,82 @@ class TestFastAPI:
         # engine cache reuse: three export_sql routes against the same db_connect share one engine
         assert len(router._engine_cache) == 1
 
-        client = make_test_client(router)
+        with make_test_client(router) as client:
+            all_input = {
+                'id': 1,
+                'str_col': 'hello',
+                'int_col': -5,
+                'float_col': -3.14,
+                'bool_col': True,
+                'json_col': {'key': 'value'},
+            }
+            resp = client.post('/all', json=all_input)
+            assert resp.status_code == 200, resp.text
+            expected = {
+                'id': 1,
+                'str_col': 'hello',
+                'int_col': -5,
+                'float_col': -3.14,
+                'bool_col': True,
+                'json_col': {'key': 'value'},
+                'str_upper': 'HELLO',
+                'int_plus1': -4,
+                'float_abs': 3.14,
+                'json_str': json.dumps({'key': 'value'}),
+            }
+            assert resp.json() == expected
+            row = t.where(t.id == 1).collect()[0]
+            assert row == expected
+            assert_sqlite_row(db_connect, 'out_all', {'id': 1}, expected)
 
-        all_input = {
-            'id': 1,
-            'str_col': 'hello',
-            'int_col': -5,
-            'float_col': -3.14,
-            'bool_col': True,
-            'json_col': {'key': 'value'},
-        }
-        resp = client.post('/all', json=all_input)
-        assert resp.status_code == 200, resp.text
-        expected = {
-            'id': 1,
-            'str_col': 'hello',
-            'int_col': -5,
-            'float_col': -3.14,
-            'bool_col': True,
-            'json_col': {'key': 'value'},
-            'str_upper': 'HELLO',
-            'int_plus1': -4,
-            'float_abs': 3.14,
-            'json_str': json.dumps({'key': 'value'}),
-        }
-        assert resp.json() == expected
-        row = t.where(t.id == 1).collect()[0]
-        assert row == expected
-        assert_sqlite_row(db_connect, 'out_all', {'id': 1}, expected)
+            resp = client.post('/partial-in', json={'id': 2, 'str_col': 'world', 'int_col': 10})
+            assert resp.status_code == 200, resp.text
+            expected = {
+                'id': 2,
+                'str_col': 'world',
+                'int_col': 10,
+                'float_col': None,
+                'bool_col': None,
+                'json_col': None,
+                'str_upper': 'WORLD',
+                'int_plus1': 11,
+                'float_abs': None,
+                'json_str': None,
+            }
+            assert resp.json() == expected
+            print(resp.json())
+            row = t.where(t.id == 2).collect()[0]
+            assert row == expected
 
-        resp = client.post('/partial-in', json={'id': 2, 'str_col': 'world', 'int_col': 10})
-        assert resp.status_code == 200, resp.text
-        expected = {
-            'id': 2,
-            'str_col': 'world',
-            'int_col': 10,
-            'float_col': None,
-            'bool_col': None,
-            'json_col': None,
-            'str_upper': 'WORLD',
-            'int_plus1': 11,
-            'float_abs': None,
-            'json_str': None,
-        }
-        assert resp.json() == expected
-        print(resp.json())
-        row = t.where(t.id == 2).collect()[0]
-        assert row == expected
+            resp = client.post('/partial-out', json={**all_input, 'id': 3})
+            assert resp.status_code == 200, resp.text
+            expected = {'id': 3, 'str_upper': 'HELLO', 'int_plus1': -4}
+            assert resp.json() == expected
+            row = t.where(t.id == 3).select(t.id, t.str_upper, t.int_plus1).collect()[0]
+            assert row == expected
 
-        resp = client.post('/partial-out', json={**all_input, 'id': 3})
-        assert resp.status_code == 200, resp.text
-        expected = {'id': 3, 'str_upper': 'HELLO', 'int_plus1': -4}
-        assert resp.json() == expected
-        row = t.where(t.id == 3).select(t.id, t.str_upper, t.int_plus1).collect()[0]
-        assert row == expected
+            resp = client.post('/minimal', json={'id': 4, 'int_col': 99})
+            assert resp.status_code == 200, resp.text
+            expected = {'int_plus1': 100}
+            assert resp.json() == expected
+            row = t.where(t.id == 4).select(t.int_plus1).collect()[0]
+            assert row == expected
+            assert_sqlite_row(db_connect, 'out_minimal', {'int_plus1': 100}, expected)
 
-        resp = client.post('/minimal', json={'id': 4, 'int_col': 99})
-        assert resp.status_code == 200, resp.text
-        expected = {'int_plus1': 100}
-        assert resp.json() == expected
-        row = t.where(t.id == 4).select(t.int_plus1).collect()[0]
-        assert row == expected
-        assert_sqlite_row(db_connect, 'out_minimal', {'int_plus1': 100}, expected)
+            # method='update': pxt insert triggers UPDATE of the existing target row keyed on id=42
+            resp = client.post('/update', json={'id': 42, 'str_col': 'fresh', 'int_col': 7})
+            assert resp.status_code == 200, resp.text
+            expected = {'id': 42, 'str_upper': 'FRESH', 'int_plus1': 8}
+            assert resp.json() == expected
+            # the baseline ('OLD', 0) was replaced by the new values
+            assert_sqlite_row(db_connect, 'out_update', {'id': 42}, expected)
 
-        # method='update': pxt insert triggers UPDATE of the existing target row keyed on id=42
-        resp = client.post('/update', json={'id': 42, 'str_col': 'fresh', 'int_col': 7})
-        assert resp.status_code == 200, resp.text
-        expected = {'id': 42, 'str_upper': 'FRESH', 'int_plus1': 8}
-        assert resp.json() == expected
-        # the baseline ('OLD', 0) was replaced by the new values
-        assert_sqlite_row(db_connect, 'out_update', {'id': 42}, expected)
+            # method='update' against an id that doesn't exist in the target -> HTTP 500 (zero rowcount)
+            resp = client.post('/update', json={'id': 999, 'str_col': 'ghost', 'int_col': 0})
+            assert resp.status_code == 500, resp.text
+            assert 'expected 1' in resp.json()['detail']
 
-        # method='update' against an id that doesn't exist in the target -> HTTP 500 (zero rowcount)
-        resp = client.post('/update', json={'id': 999, 'str_col': 'ghost', 'int_col': 0})
-        assert resp.status_code == 500, resp.text
-        assert 'expected 1' in resp.json()['detail']
-
-        # shutdown disposes the engine cache
-        router._FastAPIRouter__shutdown()  # type: ignore[attr-defined]
+        # exiting the TestClient context fired the lifespan shutdown handler
         assert router._engine_cache == {}
 
     @pytest.mark.parametrize('route_type', ['insert', 'compute'])

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -292,7 +292,7 @@ class TestFastAPI:
         assert 'expected 1' in resp.json()['detail']
 
         # shutdown disposes the engine cache
-        router._shutdown_worker_pool()
+        router._FastAPIRouter__shutdown()  # type: ignore[attr-defined]
         assert router._engine_cache == {}
 
     @pytest.mark.parametrize('route_type', ['insert', 'compute'])

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -140,7 +140,6 @@ class TestFastAPI:
     ) -> None:
         """Test insert routes with all scalar types and various input/output combinations."""
         skip_test_if_not_installed('fastapi')
-
         from pixeltable.serving import FastAPIRouter, SqlExport
 
         pxt.create_dir('test_serve')

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -292,7 +292,7 @@ class TestFastAPI:
         assert 'expected 1' in resp.json()['detail']
 
         # shutdown disposes the engine cache
-        router._shutdown()
+        router._shutdown_worker_pool()
         assert router._engine_cache == {}
 
     @pytest.mark.parametrize('route_type', ['insert', 'compute'])


### PR DESCRIPTION
`fastapi.APIRouter._shutdown` already exists, and by defining `FastAPIRouter._shutdown` we overshadow it.

This fixes the following error when `pxt serve` exits:

```
ERROR:    Traceback (most recent call last):
  File "/Users/sergeymkhitaryan/work/pixeltable/myapp/.venv/lib/python3.12/site-packages/starlette/routing.py", line 694, in lifespan
    async with self.lifespan_context(app) as maybe_state:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sergeymkhitaryan/.local/share/uv/python/cpython-3.12.12-macos-aarch64-none/lib/python3.12/contextlib.py", line 217, in __aexit__
    await anext(self.gen)
  File "/Users/sergeymkhitaryan/work/pixeltable/myapp/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 217, in merged_lifespan
    async with nested_context(app) as maybe_nested_state:
               ^^^^^^^^^^^^^^^^^^^
  File "/Users/sergeymkhitaryan/work/pixeltable/myapp/.venv/lib/python3.12/site-packages/fastapi/routing.py", line 244, in __aexit__
    await self._router._shutdown()
TypeError: object NoneType can't be used in 'await' expression

ERROR:    Application shutdown failed. Exiting.
```