### PR TITLE
Add Databricks Model Serving UDFs

### DIFF
--- a/docs/release/docs.json
+++ b/docs/release/docs.json
@@ -64,6 +64,7 @@
                   "howto/providers/working-with-anthropic",
                   "howto/providers/working-with-bedrock",
                   "howto/providers/working-with-bfl",
+                  "howto/providers/working-with-databricks",
                   "howto/providers/working-with-deepseek",
                   "howto/providers/working-with-fal",
                   "howto/providers/working-with-fabric",

--- a/docs/release/howto/providers/working-with-databricks.ipynb
+++ b/docs/release/howto/providers/working-with-databricks.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: \"Working with Databricks\"\n",
+    "icon: \"notebook\"\n",
+    "description: \"[Open in Kaggle](https://kaggle.com/kernels/welcome?src=https://github.com/pixeltable/pixeltable/blob/release/docs/release/howto/providers/working-with-databricks.ipynb) | [Open in Colab](https://colab.research.google.com/github/pixeltable/pixeltable/blob/release/docs/release/howto/providers/working-with-databricks.ipynb) | [View on GitHub](https://github.com/pixeltable/pixeltable/blob/release/docs/release/howto/providers/working-with-databricks.ipynb)\"\n",
+    "---"
+   ],
+   "id": "374fe3e7"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with Databricks Model Serving in Pixeltable\n",
+    "\n",
+    "Use `pxt.functions.databricks` to call **Foundation Models**, **Model Serving endpoints**, and **Mosaic AI agents** from computed columns.\n",
+    "\n",
+    "### Prerequisites\n",
+    "\n",
+    "- Databricks workspace with Model Serving or foundation model access\n",
+    "- Personal access token with serving permissions\n",
+    "\n",
+    "### Important notes\n",
+    "\n",
+    "- Databricks Model Serving usage may incur costs based on your workspace plan.\n",
+    "- Store PATs securely; prefer short-lived tokens or service principals in production.\n",
+    "- Be mindful of sensitive data sent to external model endpoints.\n",
+    "\n",
+    "For SQL Warehouse import/export, Delta/Iceberg I/O, UC Volume storage, and hybrid deployment, see the full Databricks deployment guide (forthcoming)."
+   ],
+   "id": "03a90bd5"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First install required libraries and configure your Databricks credentials."
+   ],
+   "id": "install-md"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%pip install -qU pixeltable openai"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "f2954c95"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "if 'DATABRICKS_HOST' not in os.environ:\n",
+    "    os.environ['DATABRICKS_HOST'] = getpass.getpass(\n",
+    "        'Enter your Databricks workspace URL (e.g. https://<workspace>.cloud.databricks.com):'\n",
+    "    )\n",
+    "\n",
+    "if 'DATABRICKS_TOKEN' not in os.environ:\n",
+    "    os.environ['DATABRICKS_TOKEN'] = getpass.getpass(\n",
+    "        'Enter your Databricks personal access token:'\n",
+    "    )"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "credentials"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's create a Pixeltable directory to hold the tables for our demo."
+   ],
+   "id": "create-dir-md"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import pixeltable as pxt\n",
+    "from pixeltable.functions import databricks as dbx_fn\n",
+    "\n",
+    "pxt.drop_dir('dbx_demo', force=True)\n",
+    "pxt.create_dir('dbx_demo')"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "b808323c"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Chat completions\n",
+    "\n",
+    "Pass any foundation model name or deployed endpoint as `model` — including Mosaic AI agent endpoints."
+   ],
+   "id": "910a5f9c"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "t = pxt.create_table('dbx_demo.docs', {'text': pxt.String})\n",
+    "msgs = [{'role': 'user', 'content': t.text}]\n",
+    "\n",
+    "t.add_computed_column(\n",
+    "    output=dbx_fn.chat_completions(\n",
+    "        msgs,\n",
+    "        model='databricks-meta-llama-3-3-70b-instruct',\n",
+    "        model_kwargs={'max_tokens': 256, 'temperature': 0.2},\n",
+    "    )\n",
+    ")\n",
+    "t.add_computed_column(summary=t.output.choices[0].message.content)\n",
+    "\n",
+    "# Deployed Mosaic AI agent:\n",
+    "# t.add_computed_column(\n",
+    "#     answer=dbx_fn.chat_completions(msgs, model='my-rag-agent-endpoint')\n",
+    "#         .choices[0].message.content\n",
+    "# )"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "9b315ee8"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "t.insert(\n",
+    "    [\n",
+    "        {\n",
+    "            'text': 'In one sentence, what is declarative data infrastructure?'\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "t.collect()"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "insert-chat"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Embeddings and semantic search\n",
+    "\n",
+    "Add embeddings and an embedding index, then run a similarity query."
+   ],
+   "id": "8cad4d16"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "embed_fn = dbx_fn.embeddings.using(model='databricks-gte-large-en')\n",
+    "t.add_computed_column(\n",
+    "    embed=dbx_fn.embeddings(t.text, model='databricks-gte-large-en')\n",
+    ")\n",
+    "t.add_embedding_index('text', string_embed=embed_fn)\n",
+    "\n",
+    "t.insert(\n",
+    "    [\n",
+    "        {\n",
+    "            'text': 'Machine learning is a subset of artificial intelligence.'\n",
+    "        },\n",
+    "        {'text': 'Deep learning uses neural networks with many layers.'},\n",
+    "        {'text': 'Python is a popular programming language.'},\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "sim = t.text.similarity(string='What is machine learning?')\n",
+    "t.order_by(sim, asc=False).limit(2).select(\n",
+    "    t.text, similarity=sim\n",
+    ").collect()"
+   ],
+   "execution_count": null,
+   "outputs": [],
+   "id": "d90f0b75"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pxt (Python 3.10)",
+   "language": "python",
+   "name": "pxt"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/release/integrations/frameworks.mdx
+++ b/docs/release/integrations/frameworks.mdx
@@ -84,6 +84,14 @@ If you have a framework that you want us to integrate with, please reach out and
     Access a variety of AI models through AWS Bedrock's unified API
   </Card>
 
