### PR TITLE
Add test timeouts

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -224,6 +224,8 @@ jobs:
           cd dashboard && npm install --silent && npm run build
       - name: Run the unit tests
         if: ${{ matrix.test-category == 'py' }}
+        # A timeout so that a hung test doesn't keep merge queue for hours
+        timeout-minutes: 90
         env:
           PXTTEST_CI_OS: ${{ matrix.os }}
           # Collect coverage for every unit-test configuration in scheduled runs. pytest-cov ensures xdist workers

--- a/tests/tool/test_db_dump_tool.py
+++ b/tests/tool/test_db_dump_tool.py
@@ -14,4 +14,5 @@ from ..utils import skip_test_if_not_installed
 class TestDbDumpTool:
     def test_db_dump_tool(self) -> None:
         skip_test_if_not_installed('transformers')
-        subprocess.run(('python', 'tool/create_test_db_dump.py'), check=True)
+        # A generous timeout to allow for a large HF download
+        subprocess.run(('python', 'tool/create_test_db_dump.py'), check=True, timeout=900)

--- a/tests/tool/test_db_dump_tool.py
+++ b/tests/tool/test_db_dump_tool.py
@@ -11,6 +11,7 @@ from ..utils import skip_test_if_not_installed
 @pytest.mark.skipif(platform.system() == 'Windows', reason='Tool is not supported on Windows')
 @pytest.mark.skipif(sysconfig.get_platform() == 'linux-aarch64', reason='Tool is not supported on Linux ARM')
 @pytest.mark.skipif(sys.version_info >= (3, 11), reason='Runs only on Python 3.10 (due to pickling issue)')
+@pytest.mark.very_expensive
 class TestDbDumpTool:
     def test_db_dump_tool(self) -> None:
         skip_test_if_not_installed('transformers')

--- a/tests/tool/test_perftest_tool.py
+++ b/tests/tool/test_perftest_tool.py
@@ -8,11 +8,14 @@ from ..utils import skip_test_if_no_client, skip_test_if_not_installed
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive  # Spawns a subprocess that runs a live LLM request
 class TestPerftestTool:
     def test_perftest_tool(self) -> None:
         skip_test_if_not_installed('openai')
         skip_test_if_not_installed('google.genai')
         skip_test_if_no_client('openai')
         subprocess.run(
-            ('python', '-m', 'tool.perftest_providers', '--provider', 'openai', '--n', '1', '--t', '10'), check=True
+            ('python', '-m', 'tool.perftest_providers', '--provider', 'openai', '--n', '1', '--t', '10'),
+            check=True,
+            timeout=120,
         )


### PR DESCRIPTION
* 90 minutes timeout to `pytest` step in CI so that a hung test doesn't block merge queue for hours (actual runtimes are 30-60 minutes)
* Added timeout args to `subprocess.run()` in some tests