### PR TITLE
Infer union type annotations as their common supertype

### DIFF
--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -337,16 +337,22 @@ class ColumnType:
         origin = typing.get_origin(t)
         type_args = typing.get_args(t)
         if origin in (typing.Union, types.UnionType):
-            # Check if `t` has the form T | None.
-            if len(type_args) == 2 and type(None) in type_args:
-                # `t` is a type of the form T | None (equivalently, T | None or None | T).
-                # We treat it as the underlying type but with nullable=True.
-                underlying_py_type = type_args[0] if type_args[1] is type(None) else type_args[1]
-                underlying = cls.from_python_type(
-                    underlying_py_type, allow_builtin_types=allow_builtin_types, infer_pydantic_json=infer_pydantic_json
+            # `None` in the union just makes the result nullable; resolve the other arms to column types and take
+            # their common supertype
+            nullable = type(None) in type_args or nullable_default
+            arms = [
+                cls.from_python_type(
+                    arg, allow_builtin_types=allow_builtin_types, infer_pydantic_json=infer_pydantic_json
                 )
-                if underlying is not None:
-                    return underlying.copy(nullable=True)
+                for arg in type_args
+                if arg is not type(None)
+            ]
+            # an arm isn't itself inferable, so the union isn't either
+            if any(arm is None for arm in arms):
+                return None
+            common = cls.common_supertype(arms)
+            if common is not None:
+                return common.copy(nullable=nullable)
         elif origin is Required:
             assert len(type_args) == 1
             return cls.from_python_type(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -305,6 +305,32 @@ class TestTypes:
             assert non_nullable_pxt_type._to_str(as_schema=True) == f'Required[{string}]'
             assert nullable_pxt_type._to_str(as_schema=True) == string
 
+    def test_union_inference(self, init_env: None) -> None:
+        class NonInferable:
+            pass
+
+        test_cases: tuple[tuple[Any, Any], ...] = (
+            # A union of distinct types infers to the common supertype that can represent all arms.
+            (str | list[str], JsonType(nullable=False)),
+            (int | str, JsonType(nullable=False)),
+            (dict[str, int] | list[str], JsonType(nullable=False)),
+            # Numeric arms use the scalar supertype rules, not JSON.
+            (int | float, FloatType(nullable=False)),
+            # `None` in the union makes the result nullable.
+            (str | list[str] | None, JsonType(nullable=True)),
+            # No common supertype, or a non-inferable arm: not inferable (must not crash, regardless of arm order).
+            (PIL.Image.Image | str, None),
+            (bytes | str, None),
+            (str | NonInferable, None),
+            (NonInferable | str, None),
+        )
+
+        for py_type, expected in test_cases:
+            assert ColumnType.from_python_type(py_type) == expected, py_type
+
+        # nullable_default applies to unions too.
+        assert ColumnType.from_python_type(int | str, nullable_default=True) == JsonType(nullable=True)
+
     def test_supertype(self, init_env: None) -> None:
         test_cases = [
             (IntType(), FloatType(), FloatType()),


### PR DESCRIPTION
Pixeltable could previously only infer a column type for union annotations of the form T | None, which it
treated as a nullable T. Any other union, such as str | list[str], raised "Cannot infer pixeltable type", so
UDFs and iterators could not declare a parameter that accepts more than one type.

This change infers the common supertype across all arms of a union. A union whose arms are all JSON-compatible
resolves to Json (so str | list[str] and int | str become Json), numeric unions follow the usual scalar
widening rules (so int | float becomes Float), and a union whose arms have no common supertype, such as
Image | str, remains uninferable as before. The existing T | None behavior is unchanged.

This unblocks declaring a parameter that accepts either a single value or a list of values.
