### PR TITLE
Fix random_json in random_ops.py

### DIFF
--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -309,7 +309,7 @@ class RandomTableOps:
         if r >= freq:
             return None
 
-        match random.randint(0, 4):
+        match random.randint(0, 3):
             case 0:
                 return {'this': 'is', 'a': 'simple', 'json': 'dict'}
             case 1:


### PR DESCRIPTION
`random.randint(0, 4)` can return 4 which is not handled explicitly