### PR TITLE
Use the RPC timeout for the direct-HTTP proxy transport

### DIFF
--- a/pixeltable/service/proxy_client.py
+++ b/pixeltable/service/proxy_client.py
@@ -88,6 +88,12 @@ class Transport(abc.ABC):
         """Release any transport resources."""
 
 
+_CONNECT_TIMEOUT = 30.0
+# An RPC runs a catalog operation to completion server-side (inserts, computed-column population, drops of
+# tables with many media files), so this bounds job execution, not request latency.
+_RPC_TIMEOUT = 1800.0
+
+
 class HttpTransport(Transport):
     """Direct HTTP to a reachable proxy daemon endpoint."""
 
@@ -96,7 +102,7 @@ class HttpTransport(Transport):
 
     def __init__(self, endpoint: str):
         self._endpoint = endpoint
-        self._http = httpx.Client(base_url=endpoint, timeout=httpx.Timeout(120.0))
+        self._http = httpx.Client(base_url=endpoint, timeout=httpx.Timeout(_RPC_TIMEOUT, connect=_CONNECT_TIMEOUT))
 
     def post(self, body: bytes) -> bytes:
         response = self._http.post('/rpc', content=body, headers={'Content-Type': 'application/octet-stream'})
@@ -113,8 +119,6 @@ class HttpTransport(Transport):
         self._http.close()
 
 
-_CONNECT_TIMEOUT = 30.0
-_RPC_TIMEOUT = 1800.0
 _MAX_POOL_SIZE = 16  # matches the fetch_media download threadpool
 
 # The server can restart and drop the connection mid-call; retry transient transport failures with backoff.

--- a/pixeltable/service/proxy_client.py
+++ b/pixeltable/service/proxy_client.py
@@ -88,12 +88,6 @@ class Transport(abc.ABC):
         """Release any transport resources."""
 
 
-_CONNECT_TIMEOUT = 30.0
-# An RPC runs a catalog operation to completion server-side (inserts, computed-column population, drops of
-# tables with many media files), so this bounds job execution, not request latency.
-_RPC_TIMEOUT = 1800.0
-
-
 class HttpTransport(Transport):
     """Direct HTTP to a reachable proxy daemon endpoint."""
 
@@ -119,6 +113,8 @@ class HttpTransport(Transport):
         self._http.close()
 
 
+_CONNECT_TIMEOUT = 30.0
+_RPC_TIMEOUT = 1800.0
 _MAX_POOL_SIZE = 16  # matches the fetch_media download threadpool
 
 # The server can restart and drop the connection mid-call; retry transient transport failures with backoff.


### PR DESCRIPTION
Synchronize `HttpTransport`'s and `TunnelTransport`'s timeouts.