### PR TITLE
Add api for patching secrets on org/db

### DIFF
--- a/pixeltable/service/management_protocol.py
+++ b/pixeltable/service/management_protocol.py
@@ -7,7 +7,7 @@ import re
 from enum import Enum
 from typing import Literal, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from pixeltable.config import ServiceConfig
 
@@ -36,9 +36,8 @@ class ServiceOperationType(str, Enum):
 
     LIST_ORGS = 'list_orgs'
 
-    SET_SECRET = 'set_secret'
-    DELETE_SECRET = 'delete_secret'
     LIST_SECRETS = 'list_secrets'
+    PATCH_SECRETS = 'patch_secrets'
 
 
 # Db operations
@@ -141,29 +140,6 @@ class GetBundleUploadUrlResponse(BaseModel):
 # Secrets
 
 
-class SetSecretRequest(BaseModel):
-    operation_type: Literal[ServiceOperationType.SET_SECRET] = ServiceOperationType.SET_SECRET
-    org: str
-    db: Optional[str] = None
-    key: str
-    value: str
-
-
-class SetSecretResponse(BaseModel):
-    key: str
-
-
-class DeleteSecretRequest(BaseModel):
-    operation_type: Literal[ServiceOperationType.DELETE_SECRET] = ServiceOperationType.DELETE_SECRET
-    org: str
-    db: Optional[str] = None
-    key: str
-
-
-class DeleteSecretResponse(BaseModel):
-    key: str
-
-
 class ListSecretsRequest(BaseModel):
     operation_type: Literal[ServiceOperationType.LIST_SECRETS] = ServiceOperationType.LIST_SECRETS
     org: str
@@ -172,6 +148,20 @@ class ListSecretsRequest(BaseModel):
 
 class ListSecretsResponse(BaseModel):
     keys: list[str]
+
+
+class PatchSecretsRequest(BaseModel):
+    """One scope's secrets changed together: `set` upserts, `delete` removes, applied atomically."""
+
+    operation_type: Literal[ServiceOperationType.PATCH_SECRETS] = ServiceOperationType.PATCH_SECRETS
+    org: str
+    db: Optional[str] = None
+    set: dict[str, str] = Field(default_factory=dict)
+    delete: list[str] = Field(default_factory=list)
+
+
+class PatchSecretsResponse(BaseModel):
+    keys: list[str]  # every key in the scope after the patch
 
 
 # Services

--- a/pixeltable_cli/client/commands/secret.py
+++ b/pixeltable_cli/client/commands/secret.py
@@ -1,0 +1,96 @@
+"""`pxt secret {list,set,rm} <uri>` - manage org- and database-scoped runtime secrets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from pixeltable_cli.utils import split_pxt_uri
+
+from ..parser import Parser
+from ..utils import get_request, post_request
+
+EPILOG = """\
+Examples:
+  pxt secret list pxt://myorg
+  pxt secret list pxt://myorg:mydb
+  pxt secret set  pxt://myorg OPENAI_API_KEY=sk-... ANTHROPIC_API_KEY=sk-...
+  pxt secret rm   pxt://myorg:mydb OLD_KEY STALE_KEY
+
+Secrets set on an org reach every database in it; secrets set on a database apply to that one and
+win on a key collision. Each command restarts the pods that read them.
+"""
+
+
+def run(argv: list[str]) -> None:
+    parser = Parser(prog='pxt secret', description='manage runtime secrets', epilog=EPILOG)
+    sub = parser.add_subparsers(dest='action', required=True)
+
+    p = sub.add_parser('list', help='list secret names in a scope (never their values)')
+    p.add_argument('uri', help='Scope URI: pxt://org or pxt://org:db')
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    p = sub.add_parser('set', help='add or replace secrets')
+    p.add_argument('uri', help='Scope URI: pxt://org or pxt://org:db')
+    p.add_argument('assignments', nargs='+', metavar='KEY=VALUE')
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    p = sub.add_parser('rm', help='remove secrets')
+    p.add_argument('uri', help='Scope URI: pxt://org or pxt://org:db')
+    p.add_argument('keys', nargs='+', metavar='KEY')
+    p.add_argument('--json', action='store_true', dest='json_output', help='Emit JSON output')
+
+    args = parser.parse_args(argv)
+
+    if args.action == 'list':
+        _list(args)
+    elif args.action == 'set':
+        _patch(args, _assignments(args.assignments), [])
+    elif args.action == 'rm':
+        _patch(args, {}, args.keys)
+
+
+def _scope(uri: str, prog: str) -> tuple[str, str | None]:
+    """Parse pxt://org or pxt://org:db; a db is the narrower scope, its absence means the whole org."""
+    parts = split_pxt_uri(uri)
+    if parts is None or parts.path is not None:
+        print(f'{prog}: error: URI must be pxt://org or pxt://org:db, got {uri!r}', file=sys.stderr)
+        sys.exit(2)
+    return parts.org, parts.db
+
+
+def _assignments(items: list[str]) -> dict[str, str]:
+    secrets: dict[str, str] = {}
+    for item in items:
+        key, sep, value = item.partition('=')
+        if not sep or key == '':
+            print(f"pxt secret set: error: expected KEY=VALUE, got {item!r}", file=sys.stderr)
+            sys.exit(2)
+        secrets[key] = value
+    return secrets
+
+
+def _print_keys(keys: list[str], json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(keys))
+    elif not keys:
+        print('No secrets.')
+    else:
+        for key in keys:
+            print(key)
+
+
+def _list(args: argparse.Namespace) -> None:
+    org, db = _scope(args.uri, 'pxt secret list')
+    params = {'org': org}
+    if db is not None:
+        params['db'] = db
+    resp = get_request('/api/secrets', params)
+    _print_keys(resp.get('keys', []) if isinstance(resp, dict) else [], args.json_output)
+
+
+def _patch(args: argparse.Namespace, to_set: dict[str, str], to_delete: list[str]) -> None:
+    org, db = _scope(args.uri, f'pxt secret {args.action}')
+    resp = post_request('/api/secrets', {'org': org, 'db': db, 'set': to_set, 'delete': to_delete})
+    _print_keys(resp.get('keys', []) if isinstance(resp, dict) else [], args.json_output)

