### PR TITLE
[PXT-1233] mark fal ai tests very expensive

### DIFF
--- a/scripts/prepare-nb-tests.sh
+++ b/scripts/prepare-nb-tests.sh
@@ -10,7 +10,6 @@ SKIP_NOTEBOOKS=(
     working-with-reve               # [PXT-1116] Out of credits
     working-with-runwayml           # [PXT-1120] RunwayML integration is very broken
     working-with-twelvelabs         # [PXT-1119] Exceeds rate limit
-    working-with-fal                # [PXT-1220] fal.ai integration failing on CI
 
     # [PXT-1220] Temporarily disabled: these use `.apply()` or locally-defined UDFs in computed columns, which
     # are now prohibited. Re-enable once they are reworked to use module-level `@pxt.udf`.
@@ -43,6 +42,7 @@ VERY_EXPENSIVE_NOTEBOOKS=(
     img-detection-vs-segmentation   # Resource intensive
     video-generate-ai               # High dollar cost
     working-with-gemini             # High dollar cost
+    working-with-fal                # [PXT-1220] fal.ai integration failing on CI
     working-with-together           # Poor reliability
 )
 

--- a/scripts/prepare-nb-tests.sh
+++ b/scripts/prepare-nb-tests.sh
@@ -42,7 +42,7 @@ VERY_EXPENSIVE_NOTEBOOKS=(
     img-detection-vs-segmentation   # Resource intensive
     video-generate-ai               # High dollar cost
     working-with-gemini             # High dollar cost
-    working-with-fal                # [PXT-1220] fal.ai integration failing on CI
+    working-with-fal                # [PXT-1233] fal.ai integration failing on CI
     working-with-together           # Poor reliability
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ from .utils import (
 _logger = logging.getLogger('pixeltable_test')
 
 
-DO_RERUN: bool
+DO_RERUN: bool = True
 
 
 def pytest_addoption(parser: argparsing.Parser) -> None:

--- a/tests/functions/test_fal.py
+++ b/tests/functions/test_fal.py
@@ -8,7 +8,7 @@ from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, v
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
-@pytest.mark.expensive
+@pytest.mark.very_expensive
 @pytest.mark.remote_api
 @rerun(reruns=3, reruns_delay=8)
 class TestFal:

--- a/tests/functions/test_image.py
+++ b/tests/functions/test_image.py
@@ -7,7 +7,7 @@ import pixeltable as pxt
 import pixeltable.type_system as ts
 from pixeltable.functions.image import alpha_composite, blend, composite, tile_iterator
 
-from ..utils import SAMPLE_IMAGE_URL, pxt_raises
+from ..utils import SAMPLE_IMAGE_URL, pxt_raises, rerun
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -79,6 +79,7 @@ class TestImage:
                 size=(200, 300), mode='RGB', nullable=nullable
             )
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_tile_iterator(self, uses_db: None) -> None:
         t = pxt.create_table('test_tbl', {'image': pxt.Image})
         t.insert(image=SAMPLE_IMAGE_URL)
@@ -98,6 +99,7 @@ class TestImage:
                 tile = image.crop(box)
                 assert list(result['tile'].getdata()) == list(tile.getdata())
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_tile_iterator_errors(self, uses_db: None) -> None:
         t = pxt.create_table('test_tbl', {'image': pxt.Image})
         t.insert(image=SAMPLE_IMAGE_URL)

--- a/tests/functions/test_json.py
+++ b/tests/functions/test_json.py
@@ -6,7 +6,7 @@ import pytest
 import pixeltable as pxt
 import pixeltable.functions as pxtf
 
-from ..utils import pxt_raises, skip_test_if_no_config, skip_test_if_not_installed
+from ..utils import pxt_raises, rerun, skip_test_if_no_config, skip_test_if_not_installed
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -88,6 +88,7 @@ class TestJson:
         assert res['my_str'] == [f'string_{j}' if j < i else None for i in range(50) for j in range(i + 1)]
 
     @pytest.mark.very_expensive  # Downloads a Hugging Face model
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_list_iterator_appl(self, uses_db: None) -> None:
         """
         Fully worked example of flattening object detection output.

--- a/tests/functions/test_twelvelabs.py
+++ b/tests/functions/test_twelvelabs.py
@@ -92,6 +92,7 @@ class TestTwelveLabs:
         res = v.select(embedding=v.video_segment.embedding()).collect()
         assert res['embedding'][0].shape == (512,)
 
+    @pytest.mark.skip(reason='feature broken: PXT-1234')
     def test_embed_large_media(self, uses_db: None) -> None:
         skip_test_if_not_installed('twelvelabs')
         skip_test_if_no_client('twelvelabs')

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -6,7 +6,7 @@ import pytest
 import pixeltable as pxt
 import pixeltable.type_system as ts
 
-from ..utils import ensure_s3_pytest_resources_access, pxt_raises
+from ..utils import ensure_s3_pytest_resources_access, pxt_raises, rerun
 
 pytestmark = pytest.mark.local('TODO: convert; import/export (import)')
 
@@ -85,6 +85,7 @@ class TestImport:
         t2.insert(data)
         assert t2.count() == 8
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_import_json(self, uses_db: None) -> None:
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'
         jeopardy = 'https://raw.githubusercontent.com/pixeltable/pixeltable/main/tests/data/json/jeopardy.json'
@@ -105,6 +106,7 @@ class TestImport:
             's3://pxt-test/pytest-resources/example.json',
         ],
     )
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_import_json_from_remote(self, uses_db: None, source: str) -> None:
         if source.startswith('s3://'):
             ensure_s3_pytest_resources_access()
@@ -112,6 +114,7 @@ class TestImport:
         assert tab.count() == 4
         assert tab._get_schema() == EXPECTED_SCHEMA
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_insert_json(self, uses_db: None) -> None:
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'
         jeopardy = 'https://raw.githubusercontent.com/pixeltable/pixeltable/main/tests/data/json/jeopardy.json'

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -7,7 +7,7 @@ import pytest
 import pixeltable as pxt
 from pixeltable.config import Config
 
-from ..utils import create_all_datatypes_tbl, get_image_files, skip_test_if_not_installed, validate_update_status
+from ..utils import create_all_datatypes_tbl, get_image_files, rerun, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('TODO: convert; import/export (json)')
 
@@ -155,6 +155,7 @@ class TestJson:
 
         assert original == reimported
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_export_remote_urls(self, uses_db: None, tmp_path: pathlib.Path) -> None:
         """Verify that remote URLs (S3, HTTPS) are exported as-is."""
         skip_test_if_not_installed('boto3')

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -11,7 +11,7 @@ import pixeltable as pxt
 import pixeltable.type_system as ts
 from pixeltable.env import Env
 
-from ..utils import ensure_s3_pytest_resources_access, pxt_raises, skip_test_if_not_installed
+from ..utils import ensure_s3_pytest_resources_access, pxt_raises, rerun, skip_test_if_not_installed
 
 pytestmark = pytest.mark.local('TODO: convert; import/export (pandas)')
 
@@ -175,6 +175,7 @@ class TestPandas:
             's3://pxt-test/pytest-resources/onlinefoods.csv',
         ],
     )
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_import_csv_from_remote(self, uses_db: None, source: str) -> None:
         if source.startswith('s3://'):
             ensure_s3_pytest_resources_access()
@@ -221,6 +222,7 @@ class TestPandas:
             's3://pxt-test/pytest-resources/Financial Sample.xlsx',
         ],
     )
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_import_excel_from_remote(self, uses_db: None, source: str) -> None:
         skip_test_if_not_installed('openpyxl')
         if source.startswith('s3://'):

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -16,6 +16,7 @@ from ..utils import (
     get_image_files,
     make_test_arrow_table,
     pxt_raises,
+    rerun,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -105,6 +106,7 @@ class TestParquet:
             's3://pxt-test/pytest-resources/alltypes_plain.parquet',
         ],
     )
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_import_parquet_from_remote(self, uses_db: None, source: str) -> None:
         skip_test_if_not_installed('pyarrow')
         if source.startswith('s3://'):

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -32,6 +32,7 @@ from .utils import (
     get_image_files,
     pxt_raises,
     reload_catalog,
+    rerun,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -1183,6 +1184,7 @@ class TestExprs:
         result = t.select(t.img, t.img.height, t.img.rotate(90)).show(n=100)
         _ = result._repr_html_()
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_ext_imgs(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
         t = pxt.create_table(p('img_test'), {'img': pxt.Image})

--- a/tests/test_file_cache.py
+++ b/tests/test_file_cache.py
@@ -18,7 +18,7 @@ class TestFileCache:
     # TODO: Understand why this test is flaky on Windows. (It appears to be a timing issue
     #     related to the Windows filesystem.)
     @pytest.mark.skipif(platform.system() == 'Windows', reason='Test is flaky on Windows')
-    @rerun(reruns=3)  # Occasional download timeouts
+    @rerun(reruns=3, reruns_delay=15)  # Occasional download timeouts
     def test_eviction(self, uses_db: None) -> None:
         # Set a very small cache size of 200 kiB for this test (the imagenette images are ~5-10 kiB each)
         fc = FileCache.get()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -24,6 +24,7 @@ from .utils import (
     local_embedding,
     pxt_raises,
     reload_catalog,
+    rerun,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -79,6 +80,7 @@ class TestIndex:
         reload_tester.run_reload_test(clear=True)
 
     @pytest.mark.parametrize('use_index_name,use_separate_embeddings', [(False, False), (True, False), (False, True)])
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_similarity(
         self,
         use_index_name: bool,

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -5,7 +5,7 @@ import pytest
 
 import pixeltable as pxt
 
-from .utils import SAMPLE_IMAGE_URL, ReloadTester, create_test_tbl, pxt_raises
+from .utils import SAMPLE_IMAGE_URL, ReloadTester, create_test_tbl, pxt_raises, rerun
 
 
 def _local_path(name: str) -> str:
@@ -343,6 +343,7 @@ class TestSample:
         n = len(t.select().sample(fraction=0.01, seed=0).collect())
         assert v.count() == n
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_sample_iterator(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
         print('\n\nCREATE TABLE WITH ONE IMAGE COLUMN\n')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -44,6 +44,7 @@ from .utils import (
     pxt_raises,
     read_data_file,
     reload_catalog,
+    rerun,
     skip_test_if_not_installed,
     stock_price,
     validate_repr,
@@ -2054,6 +2055,7 @@ class TestTable:
         rows = [{'media': f, 'is_bad_media': not is_valid} for f, is_valid in zip(doc_paths, is_valid)]
         self.check_bad_media(p, rows, pxt.Document, validate_local_path=catalog_mode == 'local')
 
+    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
     def test_validate_external_url(self, make_catalog_path: Callable[[str], str], catalog_mode: CatalogMode) -> None:
         p = make_catalog_path
         skip_test_if_not_installed('boto3')


### PR DESCRIPTION
Also add `@rerun` to tests that depend on githubusercontent.com as we've been getting 429s from it recently.

Also fix the `@rerun` annotation compatibility with the proxy mode (daemon does not get a `pytest_configure()` call and `DO_RERUN` in `conftest.py` ends up uninitialized)

Also disable `TestTwelveLabs.test_embed_large_media` as it appears to be broken or highly flaky.