### PR TITLE
fix: support both SentenceTransformer embedding-dimension APIs

### DIFF
--- a/pixeltable/functions/huggingface.py
+++ b/pixeltable/functions/huggingface.py
@@ -78,7 +78,11 @@ def _(model_id: str) -> ts.ArrayType:
     from sentence_transformers import SentenceTransformer
 
     model = _lookup_model(model_id, SentenceTransformer)
-    return ts.ArrayType((model.get_embedding_dimension(),), dtype=ts.FloatType(), nullable=False)
+    # Newer sentence-transformers: get_embedding_dimension; older wheels: get_sentence_embedding_dimension.
+    get_dim = getattr(model, 'get_embedding_dimension', None)
+    if not callable(get_dim):
+        get_dim = model.get_sentence_embedding_dimension
+    return ts.ArrayType((get_dim(),), dtype=ts.FloatType(), nullable=False)
 
 
 @pxt.udf(batch_size=32)


### PR DESCRIPTION
## Summary
- Opening views/tables with a Hugging Face embedding index (e.g. `app/chunks`) 500s: `SentenceTransformer` has no `get_embedding_dimension`.
- #1380 renamed to the newer API; this wheel still uses `get_sentence_embedding_dimension`. Try the new name, fall back to the old one.
- Separate from #1531 (dashboard `indexes` field) and #1524 (friendly API errors).

## Test plan
- [ ] Restart the local daemon so it loads this `huggingface.py`
- [ ] Open `app/chunks` (or any embedding view): schema/data load, no HTTP 500
- [ ] Open a table without embeddings (e.g. `basics_tutorial_agent/memory`): still works
- [ ] `pytest tests/functions/test_huggingface.py -k sentence_transformer` if HF deps/credentials are available


Made with [Cursor](https://cursor.com)