### PR TITLE
[PXT-1230] Fix insert cold start caused by huggingface import

### DIFF
--- a/pixeltable/io/table_data_conduit.py
+++ b/pixeltable/io/table_data_conduit.py
@@ -421,7 +421,7 @@ class HFTableDataConduit(TableDataConduit):
         t = cls(**kwargs)
         import datasets
 
-        assert isinstance(tds.source, cls._get_dataset_classes())
+        assert cls._is_dataset_class(tds.source)
         if 'column_name_for_split' in t.extra_fields:
             t.column_name_for_split = t.extra_fields['column_name_for_split']
 
@@ -445,19 +445,20 @@ class HFTableDataConduit(TableDataConduit):
         return t
 
     @classmethod
-    def _get_dataset_classes(cls) -> tuple[type, ...]:
+    def _is_dataset_class(cls, obj: Any) -> bool:
+        if 'datasets' not in sys.modules:
+            return False
         import datasets
 
-        return (datasets.Dataset, datasets.DatasetDict, datasets.IterableDataset, datasets.IterableDatasetDict)
+        return isinstance(
+            obj, (datasets.Dataset, datasets.DatasetDict, datasets.IterableDataset, datasets.IterableDatasetDict)
+        )
 
     @classmethod
     def is_applicable(cls, tds: TableDataConduit) -> bool:
-        try:
-            return (isinstance(tds.source_format, str) and tds.source_format.lower() == 'huggingface') or (
-                'datasets' in sys.modules and isinstance(tds.source, cls._get_dataset_classes())
-            )
-        except ImportError:
-            return False
+        return (
+            isinstance(tds.source_format, str) and tds.source_format.lower() == 'huggingface'
+        ) or cls._is_dataset_class(tds.source)
 
     def infer_schema_part1(self) -> tuple[dict[str, ts.ColumnType], list[str]]:
         from pixeltable.io.hf_datasets import _get_hf_schema, huggingface_schema_to_pxt_schema

--- a/pixeltable/io/table_data_conduit.py
+++ b/pixeltable/io/table_data_conduit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import json
 import logging
+import sys
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Iterator, Literal, Sequence, cast
@@ -452,8 +453,8 @@ class HFTableDataConduit(TableDataConduit):
     @classmethod
     def is_applicable(cls, tds: TableDataConduit) -> bool:
         try:
-            return (isinstance(tds.source_format, str) and tds.source_format.lower() == 'huggingface') or isinstance(
-                tds.source, cls._get_dataset_classes()
+            return (isinstance(tds.source_format, str) and tds.source_format.lower() == 'huggingface') or (
+                'datasets' in sys.modules and isinstance(tds.source, cls._get_dataset_classes())
             )
         except ImportError:
             return False


### PR DESCRIPTION
The first insert into a table paid a ~300ms cold start even when the source was a plain list of dicts. TableDataConduit.create() runs HFTableDataConduit.is_applicable() on every insert, and that check unconditionally imports the huggingface datasets library just to build the tuple of dataset classes for an isinstance test, so the import cost lands inside the first insert.

If the application never imported datasets, the source cannot be a huggingface dataset instance, so there is nothing to check. is_applicable() now consults sys.modules and only runs the isinstance check (and the import behind it) when datasets is already loaded in the process. Actual huggingface sources are unaffected, since constructing a Dataset requires the module to be loaded.

Measured with the OTEL spans from PXT-923: on a cold insert of a single dict row, the pixeltable.data_source.prepare span drops from ~350ms to ~2ms and the whole insert from ~356ms to ~8ms, with the datasets module no longer imported at all.