### PR TITLE
Avoid going on network in tests when possible

### DIFF
--- a/tests/benchmarks/test_expr_eval_perf.py
+++ b/tests/benchmarks/test_expr_eval_perf.py
@@ -7,7 +7,8 @@ import pixeltable as pxt
 import pixeltable.functions as pxtf
 from pixeltable.env import Env
 
-from ..utils import SAMPLE_IMAGE_URL, get_audio_files, get_video_files, rerun_on_network_error
+from ..conftest import SampleFileServer
+from ..utils import SAMPLE_IMAGE_FILE_PATH, get_audio_files, get_video_files
 
 pytestmark = pytest.mark.local('expr-eval/insert performance benchmark')
 
@@ -94,16 +95,18 @@ class TestExprEvalPerformance:
                 conn.execute(sa.text(f'DROP TABLE IF EXISTS {table_name}'))
 
     @pytest.mark.benchmark(group='image_transform')
-    @rerun_on_network_error()
-    def test_insert_image_resize(self, uses_db: None, benchmark: BenchmarkFixture) -> None:
+    def test_insert_image_resize(
+        self, uses_db: None, benchmark: BenchmarkFixture, sample_file_server: SampleFileServer
+    ) -> None:
         """Benchmark image resize operations."""
         row_count = 200
+        img_url = sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)
 
         t = pxt.create_table('img_resize_tbl', {'img': pxt.Image | None})
         t.add_computed_column(resized=t.img.resize((128, 128)))
 
         def insert_resized() -> None:
-            t.insert({'img': SAMPLE_IMAGE_URL} for _ in range(row_count))
+            t.insert({'img': img_url} for _ in range(row_count))
 
         benchmark(insert_resized)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import platform
 import shutil
 import sys
 import threading
+import urllib.parse
 import uuid
 from typing import Callable, Iterator
 
@@ -496,7 +497,7 @@ def reload_tester(init_env: None) -> ReloadTester:
     return ReloadTester()
 
 
-_SERVED_DIR = TESTS_DIR / 'data'
+_SERVED_DIR = TESTS_DIR.parent  # repo root
 
 
 class _QuietHandler(http.server.SimpleHTTPRequestHandler):
@@ -505,7 +506,7 @@ class _QuietHandler(http.server.SimpleHTTPRequestHandler):
 
 
 class SampleFileServer:
-    """Handle on the HTTP server started by the `sample_file_server` fixture, which serves the `tests/data` tree."""
+    """Handle on the HTTP server started by the `sample_file_server` fixture, which serves the repo tree."""
 
     base_url: str
 
@@ -513,17 +514,17 @@ class SampleFileServer:
         self.base_url = base_url
 
     def url(self, path: str | pathlib.Path) -> str:
-        """Return the http:// URL of `path`, given either as an absolute path under `tests/data` or relative to it."""
+        """Return the http:// URL of `path`, given either as an absolute path in the repo or relative to its root."""
         rel_path = pathlib.Path(path)
         if rel_path.is_absolute():
             assert rel_path.is_relative_to(_SERVED_DIR)
             rel_path = rel_path.relative_to(_SERVED_DIR)
-        return self.base_url + rel_path.as_posix()
+        return self.base_url + urllib.parse.quote(rel_path.as_posix())
 
 
 @pytest.fixture
 def sample_file_server() -> Iterator[SampleFileServer]:
-    """Serve the local test data files over a localhost HTTP server.
+    """Serve the local sample files (`tests/data`, `docs/resources`, ...) over a localhost HTTP server.
 
     Tests that need a file reachable by http:// URL (rather than a local path or file:// URL) can get one with
     `sample_file_server.url(<path of the file>)`, exercising the same download path as an internet URL without the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import functools
+import http.server
 import json
 import logging
 import os
@@ -5,6 +7,7 @@ import pathlib
 import platform
 import shutil
 import sys
+import threading
 import uuid
 from typing import Callable, Iterator
 