+  <Card
+    title="Databricks"
+    icon="database"
+    href="/howto/providers/working-with-databricks"
+  >
+    Call Databricks Model Serving, foundation models, and Mosaic AI agents from computed columns
+  </Card>
+
    <Card
     title="Groq"
     icon="microchip"

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -549,6 +549,13 @@ KNOWN_CONFIG_OPTIONS: dict[str, dict[str, Any]] = {
         'service_tier': 'Processing tier for requests (priority, default, flex, or reserved)',
     },
     'bfl': {'api_key': 'Black Forest Labs (BFL) API key', 'rate_limit': 'Rate limit for BFL API requests'},
+    'databricks': {
+        'host': 'Databricks workspace URL (e.g. https://<workspace>.cloud.databricks.com)',
+        'token': 'Databricks personal access token or OAuth token',
+        'default_chat_model': 'Default foundation model or serving endpoint for chat_completions',
+        'default_embedding_model': 'Default embedding model or endpoint for embeddings',
+        'rate_limit': 'Rate limit for Databricks API requests (requests per minute)',
+    },
     'deepseek': {'api_key': 'Deepseek API key', 'rate_limit': 'Rate limit for Deepseek API requests'},
     'fal': {'api_key': 'fal.ai API key', 'rate_limit': 'Rate limit for fal.ai API requests'},
     'fireworks': {'api_key': 'Fireworks API key', 'rate_limit': 'Rate limit for Fireworks API requests'},

