### PR TITLE
PXT-1224: add_embedding_index() uses index definition

### DIFF
--- a/pixeltable/catalog/local_table.py
+++ b/pixeltable/catalog/local_table.py
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
     import pixeltable.plan
     from pixeltable.globals import TableDataSource
 
+    from .table_version import TableVersion
+
 
 _logger = logging.getLogger(__name__)
 
@@ -786,31 +788,13 @@ class LocalTable(Table):
             self.__check_mutable('add an index to')
             col = self._resolve_column_parameter(column)
 
-            if idx_name is not None and idx_name in self._tbl_version.get().idxs_by_name:
-                if_exists_ = IfExistsParam.validated(if_exists, 'if_exists')
-                # An index with the same name already exists.
-                # Handle it according to if_exists.
-                if if_exists_ == IfExistsParam.ERROR:
-                    raise excs.AlreadyExistsError(
-                        excs.ErrorCode.INDEX_ALREADY_EXISTS, f'Duplicate index name: {idx_name}'
-                    )
-                if not isinstance(self._tbl_version.get().idxs_by_name[idx_name].idx, index.EmbeddingIndex):
-                    raise excs.RequestError(
-                        excs.ErrorCode.UNSUPPORTED_OPERATION,
-                        f'Index {idx_name!r} is not an embedding index. Cannot {if_exists_.name.lower()} it.',
-                    )
-                if if_exists_ == IfExistsParam.IGNORE:
-                    return
-                assert if_exists_ in (IfExistsParam.REPLACE, IfExistsParam.REPLACE_FORCE)
-                self.drop_index(idx_name=idx_name)
-                assert idx_name not in self._tbl_version.get().idxs_by_name
             from pixeltable.index import EmbeddingIndex
 
             # idx_name must be a valid pixeltable column name
             if idx_name is not None:
                 Column.validate_name(idx_name)
 
-            # validate EmbeddingIndex args
+            # validate EmbeddingIndex args; the resulting index is also used for duplicate detection
             idx = EmbeddingIndex(
                 metric=metric,
                 precision=precision,
@@ -820,9 +804,57 @@ class LocalTable(Table):
                 column=col,  # Pass column for shape validation
             )
             _ = idx.create_value_expr(col)  # validation only; result discarded
+
+            if idx_name is not None:
+                # Named index: duplicate detection is by name.
+                if idx_name in self._tbl_version.get().idxs_by_name:
+                    if_exists_ = IfExistsParam.validated(if_exists, 'if_exists')
+                    # An index with the same name already exists. Handle it according to if_exists.
+                    if if_exists_ == IfExistsParam.ERROR:
+                        raise excs.AlreadyExistsError(
+                            excs.ErrorCode.INDEX_ALREADY_EXISTS, f'Duplicate index name: {idx_name}'
+                        )
+                    if not isinstance(self._tbl_version.get().idxs_by_name[idx_name].idx, index.EmbeddingIndex):
+                        raise excs.RequestError(
+                            excs.ErrorCode.UNSUPPORTED_OPERATION,
+                            f'Index {idx_name!r} is not an embedding index. Cannot {if_exists_.name.lower()} it.',
+                        )
+                    if if_exists_ == IfExistsParam.IGNORE:
+                        return
+                    assert if_exists_ in (IfExistsParam.REPLACE, IfExistsParam.REPLACE_FORCE)
+                    self.drop_index(idx_name=idx_name)
+                    assert idx_name not in self._tbl_version.get().idxs_by_name
+            else:
+                # Unnamed index: duplicate detection is by index definition on this column.
+                matches = self._find_matching_embedding_idxs(col, idx)
+                if len(matches) > 0:
+                    if_exists_ = IfExistsParam.validated(if_exists, 'if_exists')
+                    if if_exists_ == IfExistsParam.ERROR:
+                        raise excs.AlreadyExistsError(
+                            excs.ErrorCode.INDEX_ALREADY_EXISTS,
+                            f'An identical embedding index already exists on column {col.name!r} '
+                            f'(index {matches[0].name!r}). Pass a distinct idx_name, '
+                            f"or if_exists='ignore' / 'replace'.",
+                        )
+                    if if_exists_ == IfExistsParam.IGNORE:
+                        return
+                    assert if_exists_ in (IfExistsParam.REPLACE, IfExistsParam.REPLACE_FORCE)
+                    for info in matches:
+                        self.drop_index(idx_name=info.name)
+
             _ = self._tbl_version.get().add_index(col, idx_name=idx_name, idx=idx)
             # TODO: how to deal with exceptions here? drop the index and raise?
             FileCache.get().emit_eviction_warnings()