@@ -31,6 +34,7 @@ from pixeltable.utils.sql import add_option_to_db_url
 
 from .utils import (
     IN_CI,
+    TESTS_DIR,
     CatalogMode,
     ReloadTester,
     create_all_datatypes_tbl,
@@ -490,6 +494,50 @@ def test_tbl(make_catalog_path: Callable[[str], str]) -> pxt.Table:
 @pytest.fixture(scope='function')
 def reload_tester(init_env: None) -> ReloadTester:
     return ReloadTester()
+
+
+_SERVED_DIR = TESTS_DIR / 'data'
+
+
+class _QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args: object) -> None:
+        pass
+
+
+class SampleFileServer:
+    """Handle on the HTTP server started by the `sample_file_server` fixture, which serves the `tests/data` tree."""
+
+    base_url: str
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+
+    def url(self, path: str | pathlib.Path) -> str:
+        """Return the http:// URL of `path`, given either as an absolute path under `tests/data` or relative to it."""
+        rel_path = pathlib.Path(path)
+        if rel_path.is_absolute():
+            assert rel_path.is_relative_to(_SERVED_DIR)
+            rel_path = rel_path.relative_to(_SERVED_DIR)
+        return self.base_url + rel_path.as_posix()
+
+
+@pytest.fixture
+def sample_file_server() -> Iterator[SampleFileServer]:
+    """Serve the local test data files over a localhost HTTP server.
+
+    Tests that need a file reachable by http:// URL (rather than a local path or file:// URL) can get one with
+    `sample_file_server.url(<path of the file>)`, exercising the same download path as an internet URL without the
+    latency and flakiness of fetching one. Requesting a path that isn't in the tree yields a genuine 404.
+    """
+    handler = functools.partial(_QuietHandler, directory=str(_SERVED_DIR))
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield SampleFileServer(f'http://127.0.0.1:{server.server_address[1]}/')
+    finally:
+        server.shutdown()
+        server.server_close()
 
 
 @pytest.fixture(scope='function')

--- a/tests/functions/test_huggingface.py
+++ b/tests/functions/test_huggingface.py
@@ -8,8 +8,9 @@ import pytest
 import pixeltable as pxt
 import pixeltable.type_system as ts
 
+from ..conftest import SampleFileServer
 from ..utils import (
-    SAMPLE_IMAGE_URL,
+    SAMPLE_IMAGE_FILE_PATH,
     ReloadTester,
     get_audio_files,
     get_image_files,
@@ -165,7 +166,7 @@ class TestHuggingface:
         assert status.num_excs == 0
         verify_row(t.tail(1)[0])
 
-    def test_detr_for_object_detection(self, uses_db: None) -> None:
+    def test_detr_for_object_detection(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_no_config('token', 'hf')
         skip_test_if_not_installed('transformers')
         from pixeltable.functions.huggingface import detr_for_object_detection
@@ -176,7 +177,7 @@ class TestHuggingface:
             detect=detr_for_object_detection(t.img, model_id='facebook/detr-resnet-50', threshold=0.8)
         )
         t.add_computed_column(featured_object=t.detect.label_text[0])
-        status = t.insert(img=SAMPLE_IMAGE_URL)
+        status = t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH))
         assert status.num_rows == 1
         assert status.num_excs == 0
         result = t.select(t.detect).collect()[0]['detect']
@@ -190,7 +191,7 @@ class TestHuggingface:
         # Test appropriate typing
         assert t.get_metadata()['columns']['featured_object']['type_'] == 'String | None'
 
-    def test_detr_for_segmentation(self, uses_db: None) -> None:
+    def test_detr_for_segmentation(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_no_config('token', 'hf')
         skip_test_if_not_installed('transformers')
         from pixeltable.functions.huggingface import detr_for_segmentation
@@ -199,7 +200,7 @@ class TestHuggingface:
         t.add_computed_column(
             seg=detr_for_segmentation(t.img, model_id='facebook/detr-resnet-50-panoptic', threshold=0.5)
         )
-        status = t.insert(img=SAMPLE_IMAGE_URL)
+        status = t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH))
         assert status.num_rows == 1
         assert status.num_excs == 0
         res = t.select(height=t.img.height, width=t.img.width).collect()[0]
@@ -214,7 +215,7 @@ class TestHuggingface:
         assert 'label_text' in result['segments_info'][0]
 
     @pytest.mark.xdist_group('large_model')
-    def test_sam3_for_segmentation(self, uses_db: None) -> None:
+    def test_sam3_for_segmentation(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_not_installed('transformers')
         from huggingface_hub import get_token
 
@@ -224,7 +225,7 @@ class TestHuggingface:
 
         t = pxt.create_table('test_tbl', {'img': pxt.Image | None})
         t.add_computed_column(seg=sam3_for_segmentation(t.img, text='orange', threshold=0.3))
-        status = t.insert(img=SAMPLE_IMAGE_URL)
+        status = t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH))
         assert status.num_rows == 1
         assert status.num_excs == 0
 
