### PR TITLE
fix(dashboard): show API error reason, not just HTTP 403

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -11,7 +11,7 @@ const API_BASE = '/api';
 /** Daemon errors are `{ detail, error_code }` (see pixeltable_cli/server/http_server.py). */
 const ERROR_LABELS: Record<string, string> = {
   MISSING_CREDENTIALS:
-    'No Pixeltable API key. Set PIXELTABLE_API_KEY or add api_key under [pixeltable] in ~/.pixeltable/config.toml.',
+    'No Pixeltable API key. Set PIXELTABLE_API_KEY or add api_key under [pixeltable] in your Pixeltable config file.',
   INSUFFICIENT_PRIVILEGES: 'Not allowed to open this catalog.',
   INVALID_PATH: 'Invalid path.',
   PATH_NOT_FOUND: 'Not found.',

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -8,11 +8,30 @@ import type {
 
 const API_BASE = '/api';
 
+/** Daemon errors are `{ detail, error_code }` (see pixeltable_cli/server/http_server.py). */
+const ERROR_LABELS: Record<string, string> = {
+  MISSING_CREDENTIALS:
+    'No Pixeltable API key. Set PIXELTABLE_API_KEY or add api_key under [pixeltable] in ~/.pixeltable/config.toml.',
+  INSUFFICIENT_PRIVILEGES: 'Not allowed to open this catalog.',
+  INVALID_PATH: 'Invalid path.',
+  PATH_NOT_FOUND: 'Not found.',
+  DIRECTORY_NOT_FOUND: 'Not found.',
+  TABLE_NOT_FOUND: 'Not found.',
+};
+
+function apiErrorMessage(body: { detail?: unknown; error?: unknown; error_code?: unknown }, status: number): string {
+  const code = typeof body.error_code === 'string' ? body.error_code : '';
+  const detail = typeof body.detail === 'string' ? body.detail : typeof body.error === 'string' ? body.error : '';
+  const label = ERROR_LABELS[code];
+  if (label) return label;
+  return detail || `HTTP ${status}`;
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
-    throw new Error(error.error || `HTTP ${response.status}`);
+    const error = await response.json().catch(() => ({}));
+    throw new Error(apiErrorMessage(error, response.status));
   }
   return response.json();
 }


### PR DESCRIPTION
## Summary
- `fetchJson` now reads the daemon’s `{ detail, error_code }` instead of a nonexistent `error` field, so the tree no longer shows a bare `HTTP 403`.
- Maps `MISSING_CREDENTIALS`, `INSUFFICIENT_PRIVILEGES`, `INVALID_PATH`, and not-found codes to short labels; unknown codes fall back to `detail` or `HTTP {status}`.
- Separate from #1523 (lineage catalog scope). No backend or DESIGN changes.