### PR TITLE
fix: prevent infinite loop in char_limit document chunking when overlap >= limit

### DIFF
--- a/pixeltable/functions/document.py
+++ b/pixeltable/functions/document.py
@@ -559,7 +559,10 @@ class document_splitter(pxt.PxtIterator):
                 end_idx = min(start_idx + self._limit, len(section.text))
                 text = section.text[start_idx:end_idx]
                 yield DocumentSection(text=text, metadata=section.metadata)
-                start_idx += self._limit - self._overlap
+                # Ensure we make progress: when overlap >= limit the step would
+                # be <= 0 and the loop would never terminate (_token_chunks has
+                # the same guard).
+                start_idx += max(1, self._limit - self._overlap)
 
     @classmethod
     def validate(cls, bound_args: dict[str, Any]) -> None:


### PR DESCRIPTION
### Bug

`DocumentSplitter._char_chunks` (`pixeltable/functions/document.py`) advances its window with:

```python
start_idx += self._limit - self._overlap
```

There is no lower bound on the step, so when `overlap >= limit` the step is `<= 0`, `start_idx` never advances, and the chunking loop never terminates (an infinite loop / hang).

`validate()` only checks `limit > 0` and `overlap >= 0`, so `overlap == limit` (and `overlap > limit`) pass validation and reach this loop. For example, `document_splitter(doc, separators='char_limit', limit=100, overlap=100)` hangs.

The token path already guards against exactly this:

```python
# _token_chunks
start_idx = max(start_idx + 1, end_idx - self._overlap)  # ensure we make progress
```

but `_char_chunks` does not.

### Fix

Give `_char_chunks` the same progress guarantee:

```python
start_idx += max(1, self._limit - self._overlap)
```

Normal configs (`overlap < limit`) are unchanged; `overlap >= limit` now steps by 1 instead of hanging.

### Verification

Reproduced the loop in isolation on the text `"abcdefghij"`:

| limit / overlap | before | after |
|---|---|---|
| 5 / 2 | `['abcde','defgh','ghij','j']` | same (unchanged) |
| 5 / 5 | **infinite loop** | `['abcde','bcdef',...]` |
| 3 / 5 | **infinite loop** | terminates |

The document tests are integration tests that need the full runtime, so I verified the loop logic directly rather than adding a heavy integration test. Happy to add one if you'd prefer.
