### PR TITLE
Proxy mode test infra improvements

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -233,11 +233,12 @@ jobs:
         # Run the tests with the 'expensive' marker only once, on ubuntu-24.04 with Python 3.10. The other tests
         # (including tests with the 'remote_api' marker that are not also marked 'expensive') will run on all matrix
         # configurations.
+        # --basetemp pins pytest's temp root dir so that the Archive step below works on all platforms
         run: |
           echo 'Running tests with options: ${{ matrix.pytest-options }}'
           echo 'Extra pre-test command    : ${{ matrix.pre-test-cmd }}'
           ${{ matrix.pre-test-cmd }}
-          pytest -v --strict-markers -n auto --dist loadgroup ${{ matrix.pytest-options }} $PYTEST_COVERAGE_OPTS
+          pytest -v --strict-markers -n auto --dist loadgroup --basetemp="$RUNNER_TEMP/pxt-pytest" ${{ matrix.pytest-options }} $PYTEST_COVERAGE_OPTS
       - name: Run the OpenTelemetry instrumentation tests
         # The opentelemetry-instrumentation-pixeltable package is a separate distribution; the core suite does not
         # collect its tests (testpaths in pyproject.toml). It is tested here against a minimal install + otel extra.
@@ -291,14 +292,14 @@ jobs:
         if: ${{ matrix.test-category == 'lint' }}
         run: ./scripts/check-notebooks.sh
       - name: Archive log files
-        # Archive the log files even if a preceding step failed. Currently we do this only on ubuntu runners.
-        if: ${{ always() && startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ always() && matrix.test-category == 'py' }}
         uses: actions/upload-artifact@v4
         with:
           name: pixeltable-pytest-logs-${{ matrix.display-name }}-${{ matrix.os }}-${{ matrix.python-version }}
+          if-no-files-found: ignore
           path: |
-            /tmp/pytest-of-runner/**/.pixeltable/logs
-            /tmp/pytest-of-runner/**/.pixeltable/proxy_*/logs
+            ${{ runner.temp }}/pxt-pytest/**/.pixeltable/logs
+            ${{ runner.temp }}/pxt-pytest/**/.pixeltable/proxy_*/logs
           include-hidden-files: true
       - name: Print utilization info
         if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -536,8 +536,6 @@ class Catalog(CatalogBase):
         The order matters: TVPs are processed before tbl_ids in both groups so that ancestor-first validation
         (write_tvps -> write_tbl_ids -> read_tvps -> read_tbl_ids) is established before any unordered ID pass runs.
         """
-        # Fault location: this is the transaction's first use of the connection; a dropped connection surfaces here.
-        fault_injection.process_fault(FaultLocation.CATALOG_ACQUIRE_LOCKS)
         x_locked_ids: set[UUID] = set()
         for tvp in write_tvps:
             if tvp.tbl_id in x_locked_ids:

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -536,6 +536,8 @@ class Catalog(CatalogBase):
         The order matters: TVPs are processed before tbl_ids in both groups so that ancestor-first validation
         (write_tvps -> write_tbl_ids -> read_tvps -> read_tbl_ids) is established before any unordered ID pass runs.
         """
+        # Fault location: this is the transaction's first use of the connection; a dropped connection surfaces here.
+        fault_injection.process_fault(FaultLocation.CATALOG_ACQUIRE_LOCKS)
         x_locked_ids: set[UUID] = set()
         for tvp in write_tvps:
             if tvp.tbl_id in x_locked_ids:

--- a/pixeltable/catalog/catalog.py
+++ b/pixeltable/catalog/catalog.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import random
 import time
+import warnings
 from collections import defaultdict
 from collections.abc import Collection
 from contextlib import contextmanager
@@ -3082,15 +3083,18 @@ class Catalog(CatalogBase):
         """Validate the underlying store for testing purposes.
         This function can and should be extended to perform more checks.
         """
