### PR TITLE
Pixeltable daemon logs at DEBUG during tests

### DIFF
--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -267,7 +267,7 @@ def configure_test_logging(db: str) -> None:
     ep = endpoint(db)
     if ep is None:
         raise excs.Error(excs.ErrorCode.INTERNAL_ERROR, f'No running proxy daemon for {db!r}')
-    response = httpx.post(f'{ep}/configure_test_logging', timeout=1.0)
+    response = httpx.post(f'{ep}/configure_test_logging', timeout=10.0)
     response.raise_for_status()
 
 

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -14,6 +14,7 @@ a given database, and locating a running one via the port.lock file in its home 
 
 import atexit
 import json
+import logging
 import os
 import shutil
 import signal
@@ -38,6 +39,9 @@ from .proxy_protocol import decode_body, encode_body
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+
+# Logger name is spelled out because __name__ here is '__main__' when daemon runs.
+_logger = logging.getLogger('pixeltable.service.proxy_daemon')
 
 _LOCK_NAME = 'port.lock'
 _STARTUP_TIMEOUT = 60.0  # generous: the daemon creates/migrates its db on first init
@@ -258,6 +262,15 @@ def reinitialize(db: str) -> None:
     response.raise_for_status()
 
 
+def configure_test_logging(db: str) -> None:
+    """Test only. Switch the running daemon's logging for test."""
+    ep = endpoint(db)
+    if ep is None:
+        raise excs.Error(excs.ErrorCode.INTERNAL_ERROR, f'No running proxy daemon for {db!r}')
+    response = httpx.post(f'{ep}/configure_test_logging', timeout=1.0)
+    response.raise_for_status()
+
+
 def delete(db: str) -> None:
     """Stop the daemon, drop its database, and remove its home directory."""
     stop(db)
