### PR TITLE
Drive pixeltable log levels from config, so spawned processes inherit them

### DIFF
--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -564,6 +564,8 @@ KNOWN_CONFIG_OPTIONS: dict[str, dict[str, Any]] = {
         'time_zone': 'Default time zone for timestamps',
         'hide_warnings': 'Hide warnings from the console',
         'verbosity': 'Verbosity level for console output',
+        'log_level': "Level of the 'pixeltable' logger, eg DEBUG (default: INFO)",
+        'sql_log_level': "Level of the 'sqlalchemy.engine' logger: INFO logs SQL statements (default: WARNING)",
         'show_progress': 'Show a progress tracker for long-running operations (default: false)',
         'api_key': 'API key for Pixeltable cloud',
         'input_media_dest': 'Default destination URI for input media data',

--- a/pixeltable/env.py
+++ b/pixeltable/env.py
@@ -52,6 +52,26 @@ _DEFAULT_PROXY_DOMAIN = 'pxt.run'
 _DEFAULT_PROXY_PORT = 9000
 
 
+def init_log_level(logger: logging.Logger, config: Config, config_key: str, *, default: int) -> None:
+    """Set logger's level from the config option 'pixeltable.<config_key>', falling back to default.
+
+    A logger whose level has already been set keeps it.
+    """
+    if logger.level != logging.NOTSET:
+        return
+    level_name = config.get_string_value(config_key)
+    if level_name is None:
+        logger.setLevel(default)
+        return
+    level = logging.getLevelNamesMapping().get(level_name.strip().upper())
+    if level is None:
+        raise excs.RequestError(
+            excs.ErrorCode.INVALID_CONFIGURATION,
+            f"Invalid value for configuration parameter 'pixeltable.{config_key}': {level_name}",
+        )
+    logger.setLevel(level)
+
+
 def store_app_name() -> str:
     """The application_name that this process's connections report to the store.
 
@@ -354,8 +374,7 @@ class Env:
         stdout_handler.setLevel(map_level(self._verbosity))
         stdout_handler.addFilter(ConsoleMessageFilter())
         pxt_logger = logging.getLogger('pixeltable')
-        if pxt_logger.level == logging.NOTSET:
-            pxt_logger.setLevel(logging.INFO)
+        init_log_level(pxt_logger, config, 'log_level', default=logging.INFO)
         pxt_logger.propagate = False
         pxt_logger.addHandler(stdout_handler)
         self._managed_logging_handlers.append((pxt_logger, stdout_handler))
@@ -370,8 +389,7 @@ class Env:
 
         # Configure sqlalchemy logging. Pixeltable users don't need to see the SQL queries by default
         sql_logger = logging.getLogger('sqlalchemy.engine')
-        if sql_logger.level == logging.NOTSET:
-            sql_logger.setLevel(logging.WARNING)
+        init_log_level(sql_logger, config, 'sql_log_level', default=logging.WARNING)
         sql_logger.addHandler(fh)
         sql_logger.propagate = False
         self._managed_logging_handlers.append((sql_logger, fh))

--- a/pixeltable/service/proxy_daemon.py
+++ b/pixeltable/service/proxy_daemon.py
@@ -159,8 +159,9 @@ def create(db: str) -> None:
 def start(db: str, test_mode: bool = False) -> str:
     """Ensure a daemon for db is running and ready; return its endpoint.
 
-    test_mode starts the daemon with --test (DEBUG logging + test-only endpoints). It only takes effect if this
-    call actually launches the daemon; an already-running one is returned as is.
+    test_mode starts the daemon with --test (test-only endpoints). It only takes effect if this call actually
+    launches the daemon; an already-running one is returned as is. The daemon's log levels come from the
+    environment we pass on, not from this flag.
     """
     create(db)
     ep = endpoint(db)
@@ -358,14 +359,10 @@ def _serve(test_mode: bool = False) -> None:
     binds to that address and port instead and skips the lock file. Used when an
     external orchestrator (e.g. a sidecar) handles routing and discovery.
 
-    test_mode: logs at DEBUG and exposes the test-only endpoints.
+    test_mode: exposes the test-only endpoints.
     """
     # mark this process as a hosted-catalog server (no client-accessible local store) before the catalog inits
     os.environ['PIXELTABLE_PROXY_DAEMON'] = '1'
-    if test_mode:
-        # Enable verbose logging
-        for name in ('pixeltable', 'sqlalchemy.engine'):
-            logging.getLogger(name).setLevel(logging.DEBUG)
     try:
         import uvicorn
     except ModuleNotFoundError as e:
@@ -384,12 +381,8 @@ def _serve(test_mode: bool = False) -> None:
     daemon_host = config.get_string_value('daemon_host')
     daemon_port = config.get_int_value('daemon_port')
 
-    log_level = 'info'
-    configured_log_level = config.get_string_value('log_level')
-    if configured_log_level is not None:
-        log_level = configured_log_level.lower()
-    elif test_mode:
-        log_level = 'debug'
+    # pixeltable log level also drives uvicorn
+    log_level = logging.getLogger('pixeltable').getEffectiveLevel()
 
     # log_config=None suppresses uvicorn's own logging setup which results in closing every handler registered so far.
     # Note: at this point, uvicorn logging has already been configured by Env.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,10 @@ def init_env(tmp_path_factory: pytest.TempPathFactory, worker_id: int) -> None: 
     os.environ['PIXELTABLE_PGDATA'] = str(shared_home / 'pgdata')
     os.environ['PIXELTABLE_API_URL'] = 'https://preprod-internal-api.pixeltable.com'
     os.environ['FIFTYONE_DATABASE_DIR'] = f'{home_dir}/.fiftyone'
+    # Verbose logging, for this process and for every pixeltable process it spawns (the proxy daemon, the pxt CLI
+    # daemon)
+    os.environ['PIXELTABLE_LOG_LEVEL'] = 'DEBUG'
+    os.environ['PIXELTABLE_SQL_LOG_LEVEL'] = 'INFO'
     if IN_CI:
         # In CI, we use a separate Hugging Face cache directory for each worker since _clear_hf_caches()
         # deletes the cache between tests.
@@ -168,6 +172,8 @@ def init_env(tmp_path_factory: pytest.TempPathFactory, worker_id: int) -> None: 
         'FIFTYONE_DATABASE_DIR',
         'HF_HOME',
         'PIXELTABLE_DB_CONNECT_STR',
+        'PIXELTABLE_LOG_LEVEL',
+        'PIXELTABLE_SQL_LOG_LEVEL',
     ):
         print(f'{var:25} = {os.environ.get(var)}')
 