-        all_contents = self.get_dir_contents(ROOT_PATH, recursive=True)
-        with self.begin_xact(for_write=False), self._allow_tbl_md_read():
-            for entry in all_contents.values():
-                if entry.table is None:
-                    continue
-                id = entry.table.id
-                tbl = self.get_table_by_id(id)
-                assert tbl is not None, id
-                self._validate_table(tbl)
+        # Some tests intentionally cause warnings (e.g. UDF is gone). Ignore those warnings.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', excs.PixeltableWarning)
+            all_contents = self.get_dir_contents(ROOT_PATH, recursive=True)
+            with self.begin_xact(for_write=False), self._allow_tbl_md_read():
+                for entry in all_contents.values():
+                    if entry.table is None:
+                        continue
+                    id = entry.table.id
+                    tbl = self.get_table_by_id(id)
+                    assert tbl is not None, id
+                    self._validate_table(tbl)
 
     def _validate_table(self, tbl: pxt.Table) -> None:
         if tbl._tbl_version is None:

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -682,7 +682,7 @@ class TableVersion:
 
         # remove this index entry from the active indexes (in memory)
         # and the index metadata (in persistent table metadata)
-        # TODO: this is wrong, it breaks revert()
+        # TODO(PXT-1254): this is wrong, it breaks revert()
         del self.idxs[idx_id]
         del self.idxs_by_name[idx_md.name]
         if idx_info.col.qid in self.idxs_by_col:

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -534,24 +534,13 @@ class Env:
         finally:
             engine.dispose()
 
-    def _pgserver_terminate_connections_stmt(self) -> str:
-        return f"""
-                SELECT pg_terminate_backend(pg_stat_activity.pid)
-                FROM pg_stat_activity
-                WHERE pg_stat_activity.datname = '{self._db_name}'
-                AND pid <> pg_backend_pid()
-            """
-
     def _drop_store_db(self) -> None:
         assert self._db_name is not None
         engine = sql.create_engine(self._dbms.default_system_db_url(), future=True, isolation_level='AUTOCOMMIT')
         preparer = engine.dialect.identifier_preparer
         try:
             with engine.begin() as conn:
-                # terminate active connections
-                if self._db_server is not None:
-                    conn.execute(sql.text(self._pgserver_terminate_connections_stmt()))
-                # drop db
+                # drop db; the statement force-terminates any active connections to it
                 stmt = self._dbms.drop_db_stmt(preparer.quote(self._db_name))
                 conn.execute(sql.text(stmt))
         finally:
@@ -885,24 +874,7 @@ class Env:
             except Exception as e:
                 _logger.warning(f'Error stopping HTTP server: {e}')
 
-        # First terminate all connections to the database
-        if self._db_server is not None:
-            assert self._dbms is not None
-            assert self._db_name is not None
-            try:
-                temp_engine = sql.create_engine(self._dbms.default_system_db_url(), isolation_level='AUTOCOMMIT')
-                try:
-                    with temp_engine.begin() as conn:
-                        conn.execute(sql.text(self._pgserver_terminate_connections_stmt()))
-                        _logger.info(f"Terminated all connections to database '{self._db_name}'")
-                except Exception as e:
-                    _logger.warning(f'Error terminating database connections: {e}')
-                finally:
-                    temp_engine.dispose()
-            except Exception as e:
-                _logger.warning(f'Error stopping database server: {e}')
-
-        # Dispose of SQLAlchemy engine (after stopping db server)
+        # Dispose of SQLAlchemy engine
         if self._sa_engine is not None:
             try:
                 self._sa_engine.dispose()

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -48,6 +48,15 @@ LOG_FMT_STR = '%(asctime)s %(levelname)s %(threadName)s %(name)s %(filename)s:%(
 T = TypeVar('T')
 
 