+
+    def _find_matching_embedding_idxs(self, col: Column, idx: index.EmbeddingIndex) -> list[TableVersion.IndexInfo]:
+        """Return existing embedding indices on col that are defined identically to idx."""
+        # the serialized dict contains everything we care about
+        target = idx.as_dict()
+        return [
+            info
+            for info in self._tbl_version.get().idxs_by_col.get(col.qid, [])
+            if isinstance(info.idx, index.EmbeddingIndex) and info.idx.as_dict() == target
+        ]
 
     def drop_embedding_index(
         self,

--- a/pixeltable/catalog/local_table.py
+++ b/pixeltable/catalog/local_table.py
@@ -788,25 +788,11 @@ class LocalTable(Table):
             self.__check_mutable('add an index to')
             col = self._resolve_column_parameter(column)
 
-            from pixeltable.index import EmbeddingIndex
-
             # idx_name must be a valid pixeltable column name
             if idx_name is not None:
                 Column.validate_name(idx_name)
-
-            # validate EmbeddingIndex args; the resulting index is also used for duplicate detection
-            idx = EmbeddingIndex(
-                metric=metric,
-                precision=precision,
-                embed=embedding,
-                string_embed=string_embed,
-                image_embed=image_embed,
-                column=col,  # Pass column for shape validation
-            )
-            _ = idx.create_value_expr(col)  # validation only; result discarded
-
-            if idx_name is not None:
-                # Named index: duplicate detection is by name.
+                # Named index: duplicate detection is by name. Handle a name collision before constructing the new
+                # index, so that if_exists='ignore' remains a true no-op and never surfaces validation errors.
                 if idx_name in self._tbl_version.get().idxs_by_name:
                     if_exists_ = IfExistsParam.validated(if_exists, 'if_exists')
                     # An index with the same name already exists. Handle it according to if_exists.
@@ -824,7 +810,21 @@ class LocalTable(Table):
                     assert if_exists_ in (IfExistsParam.REPLACE, IfExistsParam.REPLACE_FORCE)
                     self.drop_index(idx_name=idx_name)
                     assert idx_name not in self._tbl_version.get().idxs_by_name
-            else:
+
+            from pixeltable.index import EmbeddingIndex
+
+            # validate EmbeddingIndex args; the resulting index is also used for duplicate detection
+            idx = EmbeddingIndex(
+                metric=metric,
+                precision=precision,
+                embed=embedding,
+                string_embed=string_embed,
+                image_embed=image_embed,
+                column=col,  # Pass column for shape validation
+            )
+            _ = idx.create_value_expr(col)  # validation only; result discarded
+
+            if idx_name is None:
                 # Unnamed index: duplicate detection is by index definition on this column.
                 matches = self._find_matching_embedding_idxs(col, idx)
                 if len(matches) > 0:

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -444,6 +444,9 @@ class Table(SchemaObject):
                 `Array` column.
             idx_name: An optional name for the index. If not specified, a name such as `'idx0'` will be generated
                 automatically. If specified, the name must be unique for this table and a valid pixeltable column name.
+                When `idx_name` is omitted, duplicates are detected by the index definition (the embedding
+                function(s), `metric`, and `precision`) on the column: re-adding an index with an identical
+                definition is governed by `if_exists`.
             embedding: The UDF to use for the embedding. Must be a UDF that accepts a single argument of type `String`
                 or `Image` (as appropriate for the column being indexed) and returns a fixed-size 1-dimensional
                 array of floats.
@@ -456,14 +459,16 @@ class Table(SchemaObject):
             metric: Distance metric to use for the index; one of `'cosine'`, `'ip'`, or `'l2'`.
                 The default is `'cosine'`.
             precision: level of precision for the embeddings; one of `'fp16'` or `'fp32'`.
-            if_exists: Directive for handling an existing index with the same name. Must be one of the following:
+            if_exists: Directive for handling an existing index. The existing index is the one with the same name
+                (if `idx_name` is given), or one with an identical definition on the same column (if `idx_name` is
+                omitted). Must be one of the following:
 
-                - `'error'`: raise an error if an index with the same name already exists.
-                - `'ignore'`: do nothing if an index with the same name already exists.
+                - `'error'`: raise an error if such an index already exists.
+                - `'ignore'`: do nothing if such an index already exists.
                 - `'replace'` or `'replace_force'`: replace the existing index with the new one.
 
         Raises:
-            Error: If an index with the specified name already exists for the table and `if_exists='error'`, or if
+            Error: If a matching index already exists for the table and `if_exists='error'`, or if
                 the specified column does not exist.
 
         Examples:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -405,7 +405,7 @@ class TestIndex:
         assert set(emb_idxs()) == {'clip_idx'}
 
         # if_exists is now validated on the unnamed path too.
-        with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT):
+        with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT, match=r'if_exists must be one of'):
             t.add_embedding_index('img', embedding=local_embed, if_exists='invalid')  # type: ignore[arg-type]
         assert set(emb_idxs()) == {'clip_idx'}
 
