### PR TITLE
[PXT-1286] Pxt CLI Cluster Commands

### DIFF
--- a/pixeltable/service/management_protocol.py
+++ b/pixeltable/service/management_protocol.py
@@ -34,6 +34,12 @@ class ServiceOperationType(str, Enum):
     UPDATE_RUNTIME = 'update_runtime'
     GET_BUNDLE_UPLOAD_URL = 'get_bundle_upload_url'
 
+    CREATE_DB_CLUSTER = 'create_db_cluster'
+    GET_DB_CLUSTER = 'get_db_cluster'
+    LIST_DB_CLUSTERS = 'list_db_clusters'
+    UPDATE_DB_CLUSTER = 'update_db_cluster'
+    DELETE_DB_CLUSTER = 'delete_db_cluster'
+
     LIST_ORGS = 'list_orgs'
 
     SET_SECRET = 'set_secret'
@@ -69,6 +75,7 @@ class CreateDbRequest(BaseModel):
     db_name: Optional[str] = None
     location: Optional[str] = None
     region: Optional[str] = None
+    cluster: Optional[str] = None  # dedicated db cluster to place the database on (paid orgs)
     cpu: float = 0.5
     memory_mb: int = 512
     disk_gb: int = 10
@@ -136,6 +143,47 @@ class GetBundleUploadUrlRequest(BaseModel):
 class GetBundleUploadUrlResponse(BaseModel):
     presigned_url: str
     bundle_s3_key: str
+
+
+# Db clusters (dedicated PlanetScale clusters owned by paid orgs; databases are placed on them)
+
+
+class CreateDbClusterRequest(BaseModel):
+    operation_type: Literal[ServiceOperationType.CREATE_DB_CLUSTER] = ServiceOperationType.CREATE_DB_CLUSTER
+    org: Optional[str] = None
+    cluster: str
+    size: str  # PlanetScale cluster size, e.g. 'PS_10', 'PS_80'
+    region: Optional[str] = None
+
+    @field_validator('cluster')
+    @classmethod
+    def _validate_cluster_name(cls, value: str) -> str:
+        return _validate_hosted_name(value, 'Cluster name')
+
+
+class GetDbClusterRequest(BaseModel):
+    operation_type: Literal[ServiceOperationType.GET_DB_CLUSTER] = ServiceOperationType.GET_DB_CLUSTER
+    org: Optional[str] = None
+    cluster: str
+
+
+class ListDbClustersRequest(BaseModel):
+    operation_type: Literal[ServiceOperationType.LIST_DB_CLUSTERS] = ServiceOperationType.LIST_DB_CLUSTERS
+    org: Optional[str] = None
+
+
+class UpdateDbClusterRequest(BaseModel):
+    operation_type: Literal[ServiceOperationType.UPDATE_DB_CLUSTER] = ServiceOperationType.UPDATE_DB_CLUSTER
+    org: Optional[str] = None
+    cluster: str
+    size: str  # target PlanetScale cluster size
+
+
+class DeleteDbClusterRequest(BaseModel):
+    operation_type: Literal[ServiceOperationType.DELETE_DB_CLUSTER] = ServiceOperationType.DELETE_DB_CLUSTER
+    org: Optional[str] = None
+    cluster: str
+    force: bool = False  # also delete every database on the cluster
 
 
 # Secrets