+def store_app_name() -> str:
+    """The application_name that this process's connections report to the store.
+
+    Identifies them in pg_stat_activity; the pid makes it distinguishable from the connections of other Pixeltable
+    processes running against the same database.
+    """
+    return f'pixeltable-{os.getpid()}'
+
+
 class Env:
     """
     Store runtime globals for both local and non-local environments.
@@ -478,8 +487,9 @@ class Env:
         metadata.create_system_info(self._sa_engine)
 
     def _create_engine(self, time_zone_name: str, echo: bool = False) -> None:
-        # Add timezone option to connection string
+        # Add timezone and application_name options to connection string
         updated_url = add_option_to_db_url(self.db_url, f'-c timezone={time_zone_name}')
+        updated_url = add_option_to_db_url(updated_url, f'-c application_name={store_app_name()}')
 
         self._sa_engine = sql.create_engine(
             updated_url, echo=echo, isolation_level=self._dbms.transaction_isolation_level

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -31,7 +31,6 @@ import pixeltable as pxt
 from pixeltable import exceptions as excs
 from pixeltable.config import Config
 from pixeltable.env import Env
-from pixeltable.metadata.schema import base_metadata
 from pixeltable.runtime import get_runtime, reset_runtime
 
 from . import proxy_dispatch
@@ -247,12 +246,15 @@ def stop(db: str) -> None:
     _port_lock(db).unlink(missing_ok=True)
 
 
-def reset(db: str) -> None:
-    """Reset the running daemon's catalog to empty, in place (no restart, so its endpoint stays valid)."""
+def reinitialize(db: str) -> None:
+    """Test only. Drop the running daemon's cached catalog state, in place (no restart, so its endpoint stays valid).
+
+    Does not clear the store state.
+    """
     ep = endpoint(db)
     if ep is None:
         raise excs.Error(excs.ErrorCode.INTERNAL_ERROR, f'No running proxy daemon for {db!r}')
-    response = httpx.post(f'{ep}/reset', timeout=60.0)
+    response = httpx.post(f'{ep}/reinitialize', timeout=60.0)
     response.raise_for_status()
 
 
@@ -265,28 +267,10 @@ def delete(db: str) -> None:
         shutil.rmtree(home)
 
 
-def reset_catalog() -> None:
-    """Empty this daemon's catalog in place and reload it. Runs inside the daemon process.
-
-    Drops the data tables and truncates the metadata tables, then reinitializes; the result is the same
-    empty-but-initialized state as a freshly created database (init recreates the root directory record),
-    so the daemon can be reused across tests without a restart. The truncate/drop logic mirrors the test
-    harness's clean_db(); a shared home for it is a later cleanup.
+def _reinitialize() -> None:
+    """Test only. Discard this daemon's cached catalog state and reload it from the store. Runs inside the daemon
+    process.
     """
-    engine = Env.get().engine
-    inspector = sql.inspect(engine)
-    all_table_names = set(inspector.get_table_names())
-    md_table_names = set(base_metadata.tables.keys())
-    data_table_names = all_table_names - md_table_names
-    existing_md_names = all_table_names & md_table_names
-    with engine.connect() as conn:
-        if data_table_names:
-            names = ', '.join(f'"{t}"' for t in data_table_names)
-            conn.execute(sql.text(f'DROP TABLE IF EXISTS {names} CASCADE'))
-        if existing_md_names:
-            names = ', '.join(f'"{t}"' for t in existing_md_names)
-            conn.execute(sql.text(f'TRUNCATE TABLE {names} CASCADE'))
-        conn.commit()
     reset_runtime()
     pxt.init()
 
@@ -333,10 +317,10 @@ def _build_app() -> 'FastAPI':
             content=encode_body(response_json.encode(), response_parts), media_type='application/octet-stream'
         )
 
-    @app.post('/reset')
-    async def reset_endpoint() -> Response:
-        # reset_catalog() truncates tables and reinitializes; keep it off the event loop
-        await run_in_threadpool(reset_catalog)
+    @app.post('/reinitialize')
+    async def reinitialize_endpoint() -> Response:
+        # _reinitialize() rebuilds the runtime, which is synchronous; keep it off the event loop
+        await run_in_threadpool(_reinitialize)
         return Response(content='{"status": "ok"}', media_type='application/json')
 
     @app.get('/health')

--- a/pixeltable/utils/dbms.py
+++ b/pixeltable/utils/dbms.py
@@ -48,7 +48,8 @@ class PostgresqlDbms(Dbms):
         super().__init__('postgresql', _DEFAULT_ISOLATION_LEVEL, 'brin', db_url)
 
     def drop_db_stmt(self, database: str) -> str:
-        return f'DROP DATABASE {database}'
+        # WITH (FORCE) terminates any open connections to the target db before dropping it
+        return f'DROP DATABASE {database} WITH (FORCE)'
 
     def create_db_stmt(self, database: str) -> str:
         match platform.system():

--- a/pixeltable/utils/fault_injection.py
+++ b/pixeltable/utils/fault_injection.py
@@ -9,7 +9,6 @@ from typing import Any
 class FaultLocation(Enum):
     """Instrumented locations in the codebase where faults can be injected."""
 
-    CATALOG_ACQUIRE_LOCKS = auto()
     CATALOG_CREATE_USER_AFTER_EXISTS_CHECK = auto()
     CATALOG_CREATE_VIEW_BEFORE_MD_COMMITTED = auto()
     CATALOG_FINALIZE_PENDING_OPS_NON_XACT = auto()

--- a/pixeltable/utils/fault_injection.py
+++ b/pixeltable/utils/fault_injection.py
@@ -9,6 +9,7 @@ from typing import Any
 class FaultLocation(Enum):
     """Instrumented locations in the codebase where faults can be injected."""
 
+    CATALOG_ACQUIRE_LOCKS = auto()
     CATALOG_CREATE_USER_AFTER_EXISTS_CHECK = auto()
     CATALOG_CREATE_VIEW_BEFORE_MD_COMMITTED = auto()
     CATALOG_FINALIZE_PENDING_OPS_NON_XACT = auto()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,7 @@ def _set_up_external_db_schema(worker_id: int | str) -> str:
 
 
 def _worker_db_name(worker_id: int | str) -> str:
+    """The db name used by both the pytest process and its proxy daemon."""
     return f'test_{worker_id}'
 
 
@@ -255,6 +256,9 @@ def uses_db(init_env: None, request: pytest.FixtureRequest) -> Iterator[None]:
 @pytest.fixture(scope='session')
 def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
     """A per-worker local proxy daemon, started once for the session and reused across tests.