@@ -252,7 +253,7 @@ class TestHuggingface:
             assert 0.0 <= score <= 1.0
 
     @pytest.mark.xdist_group('large_model')
-    def test_sam_automatic_mask_generation(self, uses_db: None) -> None:
+    def test_sam_automatic_mask_generation(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_not_installed('transformers')
         from huggingface_hub import get_token
 
@@ -262,7 +263,7 @@ class TestHuggingface:
 
         t = pxt.create_table('test_tbl', {'img': pxt.Image | None})
         t.add_computed_column(seg=sam_automatic_mask_generation(t.img, points_per_crop=16))
-        status = t.insert(img=SAMPLE_IMAGE_URL)
+        status = t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH))
         assert status.num_rows == 1
         assert status.num_excs == 0
 
@@ -288,12 +289,12 @@ class TestHuggingface:
         for score in result['scores']:
             assert 0.0 <= score <= 1.0
 
-    def test_sam3_for_segmentation_invalid_args(self, uses_db: None) -> None:
+    def test_sam3_for_segmentation_invalid_args(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_not_installed('transformers')
         from pixeltable.functions.huggingface import sam3_for_segmentation
 
         t = pxt.create_table('test_tbl', {'img': pxt.Image | None})
-        t.insert(img=SAMPLE_IMAGE_URL)
+        t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH))
 
         with pxt_raises(pxt.ErrorCode.UNSUPPORTED_OPERATION, match='At least one of'):
             t.add_computed_column(seg=sam3_for_segmentation(t.img))
@@ -348,7 +349,7 @@ class TestHuggingface:
         assert v_fps.count() == 4
 
     @pytest.mark.xdist_group('large_model')
-    def test_sam3_for_segmentation_no_detections(self, uses_db: None) -> None:
+    def test_sam3_for_segmentation_no_detections(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_not_installed('transformers')
         from huggingface_hub import get_token
 
@@ -361,7 +362,7 @@ class TestHuggingface:
         # threshold=1.0 guarantees zero detections (scores never exceed 1.0)
         t.add_computed_column(seg=sam3_for_segmentation(t.img, text='orange', threshold=1.0))
         t.add_computed_column(viz=overlay_segmentation(t.img, t.seg.masks))
-        validate_update_status(t.insert(img=SAMPLE_IMAGE_URL), expected_rows=1)
+        validate_update_status(t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)), expected_rows=1)
 
         res = t.select(t.seg, t.viz, height=t.img.height, width=t.img.width).collect()[0]
         result = res['seg']
@@ -371,7 +372,7 @@ class TestHuggingface:
         assert result['masks'].shape == (0, res['height'], res['width'])
         assert res['viz'].size == (res['width'], res['height'])
 
-    def test_vit_for_image_classification(self, uses_db: None) -> None:
+    def test_vit_for_image_classification(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_no_config('token', 'hf')
         skip_test_if_not_installed('transformers')
         from pixeltable.functions.huggingface import vit_for_image_classification
@@ -380,7 +381,7 @@ class TestHuggingface:
         t.add_computed_column(
             img_class=vit_for_image_classification(t.img, model_id='google/vit-base-patch16-224', top_k=3)
         )
-        validate_update_status(t.insert(img=SAMPLE_IMAGE_URL), expected_rows=1)
+        validate_update_status(t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)), expected_rows=1)
         result = t.select(t.img_class).collect()[0]['img_class']
         assert result['labels'] == [962, 935, 937]
         assert result['label_text'] == ['meat loaf, meatloaf', 'mashed potato', 'broccoli']
@@ -463,7 +464,7 @@ class TestHuggingface:
         assert results[1]['sentiment'][0]['label_text'] == 'negative'
 
     @pytest.mark.xdist_group('large_model')
-    def test_image_captioning(self, uses_db: None) -> None:
+    def test_image_captioning(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_no_config('token', 'hf')
         skip_test_if_not_installed('transformers')
         from pixeltable.functions.huggingface import image_captioning
@@ -477,7 +478,7 @@ class TestHuggingface:
             )
         )
 
-        validate_update_status(t.insert(img=SAMPLE_IMAGE_URL), expected_rows=1)
+        validate_update_status(t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)), expected_rows=1)
         result = t.select(t.caption).collect()[0]
 
         # Verify we got a caption
@@ -647,7 +648,7 @@ class TestHuggingface:
         assert result['image'] is not None
 
     @pytest.mark.xdist_group('large_model')
