### PR TITLE
fix(dashboard): read TableMetadata.indexes after #1518 rename

### DIFF
--- a/dashboard/src/components/TableDetailView.tsx
+++ b/dashboard/src/components/TableDetailView.tsx
@@ -1855,7 +1855,7 @@ export function TableDetailView({ tablePath }: { tablePath: string }) {
           <div ref={schemaContentRef} className="flex flex-col h-full min-h-0 bg-card">
           <ColumnChips
             columns={Object.values(metadata.columns)}
-            indices={Object.values(metadata.indices).filter(idx => idx.index_type === 'embedding')}
+            indices={Object.values(metadata.indexes ?? {}).filter(idx => idx.index_type === 'embedding')}
             tableMediaValidation={metadata.media_validation}
             expanded={schemaExpanded}
             onToggle={toggleSchema}

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -58,7 +58,7 @@ export interface TableMetadata {
   name: string;
   path: string;
   columns: Record<string, ColumnInfo>;
-  indices: Record<string, IndexInfo>;
+  indexes: Record<string, IndexInfo>;
   is_replica: boolean;
   is_view: boolean;
   is_snapshot: boolean;


### PR DESCRIPTION
## Summary
- #1518 renamed Python `TableMetadata.indices` → `indexes`. The table inspector still called `Object.values(metadata.indices)`, which threw and blanked every table page.
- Align TS `TableMetadata` with Python; keep the `ColumnChips` prop name. Pipeline DAG `indices` is unchanged (bridge already maps `md['indexes']`).
- Separate from #1524 (friendly errors) and #1523 (lineage catalog).