@@ -273,6 +286,16 @@ def _reinitialize() -> None:
     """
     reset_runtime()
     pxt.init()
+
+
+def _configure_test_logging() -> None:
+    """Test only. Runs inside the daemon process.
+
+    Log at DEBUG, matching the local test behavior.
+    """
+    for name in ('pixeltable', 'sqlalchemy.engine'):
+        logging.getLogger(name).setLevel(logging.DEBUG)
+    _logger.info('Test only: logging at DEBUG')
 
 
 def _drop_database(db: str) -> None:
@@ -323,6 +346,11 @@ def _build_app() -> 'FastAPI':
         await run_in_threadpool(_reinitialize)
         return Response(content='{"status": "ok"}', media_type='application/json')
 
+    @app.post('/configure_test_logging')
+    async def configure_test_logging_endpoint() -> Response:
+        _configure_test_logging()
+        return Response(content='{"status": "ok"}', media_type='application/json')
+
     @app.get('/health')
     def health() -> dict[str, str]:
         return {'status': 'ok'}
@@ -371,9 +399,13 @@ def _serve() -> None:
     daemon_host = config.get_string_value('daemon_host')
     daemon_port = config.get_int_value('daemon_port')
 
+    # log_config=None suppresses uvicorn's own logging setup which results in closing every handler registered so far.
+    # Note: uvicorn logging is configured separately during Env set up. 
     log_level = (config.get_string_value('log_level') or 'info').lower()
     if daemon_host is not None or daemon_port is not None:
-        uvicorn.run(app, host=daemon_host or '127.0.0.1', port=daemon_port or 8000, log_level=log_level)
+        uvicorn.run(
+            app, host=daemon_host or '127.0.0.1', port=daemon_port or 8000, log_level=log_level, log_config=None
+        )
         return
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -391,7 +423,7 @@ def _serve() -> None:
     atexit.register(lambda: lock.unlink(missing_ok=True))
     signal.signal(signal.SIGTERM, _cleanup)
 
-    uvicorn.Server(uvicorn.Config(app, log_level='warning')).run(sockets=[sock])
+    uvicorn.Server(uvicorn.Config(app, log_level='warning', log_config=None)).run(sockets=[sock])
 
 
 if __name__ == '__main__':

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -366,7 +366,6 @@ def _serve(test_mode: bool = False) -> None:
     # mark this process as a hosted-catalog server (no client-accessible local store) before the catalog inits
     os.environ['PIXELTABLE_PROXY_DAEMON'] = '1'
     if test_mode:
-        _logger.info('Test mode enabled')
         # Enable verbose logging
         for name in ('pixeltable', 'sqlalchemy.engine'):
             logging.getLogger(name).setLevel(logging.DEBUG)
@@ -412,7 +411,10 @@ def _serve(test_mode: bool = False) -> None:
     atexit.register(lambda: lock.unlink(missing_ok=True))
     signal.signal(signal.SIGTERM, _cleanup)
 
-    log_level = 'debug' if test_mode else 'warning'
+    log_level = 'warning'
+    if test_mode:
+        log_level = 'debug'
+        _logger.info('Test mode enabled')
     uvicorn.Server(uvicorn.Config(app, log_level=log_level, log_config=None)).run(sockets=[sock])
 
 

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -40,9 +40,6 @@ from .proxy_protocol import decode_body, encode_body
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-# Logger name is spelled out because __name__ is '__main__'
-_logger = logging.getLogger('pixeltable.service.proxy_daemon')
-
 _LOCK_NAME = 'port.lock'
 _STARTUP_TIMEOUT = 60.0  # generous: the daemon creates/migrates its db on first init
 _STOP_TIMEOUT = 10.0

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -400,7 +400,7 @@ def _serve() -> None:
     daemon_port = config.get_int_value('daemon_port')
 
     # log_config=None suppresses uvicorn's own logging setup which results in closing every handler registered so far.
-    # Note: uvicorn logging is configured separately during Env set up. 
+    # Note: uvicorn logging is configured separately during Env set up.
     log_level = (config.get_string_value('log_level') or 'info').lower()
     if daemon_host is not None or daemon_port is not None:
         uvicorn.run(

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -263,7 +263,7 @@ def reinitialize(db: str) -> None:
 
 
 def configure_test_logging(db: str) -> None:
-    """Test only. Switch the running daemon's logging for test."""
+    """Test only. Switch the running daemon's logging for tests."""
     ep = endpoint(db)
     if ep is None:
         raise excs.Error(excs.ErrorCode.INTERNAL_ERROR, f'No running proxy daemon for {db!r}')

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -387,9 +387,14 @@ def _serve(test_mode: bool = False) -> None:
     daemon_host = config.get_string_value('daemon_host')
     daemon_port = config.get_int_value('daemon_port')
 
+    log_level = 'info'
+    if config.get_string_value('log_level') is not None:
+        log_level = config.get_string_value('log_level').lower()
+    elif test_mode:
+        log_level = 'debug'
+
     # log_config=None suppresses uvicorn's own logging setup which results in closing every handler registered so far.
     # Note: at this point, uvicorn logging has already been configured by Env.
