### PR TITLE
Exclude most integration tests from merge queue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,7 +302,7 @@ testpaths = ["tests"]
 addopts = '-v -m "not remote_api and not expensive and not very_expensive and not benchmark and not otel and not cloud_e2e" --strict-markers'
 markers = [
     "expensive: marks tests as expensive to run",
-    "very_expensive: marks tests as very expensive to run",
+    "very_expensive: marks tests as very expensive to run, or as depending on an unreliable external service",
     "remote_api: marks tests as calling a remote API (such as OpenAI)",
     "benchmark: marks tests as benchmark tests (excluded from regular test runs)",
     "local: test runs only against the in-process catalog, not the proxy (arg: reason)",

--- a/tests/functions/test_anthropic.py
+++ b/tests/functions/test_anthropic.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun_on_network_error()
 class TestAnthropic:
     def test_messages(self, uses_db: None) -> None:

--- a/tests/functions/test_bedrock.py
+++ b/tests/functions/test_bedrock.py
@@ -131,7 +131,7 @@ def _converse_image_messages(t: pxt.Table) -> list:
 
 
 @pytest.mark.remote_api
-@pytest.mark.expensive
+@pytest.mark.very_expensive
 @pytest.mark.usefixtures('bedrock_us_east_1')
 @rerun_on_network_error()
 class TestBedrock:

--- a/tests/functions/test_deepseek.py
+++ b/tests/functions/test_deepseek.py
@@ -8,6 +8,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun_on_network_error()
 class TestDeepseek:
     def test_chat_completions(self, uses_db: None) -> None:

--- a/tests/functions/test_fireworks.py
+++ b/tests/functions/test_fireworks.py
@@ -8,6 +8,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun_on_network_error()
 class TestFireworks:
     def test_fireworks(self, uses_db: None) -> None:

--- a/tests/functions/test_gemini.py
+++ b/tests/functions/test_gemini.py
@@ -197,7 +197,6 @@ class TestGemini:
         assert results['output'][0].size == (1024, 1024)
         assert results['output2'][0].size == (1280, 896)
 
-    @pytest.mark.very_expensive
     @rerun_on_network_error(reruns_delay=30)
     def test_generate_videos(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')
@@ -239,7 +238,6 @@ class TestGemini:
             assert video_stream['duration_seconds'] == duration, metadata
             assert audio_stream['duration_seconds'] == duration, metadata
 
-    @pytest.mark.very_expensive
     @rerun_on_network_error(reruns_delay=30)
     def test_generate_videos_reference_images(self, uses_db: None) -> None:
         skip_test_if_not_installed('google.genai')

--- a/tests/functions/test_groq.py
+++ b/tests/functions/test_groq.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun(reruns=4, reruns_delay=8)
 class TestGroq:
     def test_chat_completions(self, uses_db: None) -> None:

--- a/tests/functions/test_huggingface.py
+++ b/tests/functions/test_huggingface.py
@@ -462,7 +462,6 @@ class TestHuggingface:
         assert results[0]['sentiment'][0]['label_text'] == 'positive'
         assert results[1]['sentiment'][0]['label_text'] == 'negative'
 
-    @pytest.mark.very_expensive  # Large model
     @pytest.mark.xdist_group('large_model')
     def test_image_captioning(self, uses_db: None) -> None:
         skip_test_if_no_config('token', 'hf')
@@ -619,7 +618,6 @@ class TestHuggingface:
         assert result['audio'] is not None
         # Audio should be pxt.Audio type - basic check that it's not empty
 
-    @pytest.mark.very_expensive  # Large model
     @pytest.mark.xdist_group('large_model')
     def test_text_to_image(self, uses_db: None) -> None:
         skip_test_if_no_config('token', 'hf')
@@ -648,7 +646,6 @@ class TestHuggingface:
         # Verify we got an image
         assert result['image'] is not None
 
-    @pytest.mark.very_expensive  # Large model
     @pytest.mark.xdist_group('large_model')
     def test_image_to_image(self, uses_db: None) -> None:
         skip_test_if_no_config('token', 'hf')
@@ -675,7 +672,6 @@ class TestHuggingface:
         # Verify we got a modified image
         assert result['modified_image'] is not None
 
-    @pytest.mark.very_expensive  # Large model
     @pytest.mark.xdist_group('large_model')
     def test_image_to_video(self, uses_db: None) -> None:
         skip_test_if_no_config('token', 'hf')

--- a/tests/functions/test_jina.py
+++ b/tests/functions/test_jina.py
@@ -7,7 +7,7 @@ from ..utils import rerun_on_network_error, skip_test_if_no_client, validate_upd
 pytestmark = pytest.mark.local('UDF/integration test')
 
 
-@pytest.mark.expensive
+@pytest.mark.very_expensive
 @pytest.mark.remote_api
 @rerun_on_network_error()
 class TestJina:

--- a/tests/functions/test_mistralai.py
+++ b/tests/functions/test_mistralai.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun_on_network_error()
 class TestMistral:
     def test_chat_completions(self, uses_db: None) -> None:

--- a/tests/functions/test_openrouter.py
+++ b/tests/functions/test_openrouter.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
+@pytest.mark.very_expensive
 @rerun_on_network_error()
 class TestOpenRouter:
     def test_chat_completions(self, uses_db: None) -> None:

--- a/tests/functions/test_twelvelabs.py
+++ b/tests/functions/test_twelvelabs.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.local('UDF/integration test')
 
 
 @pytest.mark.remote_api
-@pytest.mark.expensive
+@pytest.mark.very_expensive
 @rerun_on_network_error()
 class TestTwelveLabs:
     def test_embed_text(self, uses_db: None) -> None:


### PR DESCRIPTION
OpenAI is intentionally left in, it appears to be very reliable.

Bonus: removed redundant `very_expensive` marks on test functions where the entire class is already marked so.