### PR TITLE
Mark more unreliable provider tests "very expensive"

### DIFF
--- a/scripts/prepare-nb-tests.sh
+++ b/scripts/prepare-nb-tests.sh
@@ -27,6 +27,7 @@ VERY_EXPENSIVE_NOTEBOOKS=(
     working-with-gemini             # High dollar cost
     working-with-fal                # [PXT-1233] fal.ai integration failing on CI
     working-with-together           # Poor reliability
+    working-with-replicate          # Unreliable
 )
 
 # Notebooks that are skipped unless --include-expensive is passed: all notebooks that use HF models.

--- a/tests/functions/test_anthropic.py
+++ b/tests/functions/test_anthropic.py
@@ -2,14 +2,20 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import (
+    rerun,
+    rerun_on_network_error,
+    skip_test_if_no_client,
+    skip_test_if_not_installed,
+    validate_update_status,
+)
 from .tool_utils import run_tool_invocations_test
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestAnthropic:
     def test_messages(self, uses_db: None) -> None:
         skip_test_if_not_installed('anthropic')

--- a/tests/functions/test_bedrock.py
+++ b/tests/functions/test_bedrock.py
@@ -12,7 +12,7 @@ from ..utils import (
     get_audio_files,
     get_image_files,
     get_video_files,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_no_aws_credentials,
     validate_update_status,
 )
@@ -132,7 +132,7 @@ def _converse_image_messages(t: pxt.Table) -> list:
 @pytest.mark.remote_api
 @pytest.mark.expensive
 @pytest.mark.usefixtures('bedrock_us_east_1')
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestBedrock:
     def test_invoke_model_twelvelabs_marengo_image(self, uses_db: None) -> None:
         skip_test_if_no_aws_credentials()

--- a/tests/functions/test_bfl.py
+++ b/tests/functions/test_bfl.py
@@ -3,7 +3,7 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import TESTS_DIR, rerun, skip_test_if_no_client, validate_update_status
+from ..utils import TESTS_DIR, rerun_on_network_error, skip_test_if_no_client, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -14,7 +14,7 @@ TEST_IMAGE_PATH = TESTS_DIR / 'data' / 'images' / 'sewing-threads-smaller.jpg'
 @pytest.mark.remote_api
 @pytest.mark.very_expensive
 @pytest.mark.skip(reason='[PXT-1111] Out of credits')
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestBfl:
     def test_generate(self, uses_db: None) -> None:
         """Test text-to-image generation with and without optional parameters."""

--- a/tests/functions/test_deepseek.py
+++ b/tests/functions/test_deepseek.py
@@ -2,13 +2,13 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestDeepseek:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('openai')

--- a/tests/functions/test_fabric.py
+++ b/tests/functions/test_fabric.py
@@ -9,7 +9,7 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -28,7 +28,7 @@ def _skip_if_not_fabric() -> None:
 
 @pytest.mark.skip(reason='Requires Microsoft Fabric environment with synapse-ml-fabric SDK')
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestFabric:
     """Test suite for Microsoft Fabric Azure OpenAI integration."""
 

--- a/tests/functions/test_fal.py
+++ b/tests/functions/test_fal.py
@@ -3,14 +3,14 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.very_expensive
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestFal:
     def test_text_to_image(self, uses_db: None) -> None:
         skip_test_if_not_installed('fal_client')

--- a/tests/functions/test_fireworks.py
+++ b/tests/functions/test_fireworks.py
@@ -2,13 +2,13 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestFireworks:
     def test_fireworks(self, uses_db: None) -> None:
         skip_test_if_not_installed('fireworks')