-    def test_image_to_image(self, uses_db: None) -> None:
+    def test_image_to_image(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_no_config('token', 'hf')
         skip_test_if_not_installed('transformers')
         skip_test_if_not_installed('diffusers')
@@ -666,14 +667,16 @@ class TestHuggingface:
             )
         )
 
-        validate_update_status(t.insert(img=SAMPLE_IMAGE_URL, prompt=test_prompt), expected_rows=1)
+        validate_update_status(
+            t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH), prompt=test_prompt), expected_rows=1
+        )
         result = t.select(t.modified_image).collect()[0]
 
         # Verify we got a modified image
         assert result['modified_image'] is not None
 
     @pytest.mark.xdist_group('large_model')
-    def test_image_to_video(self, uses_db: None) -> None:
+    def test_image_to_video(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_no_config('token', 'hf')
         skip_test_if_not_installed('transformers')
         skip_test_if_not_installed('diffusers')
@@ -690,7 +693,7 @@ class TestHuggingface:
             )
         )
 
-        validate_update_status(t.insert(img=SAMPLE_IMAGE_URL), expected_rows=1)
+        validate_update_status(t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)), expected_rows=1)
         result = t.select(t.video).collect()[0]
 
         # Verify we got a video

--- a/tests/functions/test_image.py
+++ b/tests/functions/test_image.py
@@ -9,7 +9,7 @@ import pixeltable as pxt
 import pixeltable.type_system as ts
 from pixeltable.functions.image import alpha_composite, blend, composite, stitch_tiles, tile_iterator
 
-from ..utils import SAMPLE_IMAGE_URL, get_image_files, pxt_raises, rerun_on_network_error
+from ..utils import SAMPLE_IMAGE_FILE_PATH, get_image_files, pxt_raises
 
 pytestmark = pytest.mark.local('UDF/integration test')
 
@@ -96,10 +96,9 @@ class TestImage:
                 size=(200, 300), mode='RGB', nullable=nullable
             )
 
-    @rerun_on_network_error()
     def test_tile_iterator(self, uses_db: None) -> None:
         t = pxt.create_table('test_tbl', {'image': pxt.Image | None})
-        t.insert(image=SAMPLE_IMAGE_URL)
+        t.insert(image=SAMPLE_IMAGE_FILE_PATH)
         v = pxt.create_view('test_view', t, iterator=tile_iterator(t.image, (100, 100), overlap=(10, 10)))
         image: Image = t.collect()[0]['image']
         results = v.select(v.pos, v.tile, v.tile_coord, v.tile_box).order_by(v.pos).collect()
@@ -194,10 +193,9 @@ class TestImage:
         assert len(result) == 1
         assert result[0]['stitched'] is None
 
-    @rerun_on_network_error()
     def test_tile_iterator_errors(self, uses_db: None) -> None:
         t = pxt.create_table('test_tbl', {'image': pxt.Image | None})
-        t.insert(image=SAMPLE_IMAGE_URL)
+        t.insert(image=SAMPLE_IMAGE_FILE_PATH)
 
         # Test overlap >= tile_size
         for overlap in ((0, 100), (100, 0)):

--- a/tests/functions/test_json.py
+++ b/tests/functions/test_json.py
@@ -6,6 +6,7 @@ import pytest
 import pixeltable as pxt
 import pixeltable.functions as pxtf
 
+from ..conftest import SampleFileServer
 from ..utils import pxt_raises, rerun_on_network_error, skip_test_if_no_config, skip_test_if_not_installed
 
 pytestmark = pytest.mark.local('UDF/integration test')
@@ -456,7 +457,7 @@ class TestJson:
 
     @pytest.mark.very_expensive  # Downloads a Hugging Face model
     @rerun_on_network_error()