@@ -440,6 +440,11 @@ class TestIndex:
         t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed, if_exists='ignore')
         assert 'clip_idx' in emb_idxs() and len(emb_idxs()) == 3
         assert emb_idxs()['clip_idx']['parameters']['metric'] == 'cosine'
+
+        # if_exists='ignore' on an existing name is a no-op even when the new embedding would fail validation:
+        # the name collision is resolved before the new index is constructed.
+        t.add_embedding_index('img', idx_name='clip_idx', embedding=self.bad_embed, if_exists='ignore')
+        assert 'clip_idx' in emb_idxs() and len(emb_idxs()) == 3
 
         # cannot use if_exists to ignore or replace an existing index
         # that is not an embedding (like, default btree indexes).

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -386,22 +386,34 @@ class TestIndex:
     ) -> None:
         t = small_img_tbl
         sample_img = t.select(t.img).head(1)[0, 'img']
-        initial_indexes = len(t._list_index_info_for_test())
+
+        def emb_idxs() -> dict[str, Any]:
+            return {name: idx for name, idx in t.get_metadata()['indices'].items() if idx['index_type'] == 'embedding'}
 
         t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed)
-        indexes = t._list_index_info_for_test()
-        assert len(indexes) == initial_indexes + 1
-        assert indexes[initial_indexes]['_name'] == 'clip_idx'
-        clip_idx_id_before = indexes[initial_indexes]['_id']
+        assert set(emb_idxs()) == {'clip_idx'}
 
-        # when index name is not provided, the index is created with
-        # a newly generated name. And if_exists parameter does not apply
-        # and will be ignored.
-        t.add_embedding_index('img', embedding=local_embed, if_exists='error')
-        assert len(t._list_index_info_for_test()) == initial_indexes + 2
+        # when index name is not provided, duplicates are detected by the index definition (embeddings + metric +
+        # precision) on the column. local_embed here has the same definition as the named clip_idx above, so it
+        # is a duplicate
+        with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='identical embedding index'):
+            t.add_embedding_index('img', embedding=local_embed, if_exists='error')
+        assert set(emb_idxs()) == {'clip_idx'}
 
-        t.add_embedding_index('img', embedding=local_embed, if_exists='invalid')  # type: ignore[arg-type]
-        assert len(t._list_index_info_for_test()) == initial_indexes + 3
+        # if_exists='ignore' makes the duplicate a no-op.
+        t.add_embedding_index('img', embedding=local_embed, if_exists='ignore')
+        assert set(emb_idxs()) == {'clip_idx'}
+
+        # if_exists is now validated on the unnamed path too.
+        with pxt_raises(pxt.ErrorCode.INVALID_ARGUMENT):
+            t.add_embedding_index('img', embedding=local_embed, if_exists='invalid')  # type: ignore[arg-type]
+        assert set(emb_idxs()) == {'clip_idx'}
+
+        # an index that differs in metric is not a duplicate
+        t.add_embedding_index('img', embedding=local_embed, metric='ip')
+        # an index using a different embedding (bound via .using()) is not a duplicate
+        t.add_embedding_index('img', embedding=local_embedding.using(dim=256))
+        assert len(emb_idxs()) == 3
 
         # when index name is provided, if_exists parameter is applied.
         # invalid value is rejected.
@@ -410,41 +422,41 @@ class TestIndex:
         assert (
             "if_exists must be one of: ['error', 'ignore', 'replace', 'replace_force']" in str(exc_info.value).lower()
         )
-        assert len(t._list_index_info_for_test()) == initial_indexes + 3
+        assert len(emb_idxs()) == 3
 
-        # if_exists='error' raises an error if the index name already exists.
-        # by default, if_exists='error'.
-        with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='Duplicate index name'):
-            t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed)
-        with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='Duplicate index name'):
-            t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed, if_exists='error')
-        assert len(t._list_index_info_for_test()) == initial_indexes + 3
+        # if_exists='error' (the default) raises if the index name already exists, regardless of whether the
+        # definition matches: rejection on the named path is by name, not by definition. Vary the metric so each
+        # attempt has a definition that differs from the existing cosine clip_idx.
+        for metric in ('cosine', 'ip', 'l2'):
+            with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='Duplicate index name'):
+                t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed, metric=metric)
+            with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='Duplicate index name'):
+                t.add_embedding_index(
+                    'img', idx_name='clip_idx', embedding=local_embed, metric=metric, if_exists='error'
+                )
+        assert len(emb_idxs()) == 3
 
         # if_exists='ignore' does nothing if the index name already exists.
         t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed, if_exists='ignore')
