### PR TITLE
[PXT-1247] Fix SAM3 segmentation with no detections

### DIFF
--- a/docs/release/docs.json
+++ b/docs/release/docs.json
@@ -138,6 +138,7 @@
                       "howto/cookbooks/images/img-detect-objects",
                       "howto/cookbooks/images/img-detection-vs-segmentation",
                       "howto/cookbooks/images/img-visualize-detections",
+                      "howto/cookbooks/images/img-promptable-segmentation",
                       "howto/cookbooks/images/img-generate-captions",
                       "howto/cookbooks/images/img-image-to-image",
                       "howto/cookbooks/images/vision-batch-analysis",

--- a/pixeltable/functions/huggingface.py
+++ b/pixeltable/functions/huggingface.py
@@ -542,6 +542,10 @@ def sam3_for_segmentation(
     masks_np = result['masks'].cpu().numpy()
     if masks_np.dtype != np.bool_:
         masks_np = masks_np.astype(bool)
+    if masks_np.shape[0] == 0:
+        # with zero detections, post_process_instance_segmentation skips resizing to target_sizes,
+        # leaving masks at the model's internal resolution
+        masks_np = masks_np.reshape((0, image.height, image.width))
 
     return SamForSegmentationResponse(
         scores=result['scores'].cpu().numpy(), boxes=result['boxes'].cpu().numpy(), masks=masks_np

--- a/tests/functions/test_huggingface.py
+++ b/tests/functions/test_huggingface.py
@@ -343,6 +343,29 @@ class TestHuggingface:
         )
         assert v_fps.count() == 4
 
+    def test_sam3_for_segmentation_no_detections(self, uses_db: None) -> None:
+        skip_test_if_not_installed('transformers')
+        from huggingface_hub import get_token
+
+        if get_token() is None:
+            pytest.skip('Skipping SAM 3 test: facebook/sam3 is gated and no Hugging Face token is configured')
+        from pixeltable.functions.huggingface import sam3_for_segmentation
+        from pixeltable.functions.vision import overlay_segmentation
+
+        t = pxt.create_table('test_tbl', {'img': pxt.Image})
+        # threshold=1.0 guarantees zero detections (scores never exceed 1.0)
+        t.add_computed_column(seg=sam3_for_segmentation(t.img, text='orange', threshold=1.0))
+        t.add_computed_column(viz=overlay_segmentation(t.img, t.seg.masks))
+        validate_update_status(t.insert(img=SAMPLE_IMAGE_URL), expected_rows=1)
+
+        res = t.select(t.seg, t.viz, height=t.img.height, width=t.img.width).collect()[0]
+        result = res['seg']
+        assert result['scores'].shape == (0,)
+        assert result['boxes'].shape == (0, 4)
+        # empty masks match the image dimensions, so downstream consumers like overlay_segmentation work
+        assert result['masks'].shape == (0, res['height'], res['width'])
+        assert res['viz'].size == (res['width'], res['height'])
+
     def test_vit_for_image_classification(self, uses_db: None) -> None:
         skip_test_if_no_config('token', 'hf')
         skip_test_if_not_installed('transformers')


### PR DESCRIPTION
sam3_for_segmentation() returned masks at the model's internal resolution instead of the image resolution when there were no detections, which broke downstream consumers like overlay_segmentation(). Empty mask arrays are now reshaped to match the image dimensions, so overlaying an empty segmentation returns the original image unchanged.

Also adds the promptable segmentation notebook to the docs navigation; it was missing from docs.json.