### PR TITLE
Run TestVideo.test_basic with xfail on Windows

### DIFF
--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -82,9 +82,10 @@ class TestVideo:
         assert len(result) == total_num_rows
         return base_t, view_t
 
-    @pytest.mark.skipif(
+    @pytest.mark.xfail(
         platform.system() == 'Windows',
         reason='PXT-1295: TestVideo.test_basic[proxy] consistently fails on Windows in CI',
+        strict=False,
     )
     def test_basic(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path


### PR DESCRIPTION
The test will be run, but any outcome will be ignored. This should enable us to debug it.