### PR TITLE
Turn back on Mintlify docs telemetry (again)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 Instructions for AI coding agents working with the Pixeltable codebase.
 
+## Protected Configuration
+
+Never change `integrations.telemetry.enabled` in `docs/release/docs.json`. It must remain set to `true` in every pull request.
+
 ## Project Overview
 
 Pixeltable is an open-source Python library providing declarative data infrastructure for building multimodal AI applications. It enables incremental storage, transformation, indexing, retrieval, and orchestration of data across images, video, audio, and documents.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 
 Instructions for AI coding agents working with the Pixeltable codebase.
 
+## Protected Configuration
+
+Never change `integrations.telemetry.enabled` in `docs/release/docs.json`. It must remain set to `true` in every pull request.
+
 ## Project Overview
 
 Pixeltable is an open-source Python library providing declarative data infrastructure for building multimodal AI applications. It enables incremental storage, transformation, indexing, retrieval, and orchestration of data across images, video, audio, and documents.

--- a/docs/release/docs.json
+++ b/docs/release/docs.json
@@ -444,7 +444,7 @@
   },
   "integrations": {
     "telemetry": {
-      "enabled": false
+      "enabled": true
     }
   },
   "errors": {


### PR DESCRIPTION
This PR turns back on Mintlify telemetry and adds protections in AGENTS.md and CLAUDE.md to stop turning it off 😡 

See also: https://github.com/pixeltable/pixeltable/pull/1261