### PR TITLE
Update models used by deepseek test

### DIFF
--- a/docs/release/howto/providers/working-with-deepseek.ipynb
+++ b/docs/release/howto/providers/working-with-deepseek.ipynb
@@ -47,7 +47,15 @@
     "id": "AQ6_Py7_7d0r",
     "outputId": "f82cfe36-be9e-4d43-f13e-9f6f5b680e8e"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Deepseek API Key: ········\n"
+     ]
+    }
+   ],
    "source": [
     "import getpass\n",
     "import os\n",
@@ -78,14 +86,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to Pixeltable database at: postgresql+psycopg://postgres:@/pixeltable?host=/Users/asiegel/.pixeltable/pgdata\n",
+      "Connected to Pixeltable database at: postgresql+psycopg://postgres:@/pixeltable?host=/Users/sergeymkhitaryan/.pixeltable/pgdata\n",
       "Created directory 'deepseek_demo'.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<pixeltable.catalog.dir.Dir at 0x14c339cc0>"
+       "<pixeltable.catalog.dir.Dir at 0x31342ada0>"
       ]
      },
      "execution_count": 1,
@@ -128,7 +136,7 @@
      "output_type": "stream",
      "text": [
       "Created table 'chat'.\n",
-      "Added 0 column values with 0 errors in 0.01 s\n"
+      "Added 0 column values with 0 errors in 0.00 s\n"
      ]
     },
     {
@@ -151,7 +159,7 @@
     "\n",
     "msgs = [{'role': 'user', 'content': t.input}]\n",
     "t.add_computed_column(\n",
-    "    output=deepseek.chat_completions(messages=msgs, model='deepseek-chat')\n",
+    "    output=deepseek.chat_completions(messages=msgs, model='deepseek-v4-flash')\n",
     ")"
    ]
   },
@@ -205,7 +213,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inserted 1 row with 0 errors in 18.72 s (0.05 rows/s)\n"
+      "Inserted 1 row with 0 errors in 3.99 s (0.25 rows/s)\n"
      ]
     },
     {
@@ -221,21 +229,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>What was the outcome of the 1904 US Presidential election?</td>\n",
-       "      <td>The **1904 U.S. presidential election** resulted in a decisive victory for the **incumbent Republican President Theodore Roosevelt**, who was seeking a full term in his own right after succeeding the assassinated William McKinley in 1901.\n",
-       "\n",
-       "Here are the key details of the outcome:\n",
-       "\n",
-       "---\n",
-       "\n",
-       "### **Results at a Glance**\n",
-       "- **Winner:** **Theodore Roosevelt** (Republican)\n",
-       "- **Opponent:** **Alton B. Parker** (Democrat)\n",
-       "- **Electoral Vote:**  \n",
-       "  - Roosevelt: **336** electoral votes  \n",
-       "  - Parker: **140** ...... t by supporting William Howard Taft’s candidacy (though he later ran again in 1912 with the Bull Moose Party).\n",
-       "- The election solidified Roosevelt’s control of the Republican Party and marked the continued dominance of Republicans in national politics (they had won every presidential election since 1896 except 1912).\n",
-       "\n",
-       "In short, the 1904 election was a **major personal triumph for Theodore Roosevelt**, affirming his progressive leadership and giving him a powerful mandate for his second term.</td>\n",
+       "      <td>The 1904 United States presidential election resulted in a decisive victory for the incumbent Republican President Theodore Roosevelt. He defeated the Democratic nominee, Alton B. Parker, by a wide margin in both the popular vote (56.4% to 37.6%) and the Electoral College (336 to 140). Roosevelt&#x27;s win marked his first full term in office after succeeding the assassinated William McKinley in 1901.</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -245,7 +239,7 @@
        "0  What was the outcome of the 1904 US Presidenti...   \n",
        "\n",
        "                                            response  \n",
-       "0  The **1904 U.S. presidential election** result...  "
+       "0  The 1904 United States presidential election r...  "
       ]
      },
      "execution_count": 4,
@@ -284,7 +278,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "pxt",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -298,7 +292,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.19"
+   "version": "3.10.20"
   }
  },
  "nbformat": 4,

