### PR TITLE
Fix test_db_migration + more

### DIFF
--- a/tests/functions/test_bedrock.py
+++ b/tests/functions/test_bedrock.py
@@ -12,6 +12,7 @@ from ..utils import (
     get_audio_files,
     get_image_files,
     get_video_files,
+    rerun,
     rerun_on_network_error,
     skip_test_if_no_aws_credentials,
     validate_update_status,
@@ -268,6 +269,7 @@ class TestBedrock:
         validate_update_status(t.insert(input='What is the capital of France?'), expected_rows=1)
         assert 'Paris' in t.collect()[0]['response']
 
+    @rerun(reruns=3, reruns_delay=8)
     def test_converse_tool_invocations(self, uses_db: None) -> None:
         skip_test_if_no_aws_credentials()
         from pixeltable.functions import bedrock

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -327,7 +327,8 @@ class TestMigration:
         if version >= 45:
             row['c9'] = get_audio_files()[0]
             row['c10'] = get_video_files()[0]
-            row['c11'] = get_documents()[0]
+            # TODO(PXT-1249): document_splitter does not currently support xml
+            row['c11'] = next(d for d in get_documents() if not d.endswith('.xml'))
             row['c12'] = np.zeros((10,), dtype=np.float64)
             row['c13'] = uuid.uuid4()
             row['c14'] = datetime.now().date()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -29,8 +29,8 @@ from pixeltable.metadata.schema import Table, TableSchemaVersion, TableVersion
 from .conftest import clean_db
 from .utils import (
     SAMPLE_IMAGE_URL,
-    TESTS_DIR,
     get_audio_files,
+    get_documents,
     get_video_files,
     reload_catalog,
     rerun,
@@ -327,7 +327,7 @@ class TestMigration:
         if version >= 45:
             row['c9'] = get_audio_files()[0]
             row['c10'] = get_video_files()[0]
-            row['c11'] = TESTS_DIR / 'data' / 'documents' / 'pxtbrief.txt'
+            row['c11'] = get_documents()[0]
             row['c12'] = np.zeros((10,), dtype=np.float64)
             row['c13'] = uuid.uuid4()
             row['c14'] = datetime.now().date()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -29,8 +29,8 @@ from pixeltable.metadata.schema import Table, TableSchemaVersion, TableVersion
 from .conftest import clean_db
 from .utils import (
     SAMPLE_IMAGE_URL,
+    TESTS_DIR,
     get_audio_files,
-    get_documents,
     get_video_files,
     reload_catalog,
     rerun,
@@ -327,8 +327,7 @@ class TestMigration:
         if version >= 45:
             row['c9'] = get_audio_files()[0]
             row['c10'] = get_video_files()[0]
-            # TODO(PXT-1249): document_splitter does not currently support xml
-            row['c11'] = next(d for d in get_documents() if not d.endswith('.xml'))
+            row['c11'] = TESTS_DIR / 'data' / 'documents' / 'pxtbrief.txt'
             row['c12'] = np.zeros((10,), dtype=np.float64)
             row['c13'] = uuid.uuid4()
             row['c14'] = datetime.now().date()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -541,6 +541,7 @@ def get_audio_files(include_bad_audio: bool = False, extension: str | None = Non
         glob_result = [f for f in glob_result if 'bad_audio' not in f]
     if extension is not None:
         glob_result = [f for f in glob_result if f.endswith(extension)]
+    glob_result.sort()
     return glob_result
 
 
@@ -548,29 +549,37 @@ def get_audio_file(name: str) -> str | None:
     audio_dir = TESTS_DIR / 'data' / 'audio'
     file_path = audio_dir / name
     glob_result = glob.glob(f'{file_path}', recursive=True)
+    glob_result.sort()
     return glob_result.pop(0) if len(glob_result) > 0 else None
 
 
 def get_documents() -> list[str]:
     docs_dir = TESTS_DIR / 'data' / 'documents'
-    return glob.glob(f'{docs_dir}/*', recursive=True)
+    glob_result = glob.glob(f'{docs_dir}/*', recursive=True)
+    glob_result.sort()
+    return glob_result
 
 
 def get_csv_files() -> list[str]:
     csv_dir = TESTS_DIR / 'data' / 'csv'
-    return glob.glob(f'{csv_dir}/*', recursive=True)
+    glob_result = glob.glob(f'{csv_dir}/*', recursive=True)
+    glob_result.sort()
+    return glob_result
 
 
 def get_csv_file(name: str) -> str | None:
     csv_dir = TESTS_DIR / 'data' / 'csv'
     file_path = csv_dir / name
     glob_result = glob.glob(f'{file_path}', recursive=True)
+    glob_result.sort()
     return glob_result.pop(0) if len(glob_result) > 0 else None
 
 
 def get_json_files() -> list[str]:
     json_dir = TESTS_DIR / 'data' / 'json'
-    return glob.glob(f'{json_dir}/*', recursive=True)
+    glob_result = glob.glob(f'{json_dir}/*', recursive=True)
+    glob_result.sort()
+    return glob_result
 
 
 def get_json_file(name: str) -> str | None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -985,10 +985,11 @@ def rerun(**kwargs: Any) -> Callable:
 # one of these. Matched as substrings against the failure message.
 NETWORK_ERROR_PATTERNS = [
     '429',
+    '503',
     'Too Many Requests',
     'Connection reset',
     'Connection aborted',
-    'Max retries exceeded',
+    'Service unavailable',
     'timed out',
     'Timeout',
     'ExternalServiceError',


### PR DESCRIPTION
`base_table` in the db dump now has an iterator view with document splitter. Avoid inserting XML documents to `base_table` because document splitter does not yet support XML (https://pixeltable.atlassian.net/browse/PXT-1249), and doing so causes an `AssertionError`. 

The nature of `test_db_migration` failing on some platforms but not others may have to do with the order in which `glob.glob` returns matching files.