--- a/tests/functions/test_gemini.py
+++ b/tests/functions/test_gemini.py
@@ -18,7 +18,7 @@ from ..utils import (
     get_test_video_files,
     get_video_files,
     pxt_raises,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_no_client,
     skip_test_if_not_installed,
     validate_update_status,
@@ -32,7 +32,7 @@ _logger = logging.getLogger('pixeltable_test')
 
 @pytest.mark.remote_api
 @pytest.mark.very_expensive
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestGemini:
     @pytest.mark.parametrize('model', ['gemini-2.5-flash-lite', 'gemini-3.1-pro-preview'])
     def test_generate_content(self, model: str, uses_db: None) -> None:
@@ -198,7 +198,7 @@ class TestGemini:
         assert results['output2'][0].size == (1280, 896)
 
     @pytest.mark.very_expensive
-    @rerun(reruns=3, reruns_delay=30)  # longer delay between reruns
+    @rerun_on_network_error(reruns_delay=30)
     def test_generate_videos(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')
@@ -240,7 +240,7 @@ class TestGemini:
             assert audio_stream['duration_seconds'] == duration, metadata
 
     @pytest.mark.very_expensive
-    @rerun(reruns=3, reruns_delay=30)
+    @rerun_on_network_error(reruns_delay=30)
     def test_generate_videos_reference_images(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')

--- a/tests/functions/test_gemini.py
+++ b/tests/functions/test_gemini.py
@@ -31,6 +31,7 @@ _logger = logging.getLogger('pixeltable_test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun(reruns=3, reruns_delay=8)
 class TestGemini:
     @pytest.mark.parametrize('model', ['gemini-2.5-flash-lite', 'gemini-3.1-pro-preview'])
@@ -98,7 +99,6 @@ class TestGemini:
         assert 'French horn' in results['output'][0]['candidates'][0]['content']['parts'][0]['text']
         assert 'truck' in results['output'][1]['candidates'][0]['content']['parts'][0]['text']
 
-    @pytest.mark.expensive
     def test_generate_content_video(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')
@@ -134,7 +134,6 @@ class TestGemini:
             print(f'Video analysis result id={i}: {text}')
             assert text and not any(word in text for word in ['failed', 'unable', 'invalid'])
 
-    @pytest.mark.expensive
     def test_generate_content_nano_banana(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')
@@ -179,7 +178,6 @@ class TestGemini:
 
         run_tool_invocations_test(make_table)
 
-    @pytest.mark.expensive
     def test_generate_images(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')
@@ -274,7 +272,6 @@ class TestGemini:
         file_path = results['output'][0]
         assert Path(file_path).exists()
 
-    @pytest.mark.expensive
     def test_generate_speech(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')
@@ -288,7 +285,6 @@ class TestGemini:
         assert Path(audio_path).exists()
         assert audio_path.endswith('.wav')
 
-    @pytest.mark.expensive
     def test_generate_speech_multispeaker(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')
@@ -306,7 +302,6 @@ class TestGemini:
         assert Path(audio_path).exists()
         assert audio_path.endswith('.wav')
 
-    @pytest.mark.expensive
     def test_transcribe(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('gemini')
@@ -373,7 +368,6 @@ class TestGemini:
         res = t.select(t.rowid, t.text, sim=sim).order_by(sim, asc=False).collect()
         assert res[0]['rowid'] == 3
 
-    @pytest.mark.expensive
     def test_generate_content_scheduler(self, uses_db: None) -> None:
         """
         Scheduler stress test: 30 rows on gemini-2.5-flash free tier (~10 RPM) triggers 429s

--- a/tests/functions/test_groq.py
+++ b/tests/functions/test_groq.py
@@ -2,14 +2,14 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 from .tool_utils import stock_price
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestGroq:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('groq')

--- a/tests/functions/test_groq.py
+++ b/tests/functions/test_groq.py
@@ -2,14 +2,14 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 from .tool_utils import stock_price
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@rerun_on_network_error()
+@rerun(reruns=4, reruns_delay=8)
 class TestGroq:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('groq')

--- a/tests/functions/test_huggingface.py
+++ b/tests/functions/test_huggingface.py
@@ -17,7 +17,7 @@ from ..utils import (
     get_video_files,
     pxt_raises,
     reload_catalog,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_no_config,
     skip_test_if_not_installed,
     validate_update_status,
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.very_expensive  # Downloads Hugging Face models
-@rerun(reruns=3, reruns_delay=15)  # Guard against connection errors downloading models
+@rerun_on_network_error()
 @pytest.mark.skipif(sysconfig.get_platform() == 'linux-aarch64', reason='Not supported on Linux ARM')
 class TestHuggingface:
     def test_hf_function(self, uses_db: None) -> None:

--- a/tests/functions/test_image.py
+++ b/tests/functions/test_image.py
@@ -8,7 +8,7 @@ import pixeltable as pxt
 import pixeltable.type_system as ts
 from pixeltable.functions.image import alpha_composite, blend, composite, stitch_tiles, tile_iterator
 
-from ..utils import SAMPLE_IMAGE_URL, get_image_files, pxt_raises, rerun
+from ..utils import SAMPLE_IMAGE_URL, get_image_files, pxt_raises, rerun_on_network_error
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -80,7 +80,7 @@ class TestImage:
                 size=(200, 300), mode='RGB', nullable=nullable
             )
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_tile_iterator(self, uses_db: None) -> None:
         t = pxt.create_table('test_tbl', {'image': pxt.Image})
         t.insert(image=SAMPLE_IMAGE_URL)
@@ -173,7 +173,7 @@ class TestImage:
         assert len(result) == 1
         assert result[0]['stitched'] is None
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_tile_iterator_errors(self, uses_db: None) -> None:
         t = pxt.create_table('test_tbl', {'image': pxt.Image})
         t.insert(image=SAMPLE_IMAGE_URL)

--- a/tests/functions/test_jina.py
+++ b/tests/functions/test_jina.py
@@ -2,14 +2,14 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.expensive
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestJina:
     def test_embeddings(self, uses_db: None) -> None:
         """Test basic embedding generation."""

--- a/tests/functions/test_json.py
+++ b/tests/functions/test_json.py
@@ -6,7 +6,7 @@ import pytest
 import pixeltable as pxt
 import pixeltable.functions as pxtf
 
-from ..utils import pxt_raises, rerun, skip_test_if_no_config, skip_test_if_not_installed
+from ..utils import pxt_raises, rerun_on_network_error, skip_test_if_no_config, skip_test_if_not_installed
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -88,7 +88,7 @@ class TestJson:
         assert res['my_str'] == [f'string_{j}' if j < i else None for i in range(50) for j in range(i + 1)]
 
     @pytest.mark.very_expensive  # Downloads a Hugging Face model
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_list_iterator_appl(self, uses_db: None) -> None:
         """
         Fully worked example of flattening object detection output.

--- a/tests/functions/test_llama_cpp.py
+++ b/tests/functions/test_llama_cpp.py
@@ -18,7 +18,7 @@ def cleanup_llama_cpp() -> Iterator[None]:
     llama_cpp.cleanup()
 
 
-@pytest.mark.expensive  # downloads from HF
+@pytest.mark.very_expensive
 @rerun(reruns=3, reruns_delay=15)  # Since it involves a HF model download
 class TestLlamaCpp:
     def test_create_chat_completions(self, uses_db: None) -> None:

--- a/tests/functions/test_llama_cpp.py
+++ b/tests/functions/test_llama_cpp.py
@@ -4,7 +4,7 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_config, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_config, skip_test_if_not_installed, validate_update_status
 from .tool_utils import stock_price, weather
 
 pytestmark = pytest.mark.local('UDF/integration test')
@@ -19,7 +19,7 @@ def cleanup_llama_cpp() -> Iterator[None]:
 
 
 @pytest.mark.very_expensive
-@rerun(reruns=3, reruns_delay=15)  # Since it involves a HF model download
+@rerun_on_network_error()
 class TestLlamaCpp:
     def test_create_chat_completions(self, uses_db: None) -> None:
         skip_test_if_no_config('token', 'hf')

--- a/tests/functions/test_mistralai.py
+++ b/tests/functions/test_mistralai.py
@@ -3,13 +3,13 @@ import pytest
 import pixeltable as pxt
 import pixeltable.type_system as ts
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestMistral:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('mistralai')

--- a/tests/functions/test_nebius.py
+++ b/tests/functions/test_nebius.py
@@ -3,14 +3,20 @@ import pytest
 import pixeltable as pxt
 import pixeltable.type_system as ts
 
-from ..utils import SAMPLE_IMAGE_URL, rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import (
+    SAMPLE_IMAGE_URL,
+    rerun_on_network_error,
+    skip_test_if_no_client,
+    skip_test_if_not_installed,
+    validate_update_status,
+)
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
 @pytest.mark.very_expensive
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestNebius:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('openai')

--- a/tests/functions/test_openai.py
+++ b/tests/functions/test_openai.py
@@ -15,6 +15,7 @@ from ..utils import (
     SAMPLE_IMAGE_URL,
     pxt_raises,
     rerun,
+    rerun_on_network_error,
     skip_test_if_no_client,
     skip_test_if_not_installed,
     validate_update_status,
@@ -27,7 +28,7 @@ _logger = logging.getLogger('pixeltable_test')
 
 
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestOpenai:
     @pytest.mark.expensive
     def test_audio(self, uses_db: None) -> None:

--- a/tests/functions/test_openrouter.py
+++ b/tests/functions/test_openrouter.py
@@ -3,13 +3,13 @@ import pytest
 import pixeltable as pxt
 from tests.functions.tool_utils import run_tool_invocations_test
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestOpenRouter:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('openai')

--- a/tests/functions/test_replicate.py
+++ b/tests/functions/test_replicate.py
@@ -3,14 +3,14 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
 @pytest.mark.very_expensive
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestReplicate:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('replicate')

--- a/tests/functions/test_replicate.py
+++ b/tests/functions/test_replicate.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun(reruns=3, reruns_delay=8)
 class TestReplicate:
     def test_chat_completions(self, uses_db: None) -> None:

--- a/tests/functions/test_reve.py
+++ b/tests/functions/test_reve.py
@@ -5,7 +5,7 @@ import pytest
 import pixeltable as pxt
 from pixeltable.functions import reve
 
-from ..utils import rerun, skip_test_if_no_client, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -15,7 +15,7 @@ _logger = logging.getLogger('pixeltable_test')
 @pytest.mark.remote_api
 @pytest.mark.skip(reason='[PXT-1116] Out of credits')
 @pytest.mark.very_expensive
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestReve:
     @pytest.mark.parametrize('default_params', [True, False], ids=['default_params', 'nondefault_params'])
     def test_create_edit_remix(self, default_params: bool, uses_db: None) -> None:

--- a/tests/functions/test_runwayml.py
+++ b/tests/functions/test_runwayml.py
@@ -5,12 +5,18 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import get_image_files, rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import (
+    get_image_files,
+    rerun_on_network_error,
+    skip_test_if_no_client,
+    skip_test_if_not_installed,
+    validate_update_status,
+)
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
-@rerun(reruns=3, reruns_delay=30)
+@rerun_on_network_error()
 class TestRunwayML:
     def test_image_to_data_uri(self) -> None:
         from pixeltable.functions.runwayml import _image_to_data_uri

--- a/tests/functions/test_together.py
+++ b/tests/functions/test_together.py
@@ -2,14 +2,14 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
 @pytest.mark.very_expensive  # Not really "very expensive", but Together AI is too unreliable for merge queue
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestTogether:
     def test_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('together')

--- a/tests/functions/test_twelvelabs.py
+++ b/tests/functions/test_twelvelabs.py
@@ -8,7 +8,7 @@ from ..utils import (
     get_audio_files,
     get_image_files,
     get_video_files,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_no_client,
     skip_test_if_not_installed,
     validate_update_status,
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 @pytest.mark.remote_api
 @pytest.mark.expensive
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestTwelveLabs:
     def test_embed_text(self, uses_db: None) -> None:
         skip_test_if_not_installed('twelvelabs')

--- a/tests/functions/test_vision.py
+++ b/tests/functions/test_vision.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 class TestVision:
+    @pytest.mark.very_expensive
     def test_eval(self, uses_db: None) -> None:
         skip_test_if_not_installed('yolox')
         from pixeltable.functions.yolox import yolox
@@ -69,6 +70,7 @@ class TestVision:
             bboxes_draw(v.frame_s, boxes=v.detections_a.bboxes, labels=v.detections_a.labels, fill=True)
         ).collect()
 
+    @pytest.mark.very_expensive
     def test_bboxes_draw(self, uses_db: None) -> None:
         skip_test_if_not_installed('yolox')
         from pixeltable.functions.yolox import yolox

--- a/tests/functions/test_vllm.py
+++ b/tests/functions/test_vllm.py
@@ -2,12 +2,12 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import rerun, skip_test_if_not_installed, validate_update_status
+from ..utils import rerun_on_network_error, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
-@rerun(reruns=3, reruns_delay=15)
+@rerun_on_network_error()
 class TestVllm:
     def test_chat_completions(self, uses_db: None) -> None:
         skip_test_if_not_installed('vllm')

--- a/tests/functions/test_voyageai.py
+++ b/tests/functions/test_voyageai.py
@@ -5,7 +5,7 @@ import pixeltable as pxt
 from ..utils import (
     get_image_files,
     get_video_files,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_no_client,
     skip_test_if_not_installed,
     validate_update_status,
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 @pytest.mark.remote_api
 @pytest.mark.very_expensive
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestVoyageAI:
     @pytest.mark.parametrize('output_dimension', [None, 512])
     def test_embeddings(self, uses_db: None, output_dimension: int | None) -> None:

--- a/tests/functions/test_whisper.py
+++ b/tests/functions/test_whisper.py
@@ -4,12 +4,12 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import get_audio_files, rerun, skip_test_if_not_installed, validate_update_status
+from ..utils import get_audio_files, rerun_on_network_error, skip_test_if_not_installed, validate_update_status
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
-@rerun(reruns=1, reruns_delay=8)
+@rerun_on_network_error()
 class TestWhisper:
     @pytest.mark.skipif(sysconfig.get_platform() == 'linux-aarch64', reason='Unreliable on Linux ARM')
     def test_whisper(self, uses_db: None) -> None:

--- a/tests/functions/test_whisperx.py
+++ b/tests/functions/test_whisperx.py
@@ -6,7 +6,7 @@ import pixeltable as pxt
 
 from ..utils import (
     get_audio_files,
-    rerun,
+    rerun_on_network_error,
     runs_linux_with_gpu,
     skip_test_if_no_config,
     skip_test_if_not_installed,
@@ -46,7 +46,7 @@ class TestWhisperx:
         assert 'long and deliberate process' in results['transcription2']['segments'][1]['text']
         assert 'city upon a hill' not in results['transcription2']['segments'][1]['text']  # due to shorter chunk size
 
-    @rerun(reruns=3, reruns_delay=15)  # Guard against connection errors downloading models
+    @rerun_on_network_error()
     def test_diarization(self, uses_db: None) -> None:
         skip_test_if_not_installed('whisperx')
         skip_test_if_no_config('token', 'hf')

--- a/tests/io/test_fiftyone.py
+++ b/tests/io/test_fiftyone.py
@@ -6,13 +6,13 @@ from PIL import Image
 
 import pixeltable as pxt
 
-from ..utils import get_image_files, pxt_raises, rerun, skip_test_if_not_installed
+from ..utils import get_image_files, pxt_raises, rerun_on_network_error, skip_test_if_not_installed
 
 pytestmark = pytest.mark.local('TODO: convert; import/export (fiftyone)')
 
 
 @pytest.mark.skipif(sysconfig.get_platform() == 'linux-aarch64', reason='Not supported on Linux ARM')
-@rerun(reruns=3, reruns_delay=8)
+@rerun_on_network_error()
 class TestFiftyone:
     @pytest.mark.xdist_group('fiftyone')
     def test_export_images(self, uses_db: None) -> None:

--- a/tests/io/test_hf_datasets.py
+++ b/tests/io/test_hf_datasets.py
@@ -10,7 +10,7 @@ import pytest
 
 import pixeltable as pxt
 
-from ..utils import CatalogMode, pxt_raises, rerun, skip_test_if_no_config, skip_test_if_not_installed
+from ..utils import CatalogMode, pxt_raises, rerun_on_network_error, skip_test_if_no_config, skip_test_if_not_installed
 
 if TYPE_CHECKING:
     import datasets  # type: ignore[import-untyped]
@@ -113,7 +113,7 @@ class TestHfDatasetsBasic:
 @pytest.mark.skipif(
     sysconfig.get_platform() == 'linux-aarch64', reason='libsndfile.so is missing on Linux ARM instances in CI'
 )
-@rerun(reruns=3, reruns_delay=15)  # Guard against connection errors downloading datasets
+@rerun_on_network_error()
 class TestHfDatasets:
     NUM_SAMPLES = 100
 

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -8,7 +8,7 @@ import pytest
 import pixeltable as pxt
 import pixeltable.type_system as ts
 
-from ..utils import ensure_s3_pytest_resources_access, get_image_files, pxt_raises, rerun
+from ..utils import ensure_s3_pytest_resources_access, get_image_files, pxt_raises, rerun_on_network_error
 
 EXPECTED_SCHEMA = {
     'name': ts.StringType(nullable=True),
@@ -87,7 +87,7 @@ class TestImport:
         t2.insert(data)
         assert t2.count() == 8
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_import_json(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'
@@ -109,7 +109,7 @@ class TestImport:
             's3://pxt-test/pytest-resources/example.json',
         ],
     )
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_import_json_from_remote(self, make_catalog_path: Callable[[str], str], source: str) -> None:
         p = make_catalog_path
         if source.startswith('s3://'):
@@ -118,7 +118,7 @@ class TestImport:
         assert tab.count() == 4
         assert tab._get_schema() == EXPECTED_SCHEMA
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_insert_json(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -12,7 +12,7 @@ from ..utils import (
     ALL_DATATYPES_SCHEMA,
     create_all_datatypes_tbl,
     get_image_files,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -170,7 +170,7 @@ class TestJson:
 
         assert original == reimported
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_export_remote_urls(self, make_catalog_path: Callable[[str], str], tmp_path: pathlib.Path) -> None:
         """Verify that remote URLs (S3, HTTPS) are exported as-is."""
         p = make_catalog_path

--- a/tests/io/test_pandas.py
+++ b/tests/io/test_pandas.py
@@ -12,7 +12,7 @@ import pixeltable as pxt
 import pixeltable.type_system as ts
 from pixeltable.env import Env
 
-from ..utils import ensure_s3_pytest_resources_access, pxt_raises, rerun, skip_test_if_not_installed
+from ..utils import ensure_s3_pytest_resources_access, pxt_raises, rerun_on_network_error, skip_test_if_not_installed
 
 EXPECTED_SCHEMA = {
     'int_col': ts.IntType(nullable=True),
@@ -177,7 +177,7 @@ class TestPandas:
             's3://pxt-test/pytest-resources/onlinefoods.csv',
         ],
     )
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_import_csv_from_remote(self, make_catalog_path: Callable[[str], str], source: str) -> None:
         p = make_catalog_path
         if source.startswith('s3://'):
@@ -227,7 +227,7 @@ class TestPandas:
             's3://pxt-test/pytest-resources/Financial Sample.xlsx',
         ],
     )
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_import_excel_from_remote(self, make_catalog_path: Callable[[str], str], source: str) -> None:
         p = make_catalog_path
         skip_test_if_not_installed('openpyxl')

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_image_files,
     make_test_arrow_table,
     pxt_raises,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -108,7 +108,7 @@ class TestParquet:
             's3://pxt-test/pytest-resources/alltypes_plain.parquet',
         ],
     )
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_import_parquet_from_remote(self, make_catalog_path: Callable[[str], str], source: str) -> None:
         p = make_catalog_path
         skip_test_if_not_installed('pyarrow')

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -22,7 +22,7 @@ from .utils import (
     get_audio_files,
     get_video_files,
     pxt_raises,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -565,7 +565,7 @@ class TestAudio:
 
     @pytest.mark.local('pure UDF test')
     @pytest.mark.very_expensive  # Downloads a Hugging Face dataset
-    @rerun(reruns=3, reruns_delay=15)  # Guard against connection errors downloading datasets
+    @rerun_on_network_error()
     def test_encode_dataset_audio(self, uses_db: None) -> None:
         """
         The point of this test case is to validate encode_audio UDF on a real-world dataset.

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -14,7 +14,7 @@ from pixeltable.functions.net import presigned_url
 from pixeltable.utils.local_store import TempStore
 from pixeltable.utils.object_stores import ObjectOps, ObjectPath, StorageTarget
 
-from .utils import CatalogMode, MediaStore, pxt_raises, rerun, skip_test_if_not_installed
+from .utils import CatalogMode, MediaStore, pxt_raises, rerun_on_network_error, skip_test_if_not_installed
 
 
 class TestDestination:
@@ -208,7 +208,7 @@ class TestDestination:
         with pytest.raises(ValueError, match='Invalid pxtfs:// store URI'):
             ObjectPath.parse_object_storage_addr('pxtfs://org:db/homebucket', allow_obj_name=False)
 
-    @rerun(reruns=3, reruns_delay=15)
+    @rerun_on_network_error()
     @pytest.mark.parametrize('dest_id', TESTED_DESTINATIONS)
     def test_destination(
         self, make_catalog_path: Callable[[str], str], dest_id: StorageTarget, catalog_mode: CatalogMode
@@ -439,7 +439,7 @@ class TestDestination:
             assert ObjectOps.count(t._id, dest=uri) == 0
 
     @pytest.mark.local('media destination/object-store internals')
-    @rerun(reruns=3, reruns_delay=15)
+    @rerun_on_network_error()
     def test_presigned_url_all_destinations(self, uses_db: None) -> None:
         """Test presigned_url UDF for all cloud storage destinations"""
         # Exclude LOCAL_STORE as it doesn't support presigned URLs

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -34,7 +34,7 @@ from .utils import (
     get_image_files,
     pxt_raises,
     reload_catalog,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -1202,7 +1202,7 @@ class TestExprs:
         result = t.select(t.img, t.img.height, t.img.rotate(90)).show(n=100)
         _ = result._repr_html_()
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_ext_imgs(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
         t = pxt.create_table(p('img_test'), {'img': pxt.Image})

--- a/tests/test_file_cache.py
+++ b/tests/test_file_cache.py
@@ -9,7 +9,7 @@ import pixeltable as pxt
 from pixeltable.env import Env
 from pixeltable.utils.filecache import FileCache
 
-from .utils import get_image_files, rerun
+from .utils import get_image_files, rerun_on_network_error
 
 pytestmark = pytest.mark.local('inspects local FileCache internals')
 
@@ -18,7 +18,7 @@ class TestFileCache:
     # TODO: Understand why this test is flaky on Windows. (It appears to be a timing issue
     #     related to the Windows filesystem.)
     @pytest.mark.skipif(platform.system() == 'Windows', reason='Test is flaky on Windows')
-    @rerun(reruns=3, reruns_delay=15)  # Occasional download timeouts
+    @rerun_on_network_error()
     def test_eviction(self, uses_db: None) -> None:
         # Set a very small cache size of 200 kiB for this test (the imagenette images are ~5-10 kiB each)
         fc = FileCache.get()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -24,7 +24,7 @@ from .utils import (
     local_embedding,
     pxt_raises,
     reload_catalog,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -80,7 +80,7 @@ class TestIndex:
         reload_tester.run_reload_test(clear=True)
 
     @pytest.mark.parametrize('use_index_name,use_separate_embeddings', [(False, False), (True, False), (False, True)])
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_similarity(
         self,
         use_index_name: bool,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,12 +11,12 @@ import pytest
 
 import pixeltable as pxt
 
-from .utils import reload_catalog, rerun, skip_test_if_no_client, skip_test_if_not_installed
+from .utils import reload_catalog, rerun_on_network_error, skip_test_if_no_client, skip_test_if_not_installed
 
 _logger = logging.getLogger('pixeltable_test')
 
 
-@rerun(reruns=3, delay=30)
+@rerun_on_network_error()
 class TestMcp:
     def test_mcp_server(self, make_catalog_path: Callable[[str], str], init_mcp_server: str) -> None:
         skip_test_if_not_installed('mcp')

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -5,7 +5,7 @@ import pytest
 
 import pixeltable as pxt
 
-from .utils import SAMPLE_IMAGE_URL, ReloadTester, create_test_tbl, pxt_raises, rerun
+from .utils import SAMPLE_IMAGE_URL, ReloadTester, create_test_tbl, pxt_raises, rerun_on_network_error
 
 
 def _local_path(name: str) -> str:
@@ -343,7 +343,7 @@ class TestSample:
         n = len(t.select().sample(fraction=0.01, seed=0).collect())
         assert v.count() == n
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_sample_iterator(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
         print('\n\nCREATE TABLE WITH ONE IMAGE COLUMN\n')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -44,7 +44,7 @@ from .utils import (
     pxt_raises,
     read_data_file,
     reload_catalog,
-    rerun,
+    rerun_on_network_error,
     skip_test_if_not_installed,
     stock_price,
     validate_repr,
@@ -2057,7 +2057,7 @@ class TestTable:
         rows = [{'media': f, 'is_bad_media': not is_valid} for f, is_valid in zip(doc_paths, is_valid)]
         self.check_bad_media(p, rows, pxt.Document, validate_local_path=catalog_mode == 'local')
 
-    @rerun(reruns=3, reruns_delay=15, only_rerun=['429', 'Too Many Requests'])
+    @rerun_on_network_error()
     def test_validate_external_url(self, make_catalog_path: Callable[[str], str], catalog_mode: CatalogMode) -> None:
         p = make_catalog_path
         skip_test_if_not_installed('boto3')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -992,6 +992,7 @@ NETWORK_ERROR_PATTERNS = [
     'timed out',
     'Timeout',
     'ExternalServiceError',
+    'URLError',
 ]
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -981,8 +981,18 @@ def rerun(**kwargs: Any) -> Callable:
 
 
 # Error patterns that indicate a transient network/service problem rather than a genuine test failure. Tests that hit
-# external services should be retried when they fail with one of these.
-NETWORK_ERROR_PATTERNS = ['429', 'Too Many Requests', 'Connection reset', 'ExternalServiceError']
+# external services (remote APIs, model/dataset downloads, cloud object stores) should be retried when they fail with
+# one of these. Matched as substrings against the failure message by pytest-rerunfailures' `only_rerun`.
+NETWORK_ERROR_PATTERNS = [
+    '429',
+    'Too Many Requests',
+    'Connection reset',
+    'Connection aborted',
+    'Max retries exceeded',
+    'timed out',
+    'Timeout',
+    'ExternalServiceError',
+]
 
 
 def rerun_on_network_error(reruns: int = 3, reruns_delay: int = 15, **kwargs: Any) -> Callable:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -980,6 +980,16 @@ def rerun(**kwargs: Any) -> Callable:
     return pytest.mark.flaky(**kwargs)
 
 
+# Error patterns that indicate a transient network/service problem rather than a genuine test failure. Tests that hit
+# external services should be retried when they fail with one of these.
+NETWORK_ERROR_PATTERNS = ['429', 'Too Many Requests', 'Connection reset', 'ExternalServiceError']
+
+
+def rerun_on_network_error(reruns: int = 3, reruns_delay: int = 15, **kwargs: Any) -> Callable:
+    """Rerun a test that fails due to a transient network/service error."""
+    return rerun(reruns=reruns, reruns_delay=reruns_delay, only_rerun=NETWORK_ERROR_PATTERNS, **kwargs)
+
+
 # This will be set to True if the tests are running in a CI environment.
 IN_CI = bool(os.environ.get('PXTTEST_IN_CI'))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -982,7 +982,7 @@ def rerun(**kwargs: Any) -> Callable:
 
 # Error patterns that indicate a transient network/service problem rather than a genuine test failure. Tests that hit
 # external services (remote APIs, model/dataset downloads, cloud object stores) should be retried when they fail with
-# one of these. Matched as substrings against the failure message by pytest-rerunfailures' `only_rerun`.
+# one of these. Matched as substrings against the failure message.
 NETWORK_ERROR_PATTERNS = [
     '429',
     'Too Many Requests',


### PR DESCRIPTION
I went over the recent merge queue failures and marked the offending provider tests `very_expensive`.

Also, unified the retry policy for network-dependent tests as a new `@rerun_on_network_error` decorator. Note: this has a side effect that some tests used to get rerun on any error, will now only be rerun on a network-related error. We can patch up other retriable errors as we go, if necessary.