### PR TITLE
Fix: dashboard wheel can ship a stale prebuilt bundle

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class DashboardBuildHook(BuildHookInterface):
+    """Rebuild the dashboard SPA into pixeltable_cli/server/static before the wheel is packaged.
+
+    The `pxt` daemon serves this prebuilt bundle, but the build output is gitignored and the
+    hatchling wheel build only *includes* whatever already sits in that directory (see the
+    `artifacts` entry in pyproject.toml) - it never regenerates it. Without this hook a wheel
+    can ship JavaScript that predates the API it talks to, which crashes the dashboard on load
+    for every user of that release. Building here makes a stale bundle impossible regardless of
+    who cuts the release.
+    """
+
+    PLUGIN_NAME = 'custom'
+
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:
+        dashboard_dir = Path(self.root) / 'dashboard'
+        # No dashboard sources present - eg building a wheel from the sdist, which excludes
+        # dashboard/. Nothing to rebuild; fall back to whatever assets are already bundled.
+        if not (dashboard_dir / 'package.json').exists():
+            return
+        if os.environ.get('PIXELTABLE_SKIP_DASHBOARD_BUILD'):
+            self.app.display_warning('PIXELTABLE_SKIP_DASHBOARD_BUILD set; skipping dashboard build')
+            return
+        npm = shutil.which('npm')
+        if npm is None:
+            raise RuntimeError(
+                'npm (Node.js >= 20) is required to build the dashboard SPA bundled in the wheel. '
+                'Install Node.js, or set PIXELTABLE_SKIP_DASHBOARD_BUILD=1 to build without rebuilding it.'
+            )
+        self.app.display_info('Building dashboard SPA ...')
+        subprocess.run([npm, 'install', '--silent'], cwd=dashboard_dir, check=True)
+        subprocess.run([npm, 'run', 'build'], cwd=dashboard_dir, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,11 @@ artifacts = [
     "pixeltable_cli/server/static/**",
 ]
 
+# Rebuild the dashboard SPA (into pixeltable_cli/server/static, picked up by `artifacts` above)
+# before packaging the wheel, so a release can never ship a stale prebuilt bundle. See hatch_build.py.
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
 [tool.isort]
 force_single_line = false
 line_length = 120


### PR DESCRIPTION
> Note: documentation and fix authored with the help of Claude Opus 4.8. @apreshill ran into this bug locally.

### Problem

`pxt dashboard` crashes on load for users of releases where the bundled
dashboard JavaScript is older than the API it talks to:

- `TypeError: can't access property "home", u.config is undefined` (`/api/status` shape)
- `TypeError: e.reduce is not a function` (`/api/dirs` shape)

The dashboard SPA is served by the `pxt` daemon from a prebuilt bundle in
`pixeltable_cli/server/static/`. That output is gitignored, and the hatchling
wheel build only *includes* whatever already sits there (via `artifacts`) — it
never rebuilds it. The rebuild only happens in the `Makefile` and in a manual
CI step, so any release cut with `hatch build` / `uv build` without first
rebuilding the dashboard ships stale (or missing) JavaScript against a newer API.

This affects **every user** who installs such a release and opens the dashboard,
not just developers with a local build. It's also silent: the build succeeds and
Python tests pass because the API itself is correct.

The client-side code is already correct (#1415); the gap is purely in packaging.

### Fix

Add a hatchling wheel build hook (`hatch_build.py`) that rebuilds the dashboard
SPA before packaging, so a wheel can never ship a stale bundle regardless of who
cuts the release.

- Runs `npm install && npm run build` in `dashboard/` during the wheel build.
- Skips gracefully when dashboard sources are absent (e.g. building a wheel from
  the sdist, which excludes `dashboard/`) and via `PIXELTABLE_SKIP_DASHBOARD_BUILD=1`.
- Fails loudly if dashboard sources are present but `npm` (Node.js >= 20) is missing,
  rather than silently shipping a stale bundle.

### Verification

- `uv build --wheel` runs the hook and the resulting wheel contains a freshly
  built bundle (confirmed both `dirs?tree=true` and the `pxt_version` mapping are
  present in the packaged JS).
- sdist build still works; top-level `dashboard/` is excluded, so the hook
  early-returns for sdist-based wheel builds.
- `ruff check` / `ruff format --check` pass.