+
+    The daemon deliberately runs against the same database as the pytest process (_worker_db_name). This way, the
+    post-test _validate_catalog_state() actually validates the store state at the end of the test.
 
     The db name is worker-scoped so parallel xdist workers don't share a catalog. start() is idempotent,
     so the per-test make_catalog_path fixture only resets the daemon's catalog rather than restarting the process.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,10 @@ def _set_up_external_db_schema(worker_id: int | str) -> str:
     return schema_name
 
 
+def _worker_db_name(worker_id: int | str) -> str:
+    return f'test_{worker_id}'
+
+
 @pytest.fixture(scope='session')
 def init_env(tmp_path_factory: pytest.TempPathFactory, worker_id: int) -> None:  # type: ignore[misc]
     os.chdir(os.path.dirname(os.path.dirname(__file__)))  # Project root directory
@@ -127,7 +131,7 @@ def init_env(tmp_path_factory: pytest.TempPathFactory, worker_id: int) -> None: 
     home_dir = str(tmp_path_factory.mktemp('base') / '.pixeltable')
     os.environ['PIXELTABLE_HOME'] = home_dir
     os.environ['PIXELTABLE_CONFIG'] = str(shared_home / 'config.toml')
-    os.environ['PIXELTABLE_DB'] = f'test_{worker_id}'
+    os.environ['PIXELTABLE_DB'] = _worker_db_name(worker_id)
     os.environ['PIXELTABLE_PGDATA'] = str(shared_home / 'pgdata')
     os.environ['PIXELTABLE_API_URL'] = 'https://preprod-internal-api.pixeltable.com'
     os.environ['FIFTYONE_DATABASE_DIR'] = f'{home_dir}/.fiftyone'
@@ -260,7 +264,7 @@ def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
     pytest.importorskip('uvicorn')
     from pixeltable.service import proxy_daemon
 