--- a/pixeltable/functions/__init__.py
+++ b/pixeltable/functions/__init__.py
@@ -15,6 +15,7 @@ from . import (
     audio,
     bedrock,
     bfl,
+    databricks,
     date,
     deepseek,
     document,

--- a/pixeltable/functions/databricks.py
+++ b/pixeltable/functions/databricks.py
@@ -1,0 +1,266 @@
+"""
+Pixeltable UDFs that wrap Databricks Model Serving and Mosaic AI agents.
+
+In order to use them, you must first ``pip install openai`` and configure your Databricks
+credentials, as described in the
+[Working with Databricks](https://docs.pixeltable.com/howto/providers/working-with-databricks) tutorial.
+"""
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import PIL.Image
+
+import pixeltable as pxt
+import pixeltable.type_system as ts
+from pixeltable import exprs
+from pixeltable.env import Env, register_client
+from pixeltable.func import Batch
+from pixeltable.runtime import get_runtime
+from pixeltable.utils.code import local_public_names
+from pixeltable.utils.image import to_base64
+
+from .openai import _openai_response_to_pxt_tool_calls
+
+if TYPE_CHECKING:
+    import openai
+
+
+@register_client('databricks', credential_param='token')
+def _(host: str, token: str) -> 'openai.AsyncOpenAI':
+    """Create an OpenAI-compatible client pointed at Databricks Model Serving."""
+    Env.get().require_package('openai')
+    import openai
+
+    base_url = f'{host.rstrip("/")}/serving-endpoints'
+    return openai.AsyncOpenAI(api_key=token, base_url=base_url)
+
+
+def _databricks_client() -> 'openai.AsyncOpenAI':
+    return get_runtime().get_client('databricks')
+
+
+_embedding_dimensions: dict[str, int] = {'databricks-gte-large-en': 1024, 'databricks-bge-large-en': 1024}
+
+
+@pxt.udf(is_deterministic=False, resource_pool='request-rate:databricks')
+async def chat_completions(
+    messages: list[dict[str, Any]],
+    *,
+    model: str,
+    model_kwargs: dict[str, Any] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: dict[str, Any] | None = None,
+) -> dict:
+    """
+    Chat completions via Databricks Model Serving or Foundation Models.
+
+    Equivalent to the Databricks OpenAI-compatible ``chat/completions`` API.
+    For additional details, see:
+    <https://docs.databricks.com/en/machine-learning/foundation-models/index.html>
+
+    Request throttling:
+    Applies the rate limit set in the config (section ``databricks``, key ``rate_limit``). If no rate
+    limit is configured, uses a default RPM for the ``request-rate:databricks`` pool.
+
+    Pass a foundation model name (e.g. ``databricks-meta-llama-3-3-70b-instruct``) or any
+    deployed Model Serving endpoint name — including Mosaic AI agents (Knowledge Assistant,
+    Multi-Agent Supervisor, custom MLflow agents).
+
+    __Requirements:__
+
+    - ``pip install openai``
+
+    Args:
+        messages: OpenAI-compatible chat messages.
+        model: Foundation model or serving endpoint name.
+        model_kwargs: Additional kwargs for the chat completions API.
+        tools: Optional function tools.
+        tool_choice: Optional tool choice configuration.
+
+    Returns:
+        OpenAI-compatible chat completion response as a dict.
+
+    Examples:
+        >>> tbl.add_computed_column(
+        ...     summary=chat_completions(
+        ...         [{'role': 'user', 'content': tbl.text}],
+        ...         model='databricks-meta-llama-3-3-70b-instruct',
+        ...     )['choices'][0]['message']['content']
+        ... )
+
+        Call a deployed Mosaic AI agent endpoint by name:
+
+        >>> tbl.add_computed_column(
+        ...     answer=chat_completions(
+        ...         [{'role': 'user', 'content': tbl.question}],
+        ...         model='my-rag-agent-endpoint',
+        ...     )['choices'][0]['message']['content']
+        ... )
+    """
+    if model_kwargs is None:
+        model_kwargs = {}
+
+    Env.get().require_package('openai')
+
+    if tools is not None:
+        model_kwargs['tools'] = [{'type': 'function', 'function': tool} for tool in tools]
+
+    if tool_choice is not None:
+        if tool_choice['auto']:
+            model_kwargs['tool_choice'] = 'auto'
+        elif tool_choice['required']:
+            model_kwargs['tool_choice'] = 'required'
+        else:
+            assert tool_choice['tool'] is not None
+            model_kwargs['tool_choice'] = {'type': 'function', 'function': {'name': tool_choice['tool']}}
+
+    if tool_choice is not None and not tool_choice['parallel_tool_calls']:
+        model_kwargs['parallel_tool_calls'] = False
+
+    messages = copy.deepcopy(messages)
+    for message in messages:
+        content = message.get('content')
+        if isinstance(content, list):
+            for part in content:
+                if (
+                    isinstance(part, dict)
+                    and part.get('type') == 'image_url'
+                    and isinstance(part.get('image_url'), PIL.Image.Image)
+                ):
+                    b64_encoded_image = to_base64(part['image_url'], format='png')
+                    part['image_url'] = {'url': f'data:image/png;base64,{b64_encoded_image}'}
+
+    result = await _databricks_client().chat.completions.create(
+        messages=messages,  # type: ignore[arg-type]
+        model=model,
+        **model_kwargs,
+    )
+    return result.model_dump()
+
+
+@pxt.udf(batch_size=32, is_deterministic=False, resource_pool='request-rate:databricks')
+async def embeddings(
+    input: Batch[str], *, model: str, model_kwargs: dict[str, Any] | None = None
+) -> Batch[pxt.Array[(None,), pxt.Float]]:
+    """
+    Create embedding vectors via Databricks embedding endpoints.
+
+    Equivalent to the Databricks OpenAI-compatible ``embeddings`` API.
+    For additional details, see:
+    <https://docs.databricks.com/en/machine-learning/foundation-models/index.html>
+
+    Request throttling:
+    Applies the rate limit set in the config (section ``databricks``, key ``rate_limit``). If no rate
+    limit is configured, uses a default RPM for the ``request-rate:databricks`` pool.
+
+    __Requirements:__
+
+    - ``pip install openai``
+
+    Args:
+        input: Text strings to embed.
+        model: Embedding model or endpoint name (e.g. ``databricks-gte-large-en``).
+        model_kwargs: Additional kwargs for the embeddings API.
+
+    Returns:
+        Embedding vectors as float arrays.
+
+    Examples:
+        >>> tbl.add_computed_column(
+        ...     embed=embeddings(tbl.text, model='databricks-gte-large-en')
+        ... )
+    """
+    if model_kwargs is None:
+        model_kwargs = {}
+
+    Env.get().require_package('openai')
+    result = await _databricks_client().embeddings.create(
+        input=input, model=model, encoding_format='float', **model_kwargs
+    )
+    return [np.array(data.embedding, dtype=np.float64) for data in result.data]
+
+
+@embeddings.conditional_return_type
+def _(model: str, model_kwargs: dict[str, Any] | None = None) -> ts.ArrayType:
+    dimensions: int | None = None
+    if model_kwargs is not None:
+        dimensions = model_kwargs.get('dimensions')
+    if dimensions is None:
+        if model not in _embedding_dimensions:
+            return ts.ArrayType((None,), dtype=ts.FloatType(), nullable=False)
+        dimensions = _embedding_dimensions[model]
+    return ts.ArrayType((dimensions,), dtype=ts.FloatType(), nullable=False)
+
+
+@pxt.udf(is_deterministic=False, resource_pool='request-rate:databricks')
+async def responses(
+    input: list[dict[str, Any]],
+    *,
+    model: str,
+    model_kwargs: dict[str, Any] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+) -> dict:
+    """
+    Responses API for Databricks Supervisor API, Apps agents, and ResponsesAgent endpoints.
+
+    Equivalent to the Databricks OpenAI-compatible ``responses`` API.
+    For additional details, see:
+    <https://docs.databricks.com/en/generative-ai/agent-framework/responses-agent.html>
+
+    Request throttling:
+    Applies the rate limit set in the config (section ``databricks``, key ``rate_limit``). If no rate
+    limit is configured, uses a default RPM for the ``request-rate:databricks`` pool.
+
+    Use ``model='apps/<app-name>'`` for Databricks Apps agents, or pass hosted tools for
+    the Supervisor API (Genie spaces, Vector Search indexes, UC tables, etc.).
+
+    __Requirements:__
+
+    - ``pip install openai``
+
+    Args:
+        input: Responses API input items.
+        model: Model or endpoint name.
+        model_kwargs: Additional kwargs (e.g. ``extra_body`` for trace_destination).
+        tools: Hosted tools for Supervisor API agent loops.
+
+    Returns:
+        Responses API result as a dict.
+
+    Examples:
+        >>> tbl.add_computed_column(
+        ...     analysis=responses(
+        ...         input=[{'role': 'user', 'content': tbl.text}],
+        ...         model='databricks-claude-sonnet-4-5',
+        ...         tools=[
+        ...             {'type': 'table', 'table': {'name': 'catalog.schema.reviews'}}
+        ...         ],
+        ...     )['output_text']
+        ... )
+    """
+    if model_kwargs is None:
+        model_kwargs = {}
+    if tools is not None:
+        model_kwargs['tools'] = tools
+
+    Env.get().require_package('openai')
+    result = await _databricks_client().responses.create(
+        input=input,  # type: ignore[arg-type]
+        model=model,
+        **model_kwargs,
+    )
+    return result.model_dump()
+
+
+def invoke_tools(tools: pxt.func.Tools, response: exprs.Expr) -> exprs.InlineDict:
+    """Converts an OpenAI response dict to Pixeltable tool invocation format and calls ``tools._invoke()``."""
+    return tools._invoke(_openai_response_to_pxt_tool_calls(response))
+
+
+__all__ = local_public_names(__name__)
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/tests/functions/test_databricks.py
+++ b/tests/functions/test_databricks.py
@@ -1,0 +1,129 @@
+"""Tests for pixeltable.functions.databricks UDFs."""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+
+import pixeltable as pxt
+
+from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+
+pytestmark = pytest.mark.local('UDF/integration test')
+
+
+class TestDatabricksMocks:
+    def test_chat_completions_mock(self, uses_db: None) -> None:
+        mock_result = mock.Mock()
+        mock_result.model_dump.return_value = {
+            'choices': [{'message': {'content': 'hello', 'role': 'assistant'}}],
+            'model': 'test-model',
+        }
+
+        mock_client = mock.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_result
+
+        with (
+            mock.patch('pixeltable.functions.databricks.Env.require_package'),
+            mock.patch('pixeltable.functions.databricks._databricks_client', return_value=mock_client),
+        ):
+            from pixeltable.functions.databricks import chat_completions
+
+            t = pxt.create_table('test_dbx_chat', {'prompt': pxt.String})
+            msgs = [{'role': 'user', 'content': t.prompt}]
+            t.add_computed_column(out=chat_completions(msgs, model='test-endpoint'))
+            validate_update_status(t.insert([{'prompt': 'hi'}]), 1)
+            result = t.collect()[0]['out']
+            assert result['choices'][0]['message']['content'] == 'hello'
+
+    def test_embeddings_mock(self, uses_db: None) -> None:
+        embedding = [0.1, 0.2, 0.3]
+        mock_data = mock.Mock()
+        mock_data.embedding = embedding
+        mock_result = mock.Mock()
+        mock_result.data = [mock_data]
+
+        mock_client = mock.AsyncMock()
+        mock_client.embeddings.create.return_value = mock_result
+
+        with (
+            mock.patch('pixeltable.functions.databricks.Env.require_package'),
+            mock.patch('pixeltable.functions.databricks._databricks_client', return_value=mock_client),
+        ):
+            from pixeltable.functions.databricks import embeddings
+
+            t = pxt.create_table('test_dbx_embed', {'text': pxt.String})
+            t.add_computed_column(vec=embeddings(t.text, model='databricks-gte-large-en'))
+            validate_update_status(t.insert([{'text': 'hello world'}]), 1)
+            result = t.collect()[0]['vec']
+            assert isinstance(result, np.ndarray)
+            assert len(result) == 3
+
+
+@pytest.mark.remote_api
+@rerun(reruns=3, reruns_delay=8)
+class TestDatabricks:
+    def test_chat_completions(self, uses_db: None) -> None:
+        skip_test_if_not_installed('openai')
+        skip_test_if_no_client('databricks')
+        from pixeltable.functions.databricks import chat_completions
+
+        t = pxt.create_table('test_tbl', {'input': pxt.String})
+        msgs = [{'role': 'user', 'content': t.input}]
+        t.add_computed_column(
+            output=chat_completions(
+                msgs,
+                model='databricks-meta-llama-3-3-70b-instruct',
+                model_kwargs={'max_tokens': 256, 'temperature': 0.2},
+            )
+        )
+        validate_update_status(t.insert(input='Name three chemical elements discovered in the 21st century.'), 1)
+        results = t.collect()
+        assert len(results['output'][0]['choices'][0]['message']['content']) > 0
+
+    def test_embeddings(self, uses_db: None) -> None:
+        skip_test_if_not_installed('openai')
+        skip_test_if_no_client('databricks')
+        from pixeltable.functions.databricks import embeddings
+
+        t = pxt.create_table('test_tbl', {'input': pxt.String})
+        t.add_computed_column(embed=embeddings(input=t.input, model='databricks-gte-large-en'))
+        validate_update_status(t.insert(input='Databricks provides foundation model embeddings.'), 1)
+        assert len(t.collect()['embed'][0]) > 0
+
+    def test_embedding_index(self, uses_db: None) -> None:
+        skip_test_if_not_installed('openai')
+        skip_test_if_no_client('databricks')
+        from pixeltable.functions.databricks import embeddings
+
+        t = pxt.create_table('docs', {'text': pxt.String})
+        t.add_embedding_index('text', string_embed=embeddings.using(model='databricks-gte-large-en'))
+
+        t.insert(
+            [
+                {'text': 'Machine learning is a subset of artificial intelligence.'},
+                {'text': 'Deep learning uses neural networks with many layers.'},
+                {'text': 'Python is a popular programming language.'},
+            ]
+        )
+
+        sim = t.text.similarity(string='What is machine learning?')
+        results = t.order_by(sim, asc=False).limit(2).select(t.text, similarity=sim).collect()
+
+        assert len(results) == 2
+        assert (
+            'machine learning' in results['text'][0].lower() or 'artificial intelligence' in results['text'][0].lower()
+        )
+
+    @pytest.mark.skip(reason='Requires deployed supervisor/responses endpoint')
+    def test_responses(self, uses_db: None) -> None:
+        skip_test_if_not_installed('openai')
+        skip_test_if_no_client('databricks')
+        from pixeltable.functions.databricks import responses
+
+        t = pxt.create_table('test_tbl', {'input': pxt.String})
+        t.add_computed_column(
+            output=responses(input=[{'role': 'user', 'content': t.input}], model='databricks-claude-sonnet-4-5')
+        )
+        validate_update_status(t.insert(input='Summarize the benefits of declarative data pipelines.'), 1)
+        assert len(t.collect()['output'][0]) > 0


### PR DESCRIPTION
## Summary
- Adds `pixeltable.functions.databricks` with OpenAI-compatible `chat_completions`, `embeddings`, `responses`, and `invoke_tools` for Databricks Model Serving / foundation models / Mosaic AI agents
- Wires `[databricks]` config (`host`, `token`, optional defaults and `rate_limit`) and registers the client with `credential_param='token'`
- Adds mock + remote API tests, slim provider cookbook, docs nav entry, and Ecosystem card

## Design notes
- Uses the documented Databricks OpenAI-compatible client (`AsyncOpenAI` with `base_url=<host>/serving-endpoints`) rather than `databricks-openai`, avoiding heavy transitive deps (mlflow / databricks-connect) that break `uv lock`
- Follows Groq/OpenAI patterns for `tool_choice`, `invoke_tools`, rate-limit pool, and docstring structure
- Files API / SQL / Delta helpers intentionally out of scope (follow-up PRs)

## Test plan
- [x] `pytest tests/functions/test_databricks.py -m "not remote_api"` (mock tests pass)
- [x] `mypy` + `ruff` clean on changed Python files
- [ ] Remote tests with `DATABRICKS_HOST` + `DATABRICKS_TOKEN` against a Ready serving endpoint
- [ ] Notebook smoke: install → credentials → chat insert/collect → embeddings search


Made with [Cursor](https://cursor.com)