-    log_level = (config.get_string_value('log_level') or 'info').lower()
     if daemon_host is not None or daemon_port is not None:
         uvicorn.run(
             app, host=daemon_host or '127.0.0.1', port=daemon_port or 8000, log_level=log_level, log_config=None
@@ -411,10 +416,6 @@ def _serve(test_mode: bool = False) -> None:
     atexit.register(lambda: lock.unlink(missing_ok=True))
     signal.signal(signal.SIGTERM, _cleanup)
 
-    log_level = 'warning'
-    if test_mode:
-        log_level = 'debug'
-        _logger.info('Test mode enabled')
     uvicorn.Server(uvicorn.Config(app, log_level=log_level, log_config=None)).run(sockets=[sock])
 
 

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -385,8 +385,9 @@ def _serve(test_mode: bool = False) -> None:
     daemon_port = config.get_int_value('daemon_port')
 
     log_level = 'info'
-    if config.get_string_value('log_level') is not None:
-        log_level = config.get_string_value('log_level').lower()
+    configured_log_level = config.get_string_value('log_level')
+    if configured_log_level is not None:
+        log_level = configured_log_level.lower()
     elif test_mode:
         log_level = 'debug'
 

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -40,7 +40,7 @@ from .proxy_protocol import decode_body, encode_body
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-# Logger name is spelled out because __name__ here is '__main__' when daemon runs.
+# Logger name is spelled out because __name__ is '__main__'
 _logger = logging.getLogger('pixeltable.service.proxy_daemon')
 
 _LOCK_NAME = 'port.lock'
@@ -159,8 +159,12 @@ def create(db: str) -> None:
     proxy_home(db).mkdir(parents=True, exist_ok=True)
 
 
-def start(db: str) -> str:
-    """Ensure a daemon for db is running and ready; return its endpoint."""
+def start(db: str, test_mode: bool = False) -> str:
+    """Ensure a daemon for db is running and ready; return its endpoint.
+
+    test_mode starts the daemon with --test (DEBUG logging + test-only endpoints). It only takes effect if this
+    call actually launches the daemon; an already-running one is returned as is.
+    """
     create(db)
     ep = endpoint(db)
     if ep is not None and _health_ok(ep):
@@ -181,14 +185,12 @@ def start(db: str) -> str:
     log_dir = proxy_home(db) / 'logs'
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / 'daemon.log'
+    argv = [sys.executable, '-m', 'pixeltable.service.proxy_daemon']
+    if test_mode:
+        argv.append('--test')
     with open(log_path, 'a', encoding='utf-8') as log_file:
         proc = subprocess.Popen(
-            [sys.executable, '-m', 'pixeltable.service.proxy_daemon'],
-            env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
+            argv, env=env, stdin=subprocess.DEVNULL, stdout=log_file, stderr=subprocess.STDOUT, start_new_session=True
         )
 
     deadline = time.monotonic() + _STARTUP_TIMEOUT
@@ -262,15 +264,6 @@ def reinitialize(db: str) -> None:
     response.raise_for_status()
 
 
-def configure_test_logging(db: str) -> None:
-    """Test only. Switch the running daemon's logging for tests."""
-    ep = endpoint(db)
-    if ep is None:
-        raise excs.Error(excs.ErrorCode.INTERNAL_ERROR, f'No running proxy daemon for {db!r}')
-    response = httpx.post(f'{ep}/configure_test_logging', timeout=10.0)
-    response.raise_for_status()
-
-
 def delete(db: str) -> None:
     """Stop the daemon, drop its database, and remove its home directory."""
     stop(db)
@@ -286,16 +279,6 @@ def _reinitialize() -> None:
     """
     reset_runtime()
     pxt.init()
-
-
-def _configure_test_logging() -> None:
-    """Test only. Runs inside the daemon process.
-
-    Log at DEBUG, matching the local test behavior.
-    """
-    for name in ('pixeltable', 'sqlalchemy.engine'):
-        logging.getLogger(name).setLevel(logging.DEBUG)
-    _logger.info('Test only: logging at DEBUG')
 
 
 def _drop_database(db: str) -> None:
@@ -317,8 +300,10 @@ def _drop_database(db: str) -> None:
         engine.dispose()
 
 
-def _build_app() -> 'FastAPI':
+def _build_app(test_mode: bool = False) -> 'FastAPI':
     """The app served by the daemon: a /rpc endpoint running the generic dispatch and a /health endpoint.
+
+    test_mode enables the test-only endpoints.
 
     fastapi is imported here rather than at module level because it is an optional dependency, needed
     only when the daemon is actually served.
@@ -340,16 +325,13 @@ def _build_app() -> 'FastAPI':
             content=encode_body(response_json.encode(), response_parts), media_type='application/octet-stream'
         )
 
-    @app.post('/reinitialize')
-    async def reinitialize_endpoint() -> Response:
-        # _reinitialize() rebuilds the runtime, which is synchronous; keep it off the event loop
-        await run_in_threadpool(_reinitialize)
-        return Response(content='{"status": "ok"}', media_type='application/json')
+    if test_mode:
 