-    db = f'testdb_{worker_id}'
+    db = _worker_db_name(worker_id)
     proxy_daemon.start(db)
     try:
         yield db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,7 +273,9 @@ def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
     try:
         yield db
     finally:
-        proxy_daemon.delete(db)
+        # stop() rather than delete(): delete() would remove the daemon's logs, making it hard to debug CI failures.
+        # The database will be cleared before the next test run.
+        proxy_daemon.stop(db)
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,7 +261,7 @@ def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
     post-test _validate_catalog_state() actually validates the store state at the end of the test.
 
     The db name is worker-scoped so parallel xdist workers don't share a catalog. start() is idempotent,
-    so the per-test make_catalog_path fixture only resets the daemon's catalog rather than restarting the process.
+    so the per-test make_catalog_path fixture only reloads the daemon's catalog rather than restarting the process.
     """
     # the proxy daemon serves over HTTP via fastapi/uvicorn (the serve extra); a minimal install omits them
     pytest.importorskip('fastapi')
@@ -321,7 +321,7 @@ def make_catalog_path(
         from pixeltable.service import proxy_daemon
 
         db = request.getfixturevalue('proxy_daemon_db')
-        proxy_daemon.reset(db)
+        proxy_daemon.reinitialize(db)
         prefix = f'pxt://local:{db}'
 
         def p(path: str) -> str:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -186,7 +186,12 @@ class TestCatalog:
             term_engine = sql.create_engine(Env.get().db_url, poolclass=sql.pool.NullPool)
             try:
                 with term_engine.connect() as term:
-                    term.execute(sql.text(Env.get()._pgserver_terminate_connections_stmt()))
+                    term.execute(
+                        sql.text(
+                            'SELECT pg_terminate_backend(pid) FROM pg_stat_activity '
+                            'WHERE datname = current_database() AND pid <> pg_backend_pid()'
+                        )
+                    )
                     term.commit()
             finally:
                 term_engine.dispose()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,12 +2,10 @@ from typing import Callable
 
 import psycopg
 import pytest
-import sqlalchemy as sql
 import sqlalchemy.exc as sql_exc
 
 import pixeltable as pxt
 import pixeltable.exceptions as excs
-from pixeltable.env import Env
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.fault_injection import FaultLocation
 from tests.coordinator import MultiThreadedScenario
@@ -171,44 +169,38 @@ class TestCatalog:
         assert ls['Name'].iloc[0] == 'test', ls
 
     @pytest.mark.local('recovers transparently when the server drops the pooled db connections')
-    def test_dropped_connection(self, uses_db: None) -> None:
-        if not Env.get().is_local:
-            # the way this test drops connections (pg_terminate_backend on the pixeltable db) is specific to pgserver
-            pytest.skip('requires pgserver')
+    def test_dropped_connection(self, uses_db: None, fault_injection: None) -> None:
         pxt.create_dir('d')
         t = pxt.create_table('d/t', {'a': pxt.Int})
         t.insert([{'a': 1}])
 
-        def kill_connections() -> None:
-            # Terminate this worker's backends out from under the pooled connections. The terminator runs on a
-            # separate connection outside the engine's pool (and the statement excludes only its own backend),
-            # so every connection the engine has pooled is killed.
-            term_engine = sql.create_engine(Env.get().db_url, poolclass=sql.pool.NullPool)
-            try:
-                with term_engine.connect() as term:
-                    term.execute(
-                        sql.text(
-                            'SELECT pg_terminate_backend(pid) FROM pg_stat_activity '
-                            'WHERE datname = current_database() AND pid <> pg_backend_pid()'
-                        )
-                    )
-                    term.commit()
-            finally:
-                term_engine.dispose()
+        # Simulate terminated PG connection
+        orig = psycopg.errors.AdminShutdown('terminating connection due to administrator command')
+        exc = sql_exc.OperationalError('<injected>', {}, orig)
+        exc.connection_invalidated = True
+
+        def arm_dropped_connection() -> ExceptionFault:
+            fault = ExceptionFault(exc)
+            get_runtime().fault_manager.inject_fault(FaultLocation.CATALOG_ACQUIRE_LOCKS, fault)
+            return fault
 
         # each operation kind reconnects and succeeds instead of raising the dropped-connection error:
         # a catalog-metadata read, a data query, and a write
-        kill_connections()
+        fault = arm_dropped_connection()
         assert 'd/t' in pxt.list_tables('d')
+        fault.assert_count(1)
 
-        kill_connections()
+        fault = arm_dropped_connection()
         assert t.count() == 1
+        fault.assert_count(1)
 
-        kill_connections()
+        fault = arm_dropped_connection()
         assert t.select(t.a).collect()['a'] == [1]
+        fault.assert_count(1)
 
-        kill_connections()
+        fault = arm_dropped_connection()
         t.insert([{'a': 2}])
+        fault.assert_count(1)
         assert t.count() == 2
 
     @pytest.mark.local('fault-injection/concurrency test against the in-process catalog internals')

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -7,7 +7,7 @@ import sqlalchemy.exc as sql_exc
 
 import pixeltable as pxt
 import pixeltable.exceptions as excs
-from pixeltable.env import Env
+from pixeltable.env import Env, store_app_name
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.fault_injection import FaultLocation
 from tests.coordinator import MultiThreadedScenario
@@ -186,12 +186,14 @@ class TestCatalog:
             term_engine = sql.create_engine(Env.get().db_url, poolclass=sql.pool.NullPool)
             try:
                 with term_engine.connect() as term:
-                    term.execute(
+                    killed = term.execute(
                         sql.text(
                             'SELECT pg_terminate_backend(pid) FROM pg_stat_activity '
-                            'WHERE datname = current_database() AND pid <> pg_backend_pid()'
-                        )
-                    )
+                            'WHERE datname = current_database() AND application_name = :app'
+                        ),
+                        {'app': store_app_name()},
+                    ).fetchall()
+                    assert len(killed) > 0
                     term.commit()
             finally:
                 term_engine.dispose()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,10 +2,12 @@ from typing import Callable
 
 import psycopg
 import pytest
+import sqlalchemy as sql
 import sqlalchemy.exc as sql_exc
 
 import pixeltable as pxt
 import pixeltable.exceptions as excs
+from pixeltable.env import Env
 from pixeltable.runtime import get_runtime
 from pixeltable.utils.fault_injection import FaultLocation
 from tests.coordinator import MultiThreadedScenario
@@ -169,38 +171,44 @@ class TestCatalog:
         assert ls['Name'].iloc[0] == 'test', ls
 
     @pytest.mark.local('recovers transparently when the server drops the pooled db connections')
-    def test_dropped_connection(self, uses_db: None, fault_injection: None) -> None:
+    def test_dropped_connection(self, uses_db: None) -> None:
+        if not Env.get().is_local:
+            # the way this test drops connections (pg_terminate_backend on the pixeltable db) is specific to pgserver
+            pytest.skip('requires pgserver')
         pxt.create_dir('d')
         t = pxt.create_table('d/t', {'a': pxt.Int})
         t.insert([{'a': 1}])
 
-        # Simulate terminated PG connection
-        orig = psycopg.errors.AdminShutdown('terminating connection due to administrator command')
-        exc = sql_exc.OperationalError('<injected>', {}, orig)
-        exc.connection_invalidated = True
-
-        def arm_dropped_connection() -> ExceptionFault:
-            fault = ExceptionFault(exc)
-            get_runtime().fault_manager.inject_fault(FaultLocation.CATALOG_ACQUIRE_LOCKS, fault)
-            return fault
+        def kill_connections() -> None:
+            # Terminate this worker's backends out from under the pooled connections. The terminator runs on a
+            # separate connection outside the engine's pool (and the statement excludes only its own backend),
+            # so every connection the engine has pooled is killed.
+            term_engine = sql.create_engine(Env.get().db_url, poolclass=sql.pool.NullPool)
+            try:
+                with term_engine.connect() as term:
+                    term.execute(
+                        sql.text(
+                            'SELECT pg_terminate_backend(pid) FROM pg_stat_activity '
+                            'WHERE datname = current_database() AND pid <> pg_backend_pid()'
+                        )
+                    )
+                    term.commit()
+            finally:
+                term_engine.dispose()
 
         # each operation kind reconnects and succeeds instead of raising the dropped-connection error:
         # a catalog-metadata read, a data query, and a write
-        fault = arm_dropped_connection()
+        kill_connections()
         assert 'd/t' in pxt.list_tables('d')
-        fault.assert_count(1)
 
-        fault = arm_dropped_connection()
+        kill_connections()
         assert t.count() == 1
-        fault.assert_count(1)
 
-        fault = arm_dropped_connection()
+        kill_connections()
         assert t.select(t.a).collect()['a'] == [1]
-        fault.assert_count(1)
 
-        fault = arm_dropped_connection()
+        kill_connections()
         t.insert([{'a': 2}])
-        fault.assert_count(1)
         assert t.count() == 2
 
     @pytest.mark.local('fault-injection/concurrency test against the in-process catalog internals')

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 import pytest
 
 import pixeltable as pxt
@@ -12,13 +14,21 @@ from .utils import pxt_raises, skip_test_if_not_local
 pytestmark = pytest.mark.local('exercises process-global Env/Config and runtime reset')
 
 
-def _reset_env(reinit: bool, db_name: str) -> None:
-    """Reset the environment for testing."""
+def _reset_env(reinit: bool, db_name: str | None) -> None:
+    """Reset the environment for testing. db_name=None restores the default test database."""
     reset_runtime()
     # Reload configs
-    Config.init(config_overrides={'pixeltable.db': db_name}, reinit=True)
+    config_overrides = {} if db_name is None else {'pixeltable.db': db_name}
+    Config.init(config_overrides=config_overrides, reinit=True)
     Env._init_env(reinit_db=reinit)
     FileCache.init()
+
+
+@pytest.fixture(autouse=True)
+def restore_env() -> Iterator[None]:
+    """Put the process back on its configured database once the test is done."""
+    yield
+    _reset_env(reinit=False, db_name=None)
 
 
 class TestEnvReset:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -750,12 +750,6 @@ class TestIndex:
             img_t.drop_embedding_index(column=img_t.img)
         assert 'does not have an index' in str(exc_info.value).lower()
 
-        # revert() makes the index reappear
-        img_t.revert()
-        with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS) as exc_info:
-            img_t.add_embedding_index('img', idx_name='idx0', image_embed=local_embed)
-        assert 'duplicate index name' in str(exc_info.value).lower()
-
         # dropping the indexed column also drops indices
         img_t.drop_column('img')
         with pxt_raises(pxt.ErrorCode.INDEX_NOT_FOUND) as exc_info:


### PR DESCRIPTION
Almost all changes are test-only so low risk.

1. In proxy mode, the daemon uses the same database as the pytest process. This allows `_validate_catalog_state()` (that runs in the pytest process at the end of the test) to actually verify the database that was used in the test.
2. `Catalog.validate_store()` ignores Pixeltable warnings.
3. `TestIndex.test_embedding_basic` does not attempt to revert a dropped index because that causes catalog corruption (https://pixeltable.atlassian.net/browse/).
4. `TestEnvReset` restores the `Env` state at the end.
5. `TestCatalog.test_dropped_connection` only drops the current process's connections to the store rather than all, which may include proxy daemon connections. To make that happen, each DB connection gets an "application name" derived from the pid.
6. `Env._clean_up()` does not forcibly terminate all connections to the database -- that was screwing with the daemon process. There was no good reason to do that to begin with -- `_clean_up()` does not drop the database (and if it did, "drop with force" takes care of active connections).
7. At the end of session-scoped `proxy_daemon_db` fixture, stop the daemon rather than delete it. Deleting it causes its logs to disappear, and CI run cannot retain them as artifacts.
8. Updated `pytest.yml` to correctly produce test artifacts (including daemon logs) on all platforms.