--- a/docs/release/howto/providers/working-with-deepseek.ipynb
+++ b/docs/release/howto/providers/working-with-deepseek.ipynb
@@ -159,7 +159,9 @@
     "\n",
     "msgs = [{'role': 'user', 'content': t.input}]\n",
     "t.add_computed_column(\n",
-    "    output=deepseek.chat_completions(messages=msgs, model='deepseek-v4-flash')\n",
+    "    output=deepseek.chat_completions(\n",
+    "        messages=msgs, model='deepseek-v4-flash'\n",
+    "    )\n",
     ")"
    ]
   },

--- a/pixeltable/functions/deepseek.py
+++ b/pixeltable/functions/deepseek.py
@@ -71,7 +71,7 @@ async def chat_completions(
         A dictionary containing the response and other metadata.
 
     Examples:
-        Add a computed column that applies the model `deepseek-chat` to an existing Pixeltable column `tbl.prompt`
+        Add a computed column that applies the model `deepseek-v4-flash` to an existing Pixeltable column `tbl.prompt`
         of the table `tbl`:
 
         >>> messages = [
@@ -79,7 +79,7 @@ async def chat_completions(
         ...     {'role': 'user', 'content': tbl.prompt},
         ... ]
         >>> tbl.add_computed_column(
-        ...     response=chat_completions(messages, model='deepseek-chat')
+        ...     response=chat_completions(messages, model='deepseek-v4-flash')
         ... )
     """
     if model_kwargs is None:

--- a/tests/functions/test_deepseek.py
+++ b/tests/functions/test_deepseek.py
@@ -36,7 +36,7 @@ class TestDeepseek:
                 },
             )
         )
-        t.add_computed_column(reasoning_output=chat_completions(model='deepseek-reasoner', messages=t.input_msgs))
+        t.add_computed_column(reasoning_output=chat_completions(model='deepseek-v4-flash', messages=t.input_msgs))
 
         validate_update_status(t.insert(input='What is the capital of France?'), 1)
         result = t.collect()

--- a/tests/functions/test_deepseek.py
+++ b/tests/functions/test_deepseek.py
@@ -18,11 +18,11 @@ class TestDeepseek:
         t = pxt.create_table('test_tbl', {'input': pxt.String})
         msgs = [{'role': 'system', 'content': 'You are a helpful assistant.'}, {'role': 'user', 'content': t.input}]
         t.add_computed_column(input_msgs=msgs)
-        t.add_computed_column(chat_output=chat_completions(model='deepseek-chat', messages=t.input_msgs))
+        t.add_computed_column(chat_output=chat_completions(model='deepseek-v4-flash', messages=t.input_msgs))
         # test a bunch of the parameters
         t.add_computed_column(
             chat_output_2=chat_completions(
-                model='deepseek-chat',
+                model='deepseek-v4-flash',
                 messages=msgs,
                 model_kwargs={
                     'frequency_penalty': 0.1,
@@ -36,10 +36,8 @@ class TestDeepseek:
                 },
             )
         )
-        t.add_computed_column(reasoning_output=chat_completions(model='deepseek-v4-flash', messages=t.input_msgs))
 
         validate_update_status(t.insert(input='What is the capital of France?'), 1)
         result = t.collect()
         assert 'paris' in result['chat_output'][0]['choices'][0]['message']['content'].lower()
         assert 'paris' in result['chat_output_2'][0]['choices'][0]['message']['content'].lower()
-        assert 'paris' in result['reasoning_output'][0]['choices'][0]['message']['content'].lower()

--- a/tool/perftest_providers.py
+++ b/tool/perftest_providers.py
@@ -91,7 +91,7 @@ def create_provider_configs(max_tokens: int) -> dict[str, ProviderConfig]:
         'deepseek': ProviderConfig(
             prompt_udf=create_chatgpt_prompt,
             udf=pxtf.deepseek.chat_completions,
-            default_model='deepseek-chat',
+            default_model='deepseek-v4-flash',
             kwargs={'model_kwargs': {'max_tokens': max_tokens, 'temperature': 0.7}},
         ),
         'bedrock': ProviderConfig(


### PR DESCRIPTION
`deepseek-reasoner` and `deepseek-chat` are both deprecated today, the suggested replacement is `deepseek-v4-flash`.