--- a/pixeltable_cli/client/main.py
+++ b/pixeltable_cli/client/main.py
@@ -35,6 +35,7 @@ COMMANDS: dict[str, str] = {
     'db': 'manage hosted databases (create/list/status/start/stop/update/update-runtime/delete)',
     'service': 'manage hosted services (create/update/list/status/start/stop/delete)',
     'org': 'manage organizations (list/status)',
+    'secret': 'manage runtime secrets for an org or database (list/set/rm)',
 }
 
 

--- a/pixeltable_cli/models.py
+++ b/pixeltable_cli/models.py
@@ -198,6 +198,13 @@ class SchemaUpdateBody(BaseModel):
     allow_destructive: bool = False
 
 
+class PatchSecretsBody(BaseModel):
+    org: str
+    db: str | None = None
+    set: dict[str, str] = {}
+    delete: list[str] = []
+
+
 class CwdBody(BaseModel):
     uri: str
 

--- a/pixeltable_cli/server/routes.py
+++ b/pixeltable_cli/server/routes.py
@@ -25,7 +25,9 @@ from pixeltable.service.management_protocol import (
     GetServiceRequest,
     ListDbRequest,
     ListOrgsRequest,
+    ListSecretsRequest,
     ListServicesRequest,
+    PatchSecretsRequest,
     StartDbRequest,
     StartServiceRequest,
     StopDbRequest,
@@ -707,6 +709,21 @@ def get_org(req: Request) -> dict[str, Any]:
 @router.get('/api/dbs')
 def list_dbs(req: Request) -> dict[str, Any]:
     return management_client.api_call(ListDbRequest(org=req.required_query_str('org')))
+
+
+@router.get('/api/secrets')
+def list_secrets(req: Request) -> dict[str, Any]:
+    return management_client.api_call(
+        ListSecretsRequest(org=req.required_query_str('org'), db=req.query_str('db'))
+    )
+
+
+@router.post('/api/secrets')
+def patch_secrets(req: Request) -> dict[str, Any]:
+    body = req.body(models.PatchSecretsBody)
+    return management_client.api_call(
+        PatchSecretsRequest(org=body.org, db=body.db, set=body.set, delete=body.delete)
+    )
 
 
 @router.post('/api/dbs')


### PR DESCRIPTION
goal is to add/replace/delete secrets in single api call.

Also adding simple version of pxt secret cli 
We can use this cli/api in org update or db update too