--- a/pixeltable_cli/client/commands/cluster.py
+++ b/pixeltable_cli/client/commands/cluster.py
@@ -1,0 +1,127 @@
+"""`pxt cluster {create,list,status,update,delete}` - manage dedicated db clusters (paid orgs)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from ..hosted import exit_unless_reached, parse_org_uri, poll_cluster, print_cluster
+from ..parser import Parser
+from ..utils import get_request, post_request
+
+EPILOG = """\
+Examples:
+  pxt cluster create pxt://org mycluster --size PS_10
+  pxt cluster list pxt://org
+  pxt cluster status pxt://org mycluster
+  pxt cluster update pxt://org mycluster --size PS_40
+  pxt cluster delete pxt://org mycluster
+  pxt cluster delete pxt://org mycluster --force
+"""
+
+
+def run(argv: list[str]) -> None:
+    parser = Parser(prog='pxt cluster', description='manage dedicated db clusters', epilog=EPILOG)
+    sub = parser.add_subparsers(dest='action', required=True)
+
+    p = sub.add_parser('create', help='create a dedicated db cluster')
+    p.add_argument('org_uri', help='Org URI: pxt://org')
+    p.add_argument('name', help='Cluster name, unique within the org')
+    p.add_argument('--size', required=True, help="PlanetScale cluster size, e.g. 'PS_10'")
+    p.add_argument('--region', default=None, help='Region (default: us-east)')
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    p = sub.add_parser('list', help='list db clusters for an org')
+    p.add_argument('org_uri', help='Org URI: pxt://org')
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    p = sub.add_parser('status', help='show status of a db cluster')
+    p.add_argument('org_uri', help='Org URI: pxt://org')
+    p.add_argument('name', help='Cluster name')
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    p = sub.add_parser('update', help='resize a db cluster')
+    p.add_argument('org_uri', help='Org URI: pxt://org')
+    p.add_argument('name', help='Cluster name')
+    p.add_argument('--size', required=True, help="target PlanetScale cluster size, e.g. 'PS_40'")
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    p = sub.add_parser('delete', help='delete a db cluster')
+    p.add_argument('org_uri', help='Org URI: pxt://org')
+    p.add_argument('name', help='Cluster name')
+    p.add_argument('--force', action='store_true', help='also delete every database on the cluster')
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    args = parser.parse_args(argv)
+
+    if args.action == 'create':
+        _create(args)
+    elif args.action == 'list':
+        _list(args)
+    elif args.action == 'status':
+        _status(args)
+    elif args.action == 'update':
+        _update(args)
+    elif args.action == 'delete':
+        _delete(args)
+
+
+def _create(args: argparse.Namespace) -> None:
+    org = parse_org_uri(args.org_uri, prog='pxt cluster create')
+    body = {'org': org, 'cluster': args.name, 'size': args.size}
+    if args.region is not None:
+        body['region'] = args.region
+    resp = post_request('/api/clusters', body)
+    result = resp.get('cluster', resp) if isinstance(resp, dict) else {}
+    if result.get('state') == 'PROVISIONING':
+        result = poll_cluster(org, args.name, {'PROVISIONING'}, f"Cluster '{args.name}' is provisioning...")
+    if args.json_output:
+        print(json.dumps(result))
+    else:
+        print_cluster(result)
+    exit_unless_reached(result, 'ACTIVE', f'creating cluster {args.name!r}')
+
+
+def _list(args: argparse.Namespace) -> None:
+    org = parse_org_uri(args.org_uri, prog='pxt cluster list')
+    resp = get_request('/api/clusters', {'org': org})
+    clusters = resp.get('clusters', []) if isinstance(resp, dict) else []
+    if args.json_output:
+        print(json.dumps(clusters))
+    elif not clusters:
+        print('No clusters.')
+    else:
+        for cluster in clusters:
+            print_cluster(cluster)
+
+
+def _status(args: argparse.Namespace) -> None:
+    org = parse_org_uri(args.org_uri, prog='pxt cluster status')
+    resp = get_request('/api/cluster', {'org': org, 'cluster': args.name})
+    result = resp.get('cluster', resp) if isinstance(resp, dict) else {}
+    if args.json_output:
+        print(json.dumps(result))
+    else:
+        print_cluster(result)
+
+
+def _update(args: argparse.Namespace) -> None:
+    org = parse_org_uri(args.org_uri, prog='pxt cluster update')
+    resp = post_request('/api/cluster/update', {'org': org, 'cluster': args.name, 'size': args.size})
+    result = resp.get('cluster', resp) if isinstance(resp, dict) else {}
+    if result.get('state') == 'RESIZING':
+        result = poll_cluster(org, args.name, {'RESIZING'}, f"Cluster '{args.name}' is resizing...")
+    if args.json_output:
+        print(json.dumps(result))
+    else:
+        print_cluster(result)
+    exit_unless_reached(result, 'ACTIVE', f'resizing cluster {args.name!r}')
+
+
+def _delete(args: argparse.Namespace) -> None:
+    org = parse_org_uri(args.org_uri, prog='pxt cluster delete')
+    post_request('/api/cluster/delete', {'org': org, 'cluster': args.name, 'force': args.force})
+    if args.json_output:
+        print(json.dumps({'deleted': args.name}))
+    else:
+        print(f"Deleted cluster '{args.name}'.")

--- a/pixeltable_cli/client/commands/db.py
+++ b/pixeltable_cli/client/commands/db.py
@@ -42,6 +42,7 @@ def run(argv: list[str]) -> None:
     p.add_argument('db_uri', nargs='?', help='Database URI: pxt://org:db (default: db_uri from the config)')
     p.add_argument('--location', default='aws', help='Cloud provider (default: aws)')
     p.add_argument('--region', default='us-east-1', help='Region (default: us-east-1)')
+    p.add_argument('--cluster', default=None, help="dedicated db cluster to place the database on (default: 'default')")
     p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
 
     p = sub.add_parser('list', help='list hosted databases for an org')
@@ -104,7 +105,10 @@ def run(argv: list[str]) -> None:
 
 def _create(args: argparse.Namespace) -> None:
     org, db = resolve_db_uri(args.db_uri, prog='pxt db create')
-    resp = post_request('/api/dbs', {'org': org, 'db': db, 'location': args.location, 'region': args.region})
+    body = {'org': org, 'db': db, 'location': args.location, 'region': args.region}
+    if args.cluster is not None:
+        body['cluster'] = args.cluster
+    resp = post_request('/api/dbs', body)
     result = resp.get('database', resp) if isinstance(resp, dict) else {}
     if result.get('state') == 'PROVISIONING':
         result = poll_db(org, db, {'PROVISIONING'}, f"Database '{db}' is provisioning...")

--- a/pixeltable_cli/client/hosted.py
+++ b/pixeltable_cli/client/hosted.py
@@ -20,6 +20,9 @@ SVC_POLL_INTERVAL = 5
 SVC_POLL_TIMEOUT = 300
 RUNTIME_POLL_INTERVAL = 10
 RUNTIME_POLL_TIMEOUT = 900
+# cluster provisioning takes ~2-4 min; a size resize plus its parameter retune can run ~10 min
+CLUSTER_POLL_INTERVAL = 10
+CLUSTER_POLL_TIMEOUT = 1200
 
 
 def parse_db_uri(uri: str, prog: str = 'pxt') -> tuple[str, str]:
@@ -115,8 +118,10 @@ def print_db(db: dict[str, Any]) -> None:
     state = db.get('state', '')
     location = db.get('location', '')
     region = db.get('region', '')
+    cluster = db.get('cluster') or ''
+    cluster_str = f'cluster={cluster}  ' if cluster else ''
     endpoint = db.get('endpoint') or ''
-    print(f'{name}  state={state}  {location}/{region}  {endpoint}'.rstrip())
+    print(f'{name}  state={state}  {cluster_str}{location}/{region}  {endpoint}'.rstrip())
     _print_workers(db.get('workers') or [])
 
 
@@ -224,6 +229,29 @@ def poll_db(org: str, db: str, pending_states: set[str], label: str | None) -> d
     return poll_state(
         '/api/db', {'org': org, 'db': db}, 'database', pending_states, DB_POLL_INTERVAL, DB_POLL_TIMEOUT, label
     )
+
+
+def poll_cluster(org: str, cluster: str, pending_states: set[str], label: str | None) -> dict[str, Any]:
+    """Poll a db cluster until its state leaves pending_states."""
+    return poll_state(
+        '/api/cluster',
+        {'org': org, 'cluster': cluster},
+        'cluster',
+        pending_states,
+        CLUSTER_POLL_INTERVAL,
+        CLUSTER_POLL_TIMEOUT,
+        label,
+    )
+
+
+def print_cluster(cluster: dict[str, Any]) -> None:
+    name = cluster.get('name', '')
+    state = cluster.get('state', '')
+    size = cluster.get('size', '')
+    region = cluster.get('region', '')
+    databases = cluster.get('database_count', 0)
+    max_databases = cluster.get('max_databases', 0)
+    print(f'{name}  state={state}  size={size}  region={region}  databases={databases}/{max_databases}')
 
 
 def poll_svc(org: str, db: str, svc_name: str, pending_states: set[str], label: str | None) -> dict[str, Any]:

--- a/pixeltable_cli/client/main.py
+++ b/pixeltable_cli/client/main.py
@@ -33,6 +33,7 @@ COMMANDS: dict[str, str] = {
     'localproxy': 'manage local proxy daemons (create/start/stop/delete)',
     'dashboard': 'print and open the dashboard URL',
     'db': 'manage hosted databases (create/list/status/start/stop/update/update-runtime/delete)',
+    'cluster': 'manage dedicated db clusters (create/list/status/update/delete)',
     'service': 'manage hosted services (create/update/list/status/start/stop/delete)',
     'org': 'manage organizations (list/status)',
 }

--- a/pixeltable_cli/server/routes.py
+++ b/pixeltable_cli/server/routes.py
@@ -16,13 +16,17 @@ from pixeltable.config import Config
 from pixeltable.env import Env
 from pixeltable.service import management_client
 from pixeltable.service.management_protocol import (
+    CreateDbClusterRequest,
     CreateDbRequest,
     CreateServiceRequest,
+    DeleteDbClusterRequest,
     DeleteDbRequest,
     DeleteServiceRequest,
     GetBundleUploadUrlRequest,
+    GetDbClusterRequest,
     GetDbRequest,
     GetServiceRequest,
+    ListDbClustersRequest,
     ListDbRequest,
     ListOrgsRequest,
     ListServicesRequest,
@@ -30,6 +34,7 @@ from pixeltable.service.management_protocol import (
     StartServiceRequest,
     StopDbRequest,
     StopServiceRequest,
+    UpdateDbClusterRequest,
     UpdateDbRequest,
     UpdateRuntimeRequest,
     UpdateServiceRequest,
@@ -749,6 +754,33 @@ def get_upload_url(req: Request) -> dict[str, Any]:
 @router.post('/api/db/update-runtime')
 def trigger_runtime_update(req: Request) -> dict[str, Any]:
     return management_client.api_call(req.body(UpdateRuntimeRequest))
+
+
+@router.get('/api/clusters')
+def list_db_clusters(req: Request) -> dict[str, Any]:
+    return management_client.api_call(ListDbClustersRequest(org=req.required_query_str('org')))
+
+
+@router.post('/api/clusters')
+def create_db_cluster(req: Request) -> dict[str, Any]:
+    return management_client.api_call(req.body(CreateDbClusterRequest))
+
+
+@router.get('/api/cluster')
+def get_db_cluster(req: Request) -> dict[str, Any]:
+    return management_client.api_call(
+        GetDbClusterRequest(org=req.required_query_str('org'), cluster=req.required_query_str('cluster'))
+    )
+
+
+@router.post('/api/cluster/update')
+def update_db_cluster(req: Request) -> dict[str, Any]:
+    return management_client.api_call(req.body(UpdateDbClusterRequest))
+
+
+@router.post('/api/cluster/delete')
+def delete_db_cluster(req: Request) -> dict[str, Any]:
+    return management_client.api_call(req.body(DeleteDbClusterRequest))
 
 
 @router.get('/api/services')


### PR DESCRIPTION
Adds a pxt cluster command group (create, list, status, update, delete) for managing dedicated db clusters owned by paid orgs. Create and update poll until the cluster reaches a stable state, same as pxt db.

pxt db create gains a --cluster option to place a new database on a dedicated cluster, and db status output now shows the cluster a database lives on.

Client side only: the CLI and local server routes forward the new cluster operations to the control plane.