@@ -191,12 +197,10 @@ def init_env(tmp_path_factory: pytest.TempPathFactory, worker_id: int) -> None: 
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
     stdout_handler.setFormatter(logging.Formatter(LOG_FMT_STR))
     pxt_logger = logging.getLogger('pixeltable')
-    pxt_logger.setLevel(logging.DEBUG)
     pxt_logger.addHandler(stdout_handler)
     test_logger = logging.getLogger('pixeltable_test')
     test_logger.setLevel(logging.DEBUG)
     test_logger.addHandler(stdout_handler)
-    logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
 
     yield
     FileCache.get().validate()

--- a/tool/create_test_db_dump.py
+++ b/tool/create_test_db_dump.py
@@ -105,7 +105,7 @@ class Dumper:
         Env._init_env(reinit_db=True)
 
         logging.getLogger('pixeltable').setLevel(logging.DEBUG)
-        logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
+        logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter(LOG_FMT_STR))
         logging.getLogger('pixeltable').addHandler(handler)

--- a/tool/random_ops.py
+++ b/tool/random_ops.py
@@ -223,7 +223,7 @@ class RandomTableOps:
         logging.getLogger('pixeltable').setLevel(logging.DEBUG)
         logging.getLogger('pixeltable').addHandler(random_ops_log_handler)
 
-        logging.getLogger('sqlalchemy.engine').setLevel(logging.DEBUG)
+        logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
     def _flush_stats(self, *, force: bool = False) -> None:
         if self.stats_file is None:


### PR DESCRIPTION
This effectively enables more verbose logging in the CLI daemon which is auto-started by the client.

* Two new log-related config options
* `--test` daemon arg now just means "enable test-only endpoints" 
* sqlalchemy log level changed from DEBUG to INFO which is still sufficient to see the SQL statements being run. DEBUG causes query results to be logged, which is excessive.