### PR TITLE
stress-tests.yml: disable fail-fast

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   random-ops:
     strategy:
+      # A failure in one random-ops variant should not cancel the others
+      fail-fast: false
       matrix:
         options: [ '', '--read-only' ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
A failure in one random-ops variant should not cancel the others.

Other .yml files already have fail fast disabled.