-    @app.post('/configure_test_logging')
-    async def configure_test_logging_endpoint() -> Response:
-        _configure_test_logging()
-        return Response(content='{"status": "ok"}', media_type='application/json')
+        @app.post('/reinitialize')
+        async def reinitialize_endpoint() -> Response:
+            # _reinitialize() rebuilds the runtime, which is synchronous; keep it off the event loop
+            await run_in_threadpool(_reinitialize)
+            return Response(content='{"status": "ok"}', media_type='application/json')
 
     @app.get('/health')
     def health() -> dict[str, str]:
@@ -369,7 +351,7 @@ def _build_app() -> 'FastAPI':
     return app
 
 
-def _serve() -> None:
+def _serve(test_mode: bool = False) -> None:
     """Daemon entrypoint.
 
     Local mode (default): binds to a random loopback port, writes a port.lock file
@@ -378,9 +360,16 @@ def _serve() -> None:
     Fixed-address mode: when PIXELTABLE_DAEMON_HOST or PIXELTABLE_DAEMON_PORT is set,
     binds to that address and port instead and skips the lock file. Used when an
     external orchestrator (e.g. a sidecar) handles routing and discovery.
+
+    test_mode: logs at DEBUG and exposes the test-only endpoints.
     """
     # mark this process as a hosted-catalog server (no client-accessible local store) before the catalog inits
     os.environ['PIXELTABLE_PROXY_DAEMON'] = '1'
+    if test_mode:
+        _logger.info('Test mode enabled')
+        # Enable verbose logging
+        for name in ('pixeltable', 'sqlalchemy.engine'):
+            logging.getLogger(name).setLevel(logging.DEBUG)
     try:
         import uvicorn
     except ModuleNotFoundError as e:
@@ -390,7 +379,7 @@ def _serve() -> None:
             'Install them with: pip install pixeltable[serve]',
         ) from e
 
-    app = _build_app()
+    app = _build_app(test_mode)
 
     # eagerly create/migrate this daemon's database before announcing readiness
     _ = get_runtime().catalog
@@ -400,7 +389,7 @@ def _serve() -> None:
     daemon_port = config.get_int_value('daemon_port')
 
     # log_config=None suppresses uvicorn's own logging setup which results in closing every handler registered so far.
-    # Note: uvicorn logging is configured separately during Env set up.
+    # Note: at this point, uvicorn logging has already been configured by Env.
     log_level = (config.get_string_value('log_level') or 'info').lower()
     if daemon_host is not None or daemon_port is not None:
         uvicorn.run(
@@ -423,8 +412,10 @@ def _serve() -> None:
     atexit.register(lambda: lock.unlink(missing_ok=True))
     signal.signal(signal.SIGTERM, _cleanup)
 
-    uvicorn.Server(uvicorn.Config(app, log_level='warning', log_config=None)).run(sockets=[sock])
+    log_level = 'debug' if test_mode else 'warning'
+    uvicorn.Server(uvicorn.Config(app, log_level=log_level, log_config=None)).run(sockets=[sock])
 
 
 if __name__ == '__main__':
-    _serve()
+    test_mode = '--test' in sys.argv[1:]
+    _serve(test_mode=test_mode)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,8 +285,7 @@ def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
     from pixeltable.service import proxy_daemon
 
     db = _worker_db_name(worker_id)
-    proxy_daemon.start(db)
-    proxy_daemon.configure_test_logging(db)
+    proxy_daemon.start(db, test_mode=True)
     try:
         yield db
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,6 +286,7 @@ def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
 
     db = _worker_db_name(worker_id)
     proxy_daemon.start(db)
+    proxy_daemon.configure_test_logging(db)
     try:
         yield db
     finally:


### PR DESCRIPTION
new `--test` cli arg enables DEBUG logging and the `/reinitialize` endpoint.

Motivation for more verbose logging is to help investigate daemon getting stuck e.g. https://github.com/pixeltable/pixeltable/actions/runs/31444605474/job/93636063420