-        indexes = t._list_index_info_for_test()
-        assert len(indexes) == initial_indexes + 3
-        assert indexes[initial_indexes]['_name'] == 'clip_idx'
-        assert clip_idx_id_before == indexes[initial_indexes]['_id']
+        assert 'clip_idx' in emb_idxs() and len(emb_idxs()) == 3
+        assert emb_idxs()['clip_idx']['parameters']['metric'] == 'cosine'
 
         # cannot use if_exists to ignore or replace an existing index
         # that is not an embedding (like, default btree indexes).
-        assert indexes[0]['_name'] == 'idx0'
+        btree_name = next(
+            name
+            for name, idx in t.get_metadata()['indices'].items()
+            if idx['index_type'] == 'btree' and idx['columns'] == ['img']
+        )
         for ie in ('ignore', 'replace', 'replace_force'):
             with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match='not an embedding index'):
-                t.add_embedding_index('img', idx_name='idx0', embedding=local_embed, if_exists=ie)
-        indexes = t._list_index_info_for_test()
-        assert len(indexes) == initial_indexes + 3
-        assert indexes[0]['_name'] == 'idx0'
-        assert indexes[initial_indexes]['_name'] == 'clip_idx'
+                t.add_embedding_index('img', idx_name=btree_name, embedding=local_embed, if_exists=ie)
+        assert 'clip_idx' in emb_idxs() and len(emb_idxs()) == 3
 
-        # if_exists='replace' replaces the existing index with the new one.
-        t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed, if_exists='replace')
-        indexes = t._list_index_info_for_test()
-        assert len(indexes) == initial_indexes + 3
-        assert indexes[initial_indexes]['_name'] != 'clip_idx'
-        assert indexes[initial_indexes + 2]['_name'] == 'clip_idx'
-        assert clip_idx_id_before != indexes[initial_indexes + 2]['_id']
+        # if_exists='replace' replaces the existing index with the new one (here, with a different metric).
+        t.add_embedding_index('img', idx_name='clip_idx', embedding=local_embed, metric='l2', if_exists='replace')
+        assert 'clip_idx' in emb_idxs() and len(emb_idxs()) == 3
+        assert emb_idxs()['clip_idx']['parameters']['metric'] == 'l2'
 
         # sanity check: use the replaced index to run a query.
         # use the index hint in similarity function to ensure clip_idx is used.
@@ -454,6 +466,43 @@ class TestIndex:
 
         # sanity check persistence
         reload_tester.run_reload_test()
+
+    def test_unnamed_duplicate_detection(self, small_img_tbl: pxt.Table, local_embed: pxt.Function) -> None:
+        t = small_img_tbl
+
+        def emb_indexes() -> dict[str, Any]:
+            return {name: idx for name, idx in t.get_metadata()['indices'].items() if idx['index_type'] == 'embedding'}
+
+        t.add_embedding_index('img', embedding=local_embed)
+        assert len(emb_indexes()) == 1
+        orig_name = next(iter(emb_indexes()))
+
+        # same definition with no idx_name -> duplicate, governed by if_exists
+        with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='identical embedding index'):
+            t.add_embedding_index('img', embedding=local_embed)
+        t.add_embedding_index('img', embedding=local_embed, if_exists='ignore')
+        assert set(emb_indexes()) == {orig_name}
+
+        # replace drops the single matching index and recreates it under a fresh name
+        t.add_embedding_index('img', embedding=local_embed, if_exists='replace')
+        assert len(emb_indexes()) == 1 and orig_name not in emb_indexes()
+
+        # a different embedding bound via .using() is not a duplicate. Function == compares only self_path, so this
+        # guards against comparing function identity instead of the serialized definition.
+        t.add_embedding_index('img', embedding=local_embedding.using(dim=256))
+        # a different metric is not a duplicate
+        t.add_embedding_index('img', embedding=local_embed, metric='ip')
+        assert len(emb_indexes()) == 3
+
+        # duplicate detection is per-column: the same embedding on a different column is allowed
+        t.add_embedding_index('category', string_embed=local_embed)
+        assert len(emb_indexes()) == 4
+
+        # duplicate detection still works against indexes reconstructed from stored metadata after a reload
+        reload_catalog()
+        t = pxt.get_table('small_img_tbl')
+        with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='identical embedding index'):
+            t.add_embedding_index('category', string_embed=local_embed)
 
     def test_update_img(self, img_tbl: pxt.Table, test_tbl: pxt.Table, reload_tester: ReloadTester) -> None:
         img_t = img_tbl


### PR DESCRIPTION
For unnamed indices, uses the actual definition, not the auto-generated name, to detect duplicates.