-    def test_list_iterator_appl(self, uses_db: None) -> None:
+    def test_list_iterator_appl(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         """
         Fully worked example of flattening object detection output.
         """
@@ -465,10 +466,7 @@ class TestJson:
 
         t = pxt.create_table('img_table', {'id': pxt.Int | None, 'img': pxt.Image | None})
         t.insert(
-            {
-                'id': id,
-                'img': f'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/{name}',
-            }
+            {'id': id, 'img': sample_file_server.url(f'docs/resources/images/{name}')}
             for id, name in enumerate(('000000000009.jpg', '000000000016.jpg'))
         )
         t.add_computed_column(

--- a/tests/functions/test_nebius.py
+++ b/tests/functions/test_nebius.py
@@ -3,8 +3,9 @@ import pytest
 import pixeltable as pxt
 import pixeltable.type_system as ts
 
+from ..conftest import SampleFileServer
 from ..utils import (
-    SAMPLE_IMAGE_URL,
+    SAMPLE_IMAGE_FILE_PATH,
     rerun_on_network_error,
     skip_test_if_no_client,
     skip_test_if_not_installed,
@@ -34,7 +35,7 @@ class TestNebius:
         result = t.collect()
         assert 'paris' in result['chat_output'][0]['choices'][0]['message']['content'].lower()
 
-    def test_vision(self, uses_db: None) -> None:
+    def test_vision(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_not_installed('openai')
         skip_test_if_no_client('nebius')
         from pixeltable.functions.nebius import chat_completions
@@ -51,7 +52,7 @@ class TestNebius:
         ]
         t.add_computed_column(response=chat_completions(msgs, model='Qwen/Qwen2.5-VL-72B-Instruct'))
 
-        validate_update_status(t.insert(image=SAMPLE_IMAGE_URL), 1)
+        validate_update_status(t.insert(image=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)), 1)
         result = t.collect()
         assert 'broccoli' in result['response'][0]['choices'][0]['message']['content'].lower()
 

--- a/tests/functions/test_openai.py
+++ b/tests/functions/test_openai.py
@@ -11,8 +11,9 @@ import pixeltable.functions as pxtf
 import pixeltable.type_system as ts
 from pixeltable.config import Config
 
+from ..conftest import SampleFileServer
 from ..utils import (
-    SAMPLE_IMAGE_URL,
+    SAMPLE_IMAGE_FILE_PATH,
     pxt_raises,
     rerun,
     rerun_on_network_error,
@@ -374,7 +375,7 @@ class TestOpenai:
         assert res[0]['tool_calls'] == {'get_customer_info': [[{'customer_id': 'Q371A', 'name': 'Aaron Siegel'}]]}
 
     @pytest.mark.expensive
-    def test_gpt_vision(self, uses_db: None) -> None:
+    def test_gpt_vision(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_not_installed('openai')
         skip_test_if_no_client('openai')
         from pixeltable.functions.openai import chat_completions, vision
@@ -390,7 +391,9 @@ class TestOpenai:
             pxt.exceptions.PixeltableDeprecationWarning,
             match=r'vision\(\) is deprecated as a separate API; use chat_completions\(\) or responses\(\) instead',
         ):
-            validate_update_status(t.insert(prompt="What's in this image?", img=SAMPLE_IMAGE_URL), 1)
+            validate_update_status(
+                t.insert(prompt="What's in this image?", img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)), 1
+            )
         result = t.collect()
         assert 'broccoli' in result['response'][0].lower()
         assert 'broccoli' in result['response_2'][0]['choices'][0]['message']['content'].lower()
@@ -478,7 +481,7 @@ class TestOpenai:
         assert t.get_metadata()['columns']['first']['type_'] == 'Image | None'
 
     @pytest.mark.expensive
-    def test_image_edits_gpt_image(self, uses_db: None) -> None:
+    def test_image_edits_gpt_image(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         skip_test_if_not_installed('openai')
         skip_test_if_no_client('openai')
         from pixeltable.functions.openai import image_edits
@@ -497,7 +500,7 @@ class TestOpenai:
         assert "'data': Json[(Image, ...)]" in edited_type
         assert "'usage':" in edited_type
 
-        validate_update_status(t.insert(img=SAMPLE_IMAGE_URL), 1)
+        validate_update_status(t.insert(img=sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)), 1)
         result = t.collect()
         assert isinstance(result['edited'][0]['data'][0], PIL.Image.Image)
 
@@ -769,7 +772,9 @@ class TestOpenai:
 
         assert status.num_excs == 0, f'{status.num_excs} rows failed permanently'
 
-    def test_shared_rate_limits_pool_different_signatures(self, uses_db: None) -> None:
+    def test_shared_rate_limits_pool_different_signatures(
+        self, uses_db: None, sample_file_server: SampleFileServer
+    ) -> None:
         """Verify that functions sharing a rate-limits pool with different resource estimators work correctly.
 
         chat_completions and vision share a pool but each has its own resource_estimator with different
@@ -786,7 +791,8 @@ class TestOpenai:
             pxt.exceptions.PixeltableDeprecationWarning,
             match=r'vision\(\) is deprecated as a separate API; use chat_completions\(\) or responses\(\) instead',
         ):
-            validate_update_status(t.insert([{'img': SAMPLE_IMAGE_URL}, {'img': SAMPLE_IMAGE_URL}]), expected_rows=2)
+            img_url = sample_file_server.url(SAMPLE_IMAGE_FILE_PATH)
+            validate_update_status(t.insert([{'img': img_url}, {'img': img_url}]), expected_rows=2)
         result = t.collect()
         assert len(result) == 2
         for row in result:

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -8,6 +8,7 @@ import pytest
 import pixeltable as pxt
 import pixeltable.type_system as ts
 
+from ..conftest import SampleFileServer
 from ..utils import ensure_s3_pytest_resources_access, get_image_files, pxt_raises, rerun_on_network_error
 
 EXPECTED_SCHEMA = {
@@ -87,11 +88,10 @@ class TestImport:
         t2.insert(data)
         assert t2.count() == 8
 
-    @rerun_on_network_error()
-    def test_import_json(self, make_catalog_path: Callable[[str], str]) -> None:
+    def test_import_json(self, make_catalog_path: Callable[[str], str], sample_file_server: SampleFileServer) -> None:
         p = make_catalog_path
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'
-        jeopardy = 'https://raw.githubusercontent.com/pixeltable/pixeltable/main/tests/data/json/jeopardy.json'
+        jeopardy = sample_file_server.url('json/jeopardy.json')
 
         # `example.json` has a variety of datatypes and tests both nullable and non-nullable columns
         t1 = pxt.io.import_json(p('example'), str(example))
@@ -118,11 +118,10 @@ class TestImport:
         assert tab.count() == 4
         assert tab._get_schema() == EXPECTED_SCHEMA
 
-    @rerun_on_network_error()
-    def test_insert_json(self, make_catalog_path: Callable[[str], str]) -> None:
+    def test_insert_json(self, make_catalog_path: Callable[[str], str], sample_file_server: SampleFileServer) -> None:
         p = make_catalog_path
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'
-        jeopardy = 'https://raw.githubusercontent.com/pixeltable/pixeltable/main/tests/data/json/jeopardy.json'
+        jeopardy = sample_file_server.url('json/jeopardy.json')
 
         # `example.json` has a variety of datatypes and tests both nullable and non-nullable columns
         t1 = pxt.io.import_json(p('example'), str(example))

--- a/tests/io/test_import.py
+++ b/tests/io/test_import.py
@@ -91,7 +91,7 @@ class TestImport:
     def test_import_json(self, make_catalog_path: Callable[[str], str], sample_file_server: SampleFileServer) -> None:
         p = make_catalog_path
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'
-        jeopardy = sample_file_server.url('json/jeopardy.json')
+        jeopardy = sample_file_server.url('tests/data/json/jeopardy.json')
 
         # `example.json` has a variety of datatypes and tests both nullable and non-nullable columns
         t1 = pxt.io.import_json(p('example'), str(example))
@@ -121,7 +121,7 @@ class TestImport:
     def test_insert_json(self, make_catalog_path: Callable[[str], str], sample_file_server: SampleFileServer) -> None:
         p = make_catalog_path
         example = Path(__file__).parent.parent / 'data' / 'json' / 'example.json'
-        jeopardy = sample_file_server.url('json/jeopardy.json')
+        jeopardy = sample_file_server.url('tests/data/json/jeopardy.json')
 
         # `example.json` has a variety of datatypes and tests both nullable and non-nullable columns
         t1 = pxt.io.import_json(p('example'), str(example))

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -11,8 +11,8 @@ import pytest
 import pixeltable as pxt
 from pixeltable.utils.arrow import to_pydict
 
+from ..conftest import SampleFileServer
 from ..utils import (
-    SAMPLE_IMAGE_URL,
     CatalogMode,
     assert_schema_eq,
     ensure_s3_pytest_resources_access,
@@ -377,15 +377,19 @@ class TestParquet:
         # Test that we can reimport the image (it will come back as bytes)
         _ = pxt.io.import_parquet(p('imported_image'), parquet_path=str(export_path))
 
-    @rerun_on_network_error()
     def test_import_images(
-        self, make_catalog_path: Callable[[str], str], catalog_mode: CatalogMode, tmp_path: pathlib.Path
+        self,
+        make_catalog_path: Callable[[str], str],
+        catalog_mode: CatalogMode,
+        tmp_path: pathlib.Path,
+        sample_file_server: SampleFileServer,
     ) -> None:
         p = make_catalog_path
         valid_images = get_image_files()
 
         # Parquet with valid image paths/URLs
-        img_data = pa.table({'image_path': [str(f) for f in valid_images[:3]] + [SAMPLE_IMAGE_URL]})
+        img_url = sample_file_server.url(valid_images[3])
+        img_data = pa.table({'image_path': [str(f) for f in valid_images[:3]] + [img_url]})
         img_pq = tmp_path / 'valid.parquet'
         pa_parquet.write_table(img_data, str(img_pq))
 
@@ -405,7 +409,14 @@ class TestParquet:
 
         # Parquet with invalid local path and invalid URL
         bad_data = pa.table(
-            {'image_path': [valid_images[0], 'not_a_real_image.jpg', 'https://httpbin.org/status/404', valid_images[1]]}
+            {
+                'image_path': [
+                    valid_images[0],
+                    'not_a_real_image.jpg',
+                    sample_file_server.url('not_a_real_image.jpg'),
+                    valid_images[1],
+                ]
+            }
         )
         bad_pq = tmp_path / 'bad.parquet'
         pa_parquet.write_table(bad_data, str(bad_pq))

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -25,6 +25,7 @@ from pixeltable.exprs import ColumnRef, Expr, Literal
 from pixeltable.functions.globals import cast
 from pixeltable.functions.video import legacy_frame_iterator
 
+from .conftest import SampleFileServer
 from .utils import (
     CatalogMode,
     ReloadTester,
@@ -34,7 +35,6 @@ from .utils import (
     get_image_files,
     pxt_raises,
     reload_catalog,
-    rerun_on_network_error,
     skip_test_if_not_installed,
     validate_update_status,
 )
@@ -1466,21 +1466,23 @@ class TestExprs:
         result = t.select(t.img, t.img.height, t.img.rotate(90)).show(n=100)
         _ = result._repr_html_()
 
-    @rerun_on_network_error()
-    def test_ext_imgs(self, make_catalog_path: Callable[[str], str]) -> None:
+    def test_ext_imgs(self, make_catalog_path: Callable[[str], str], sample_file_server: SampleFileServer) -> None:
         p = make_catalog_path
         t = pxt.create_table(p('img_test'), {'img': pxt.Image | None})
         img_urls = [
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000030.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000034.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000042.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000049.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000057.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000061.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000063.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000064.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000069.jpg',
-            'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000071.jpg',
+            sample_file_server.url(f'docs/resources/images/{name}')
+            for name in (
+                '000000000030.jpg',
+                '000000000034.jpg',
+                '000000000042.jpg',
+                '000000000049.jpg',
+                '000000000057.jpg',
+                '000000000061.jpg',
+                '000000000063.jpg',
+                '000000000064.jpg',
+                '000000000069.jpg',
+                '000000000071.jpg',
+            )
         ]
         t.insert({'img': url} for url in img_urls)
         # this fails with an assertion

--- a/tests/test_file_cache.py
+++ b/tests/test_file_cache.py
@@ -1,11 +1,6 @@
-import functools
-import http.server
 import os
 import platform
-import threading
 from collections import OrderedDict
-from collections.abc import Iterator
-from pathlib import Path
 
 import pytest
 
@@ -13,42 +8,17 @@ import pixeltable as pxt
 from pixeltable.env import Env
 from pixeltable.utils.filecache import FileCache
 
-from .utils import get_image_files, rerun_on_network_error
+from .conftest import SampleFileServer
+from .utils import get_image_files
 
 pytestmark = pytest.mark.local('inspects local FileCache internals')
-
-
-class _QuietHandler(http.server.SimpleHTTPRequestHandler):
-    def log_message(self, *args: object) -> None:
-        pass
-
-
-@pytest.fixture
-def image_server() -> Iterator[str]:
-    """Serve the local imagenette images over a localhost HTTP server, yielding the base URL.
-
-    FileCache only caches external (non-file://) URLs, so exercising it needs remote-style URLs; serving them
-    from localhost exercises the same download/cache path without the latency and flakiness of fetching over the
-    internet.
-    """
-    img_dir = Path(get_image_files()[0]).parent
-    handler = functools.partial(_QuietHandler, directory=str(img_dir))
-    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield f'http://127.0.0.1:{server.server_address[1]}/'
-    finally:
-        server.shutdown()
-        server.server_close()
 
 
 class TestFileCache:
     # TODO: Understand why this test is flaky on Windows. (It appears to be a timing issue
     #     related to the Windows filesystem.)
     @pytest.mark.skipif(platform.system() == 'Windows', reason='Test is flaky on Windows')
-    @rerun_on_network_error()
-    def test_eviction(self, uses_db: None, image_server: str) -> None:
+    def test_eviction(self, uses_db: None, sample_file_server: SampleFileServer) -> None:
         # Set a very small cache size of 200 kiB for this test (the imagenette images are ~5-10 kiB each)
         fc = FileCache.get()
         test_capacity = 200 << 10
@@ -59,7 +29,7 @@ class TestFileCache:
 
         # Construct image URLs
         image_files = get_image_files()[:50]
-        image_urls = [image_server + Path(file).name for file in image_files]
+        image_urls = [sample_file_server.url(file) for file in image_files]
 
         # Initialize a table and a dict to separately track the LRU order
         t = pxt.create_table('images', {'index': pxt.Int | None, 'image': pxt.Image | None})

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2,7 +2,6 @@ import datetime
 import random
 import string
 import sys
-from pathlib import Path
 from typing import Any, Callable, Literal
 
 import numpy as np
@@ -15,6 +14,7 @@ import pixeltable.type_system as ts
 from pixeltable.env import Env
 from pixeltable.functions.huggingface import clip
 
+from .conftest import SampleFileServer
 from .utils import (
     CatalogMode,
     ReloadTester,
@@ -90,6 +90,7 @@ class TestIndex:
         clip_or_local: tuple[pxt.Function, bool],
         reload_tester: ReloadTester,
         catalog_mode: CatalogMode,
+        sample_file_server: SampleFileServer,
     ) -> None:
         embed, is_dummy_model = clip_or_local
         skip_test_if_not_installed('imagehash')
@@ -101,13 +102,12 @@ class TestIndex:
         sample_img_localpath = res[0, 'img_localpath']
         sample_img_file_url = res[0, 'img_fileurl']
         # A PIL image is a self-contained similarity input that works in both modes. A local path, file:// URL, or
-        # an http URL rebuilt from the original filename only identifies the same image against a collocated store:
+        # an http URL rebuilt from the original path only identifies the same image against a collocated store:
         # over the proxy .localpath is a fetched cache copy (hashed name) and .fileurl is a fetchable daemon URL.
         img_inputs: list[Any] = [sample_img]
         if catalog_mode == 'local':
             assert 'file:/' in sample_img_file_url
-            sample_img_filename = Path(sample_img_localpath).name
-            sample_img_http_url = f'https://raw.githubusercontent.com/pixeltable/pixeltable/main/tests/data/imagenette2-160/{sample_img_filename}'
+            sample_img_http_url = sample_file_server.url(sample_img_localpath)
             img_inputs += [sample_img_localpath, sample_img_file_url, sample_img_http_url]
 
         for metric, is_asc in [('cosine', False), ('ip', False), ('l2', True)]:

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -5,7 +5,7 @@ import pytest
 
 import pixeltable as pxt
 
-from .utils import SAMPLE_IMAGE_URL, ReloadTester, create_test_tbl, pxt_raises, rerun_on_network_error
+from .utils import SAMPLE_IMAGE_FILE_PATH, ReloadTester, create_test_tbl, pxt_raises
 
 
 def _local_path(name: str) -> str:
@@ -343,14 +343,13 @@ class TestSample:
         n = len(t.select().sample(fraction=0.01, seed=0).collect())
         assert v.count() == n
 
-    @rerun_on_network_error()
     def test_sample_iterator(self, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
         print('\n\nCREATE TABLE WITH ONE IMAGE COLUMN\n')
         t = pxt.create_table(p('test_tile_tbl'), {'image': pxt.Image | None})
 
         print('\n\nINSERT ONE IMAGE\n')
-        t.insert(image=SAMPLE_IMAGE_URL)
+        t.insert(image=SAMPLE_IMAGE_FILE_PATH)
 
         print('\n\nSAMPLE IMAGE FROM TABLE\n')
         query = t.select().sample(fraction=0.001, seed=4171780)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -924,6 +924,8 @@ def stock_price(ticker: str) -> float:
         return 0.0
 
 
+# Local path to a sample image to use in tests. Use it whenever possible instead of fetching files over the network.
+SAMPLE_IMAGE_FILE_PATH = str(TESTS_DIR.parent / 'docs' / 'resources' / 'images' / '000000000009.jpg')
 SAMPLE_IMAGE_URL = 'https://raw.githubusercontent.com/pixeltable/pixeltable/main/docs/resources/images/000000000009.jpg'
 
 


### PR DESCRIPTION
* Generalized `image_server` to `sample_file_server` test fixture: in-process server for serving local test data over HTTP as if it were from the web
* Replace remote sample files with local files where possible 