### PR TITLE
Test harness for Pixeltable cloud

### DIFF
--- a/pixeltable/catalog/local_table.py
+++ b/pixeltable/catalog/local_table.py
@@ -242,7 +242,8 @@ class LocalTable(Table):
         if mutable_only:
             views = [t for t in views if t._tbl_version_path.is_mutable()]
         if recursive:
-            views.extend(t for view in views for t in view._get_views(recursive=True, mutable_only=mutable_only))
+            descendants = [t for view in views for t in view._get_views(recursive=True, mutable_only=mutable_only)]
+            views.extend(descendants)
         return views
 
     def columns(self) -> list[str]:
@@ -681,7 +682,7 @@ class LocalTable(Table):
 
             if len(dependent_views) > 0:
                 dependent_views_str = '\n'.join(
-                    f'view: {view._path()}, predicate: {predicate}' for view, predicate in dependent_views
+                    sorted(f'view: {view._path()}, predicate: {predicate}' for view, predicate in dependent_views)
                 )
                 raise excs.RequestError(
                     excs.ErrorCode.UNSUPPORTED_OPERATION,

--- a/pixeltable/catalog/path.py
+++ b/pixeltable/catalog/path.py
@@ -108,6 +108,18 @@ class Path:
         return cls(org=org, db=db, components=tuple(components), version=version)
 
     @classmethod
+    def localize(cls, path: str) -> str:
+        """Remove the pxt://org:db/ prefix from a path (if present)."""
+        normalized = cls._normalize(path)
+        if normalized.startswith('pxt://'):
+            m = _URI_RE.match(normalized)
+            if m is None:
+                raise excs.RequestError(excs.ErrorCode.INVALID_PATH, f'URI must have an organization: {path!r}')
+            path_part = m.group('rest') or ''
+            return path_part
+        return normalized
+
+    @classmethod
     def _normalize(cls, s: str) -> str:
         """Rewrite a recognized Pixeltable web URL to its canonical pxt:// form; otherwise unchanged."""
         for prefix in _URL_PREFIXES:

--- a/pixeltable/catalog/path.py
+++ b/pixeltable/catalog/path.py
@@ -110,14 +110,8 @@ class Path:
     @classmethod
     def localize(cls, path: str) -> str:
         """Remove the pxt://org:db/ prefix from a path (if present)."""
-        normalized = cls._normalize(path)
-        if normalized.startswith('pxt://'):
-            m = _URI_RE.match(normalized)
-            if m is None:
-                raise excs.RequestError(excs.ErrorCode.INVALID_PATH, f'URI must have an organization: {path!r}')
-            path_part = m.group('rest') or ''
-            return path_part
-        return normalized
+        p = Path.parse(path)
+        return str(Path(components=p.components, version=p.version))
 
     @classmethod
     def _normalize(cls, s: str) -> str:

--- a/pixeltable/catalog/path.py
+++ b/pixeltable/catalog/path.py
@@ -91,7 +91,11 @@ class Path:
 
         if len(components) == 0 and not allow_empty_path:
             raise excs.RequestError(excs.ErrorCode.INVALID_PATH, f'Invalid path: {path}')
-        # component identifier validation is enforced by __post_init__ at construction
+        # validate components here (before calling __post_init__) so that if validation fails, the error message
+        # exactly matches the input
+        if not all(is_valid_identifier(c, allow_hyphens=True) for c in components):
+            raise excs.RequestError(excs.ErrorCode.INVALID_PATH, f'Invalid path: {path}')
+
         if version is not None and not allow_versioned_path:
             raise excs.RequestError(excs.ErrorCode.INVALID_PATH, f'Versioned path not allowed here: {path}')
 

--- a/pixeltable/catalog/path.py
+++ b/pixeltable/catalog/path.py
@@ -110,7 +110,7 @@ class Path:
     @classmethod
     def localize(cls, path: str) -> str:
         """Remove the pxt://org:db/ prefix from a path (if present)."""
-        p = Path.parse(path)
+        p = Path.parse(path, allow_empty_path=True, allow_versioned_path=True)
         return str(Path(components=p.components, version=p.version))
 
     @classmethod

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -163,9 +163,10 @@ class PixeltableSource(pydantic.BaseModel):
 class DatabaseRuntimeConfig(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra='forbid')
 
-    exclude: list[str] | None = None
-    include: list[str] | None = None
-    include_only: list[str] | None = None
+    exclude: list[str] | None = None  # glob patterns to exclude from the bundle
+    include: list[str] | None = None  # glob patterns to explicitly include (overrides exclude or .gitignore)
+    include_only: list[str] | None = None  # glob patterns to include as the *only* files in the bundle
+                                           # (must be used independently of exclude/include)
     system_dependencies: list[str] | None = None
     # Override the runtime Python version.
     python_version: str | None = None

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -163,8 +163,9 @@ class PixeltableSource(pydantic.BaseModel):
 class DatabaseRuntimeConfig(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra='forbid')
 
-    include: list[str] | None = None
     exclude: list[str] | None = None
+    include: list[str] | None = None
+    include_only: list[str] | None = None
     system_dependencies: list[str] | None = None
     # Override the runtime Python version.
     python_version: str | None = None

--- a/pixeltable/config.py
+++ b/pixeltable/config.py
@@ -166,7 +166,7 @@ class DatabaseRuntimeConfig(pydantic.BaseModel):
     exclude: list[str] | None = None  # glob patterns to exclude from the bundle
     include: list[str] | None = None  # glob patterns to explicitly include (overrides exclude or .gitignore)
     include_only: list[str] | None = None  # glob patterns to include as the *only* files in the bundle
-                                           # (must be used independently of exclude/include)
+    # (must be used independently of exclude/include)
     system_dependencies: list[str] | None = None
     # Override the runtime Python version.
     python_version: str | None = None

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import toml
 from pathspec import PathSpec
+from tqdm import tqdm
 
 from pixeltable import config, exceptions as excs, metadata
 from pixeltable.env import Env
@@ -21,18 +22,74 @@ _logger = logging.getLogger(__name__)
 
 
 def _resolve_patterns(project_dir: Path, patterns: list[str]) -> set[Path]:
+    """Files under project_dir matching patterns, which use git wildmatch syntax (`*`, `**`, `!`, `dir/`).
+    """
+    # 'gitignore' names the pattern dialect to parse `patterns` with; no .gitignore file is read here
     spec = PathSpec.from_lines('gitignore', patterns)
     return {p for p in project_dir.rglob('*') if p.is_file() and spec.match_file(p.relative_to(project_dir))}
 
 
-def _read_gitignore(project_dir: Path) -> list[str]:
-    gitignore = project_dir / '.gitignore'
+def _gitignore_spec(dir_path: Path) -> PathSpec | None:
+    """The PathSpec for dir_path's own .gitignore, or None if it has none."""
+    gitignore = dir_path / '.gitignore'
     if not gitignore.is_file():
-        return []
-    return gitignore.read_text().splitlines()
+        return None
+    return PathSpec.from_lines('gitignore', gitignore.read_text().splitlines())
 
 
-def _collect_project_files(project_dir: Path, exclude: list[str] | None, include: list[str] | None, include_only: list[str] | None) -> list[Path]:
+def _is_gitignored(path: Path, is_dir: bool, specs: list[tuple[Path, PathSpec]]) -> bool:
+    """Whether path is ignored by specs, a list of (directory, its .gitignore) ordered outermost first.
+
+    The innermost .gitignore that has anything to say about path decides, since git lets a nested
+    .gitignore override the directories above it. Patterns are matched relative to the directory the
+    .gitignore lives in, and a trailing slash is what makes a directory-only pattern (`build/`) match.
+    """
+    for base, spec in reversed(specs):
+        rel = path.relative_to(base).as_posix() + ('/' if is_dir else '')
+        include = spec.check_file(rel).include
+        if include is not None:
+            return include
+    return False
+
+
+def _collect_unignored_files(project_dir: Path) -> set[Path]:
+    """All files under project_dir that git would not ignore.
+
+    Honors the .gitignore at every level of the tree, not just project_dir's: tools such as ruff, mypy and
+    pytest keep their caches out of git by writing a `.gitignore` containing `*` into the cache directory
+    itself, so a root-only scan bundles those caches even though `git status` reports a clean tree.
+
+    An ignored directory is not descended into, matching git's rule that a nested negation cannot
+    re-include a file whose parent directory is excluded. Directory symlinks are not followed (git stores
+    them as symlinks rather than recursing).
+
+    .git is skipped here, as git itself does, but only by default: an `include` pattern of `.git/**` still
+    reaches it, which a project that derives its version from VCS metadata needs.
+    """
+    files: set[Path] = set()
+
+    def visit(dir_path: Path, specs: list[tuple[Path, PathSpec]]) -> None:
+        spec = _gitignore_spec(dir_path)
+        if spec is not None:
+            specs = [*specs, (dir_path, spec)]
+        for entry in dir_path.iterdir():
+            if entry.name == '.git':
+                continue
+            is_dir = entry.is_dir() and not entry.is_symlink()
+            if _is_gitignored(entry, is_dir, specs):
+                continue
+            if is_dir:
+                visit(entry, specs)
+            elif entry.is_file():
+                files.add(entry)
+
+    visit(project_dir, [])
+    return files
+
+
+def _collect_project_files(
+    project_dir: Path, exclude: list[str] | None, include: list[str] | None, include_only: list[str] | None
+) -> list[Path]:
     if include_only is not None:
         if include is not None or exclude is not None:
             raise excs.RequestError(
@@ -42,9 +99,8 @@ def _collect_project_files(project_dir: Path, exclude: list[str] | None, include
         files = _resolve_patterns(project_dir, include_only)
 
     else:
-        files = {p for p in project_dir.rglob('*') if p.is_file()}
-        # Apply .gitignore excludes
-        files -= _resolve_patterns(project_dir, _read_gitignore(project_dir))
+        # Apply .gitignore excludes, at every level of the tree
+        files = _collect_unignored_files(project_dir)
         # Apply explicit excludes
         if exclude is not None:
             files -= _resolve_patterns(project_dir, exclude)
@@ -129,14 +185,22 @@ def _load_database_runtime_config(project_dir: Path) -> config.DatabaseRuntimeCo
     return lookup_database_runtime_config()
 
 
+def _abbrev_path(path: str, max_len: int = 40) -> str:
+    """Truncate path from the left, so that a long path doesn't wrap the progress bar line."""
+    return path if len(path) <= max_len else '…' + path[-(max_len - 1) :]
+
+
 def __add_tarfile(tf: tarfile.TarFile, name: str, content: bytes) -> None:
     info = tarfile.TarInfo(name=name)
     info.size = len(content)
     tf.addfile(info, fileobj=io.BytesIO(content))
 
 
-def build_db_runtime_bundle(project_dir: Path | None = None) -> Path:
+def build_db_runtime_bundle(project_dir: Path | None = None, show_progress: bool = False) -> Path:
     """Package the current project into a tarball for updating a hosted database runtime.
+
+    If show_progress is True, a progress bar tracking the number of project files added, and naming the
+    file most recently added, is displayed.
 
     Bundle layout:
         metadata.json   (always) — pxt_md_version, python_version
@@ -178,6 +242,12 @@ def build_db_runtime_bundle(project_dir: Path | None = None) -> Path:
             has_lockfile = True
     files = sorted(files_set)
 
+    print(f'A runtime bundle will be built containing {len(files)} files from {project_dir}.')
+    print(
+        'By default, all files not ignored by .gitignore are included; '
+        'you can override this with include/exclude in pixeltable.toml.'
+    )
+
     conda_env_yaml = _export_conda_env()
 
     # No lockfile and no conda export means the image has no source for Python dependencies.
@@ -198,13 +268,20 @@ def build_db_runtime_bundle(project_dir: Path | None = None) -> Path:
     if runtime_cfg and runtime_cfg.pixeltable_source:
         meta['pixeltable_source'] = runtime_cfg.pixeltable_source.model_dump(exclude_none=True)
 
-    with tarfile.open(bundle_path, 'w:bz2') as tf:
+    with (
+        tarfile.open(bundle_path, 'w:bz2') as tf,
+        tqdm(desc='Building runtime bundle', total=len(files), unit=' files', disable=not show_progress) as bar,
+    ):
         __add_tarfile(tf, 'metadata.json', json.dumps(meta).encode('utf-8'))
         if conda_env_yaml is not None:
             __add_tarfile(tf, 'project/conda-environment.yaml', conda_env_yaml)
-        for f in sorted(files):
+        for f in files:
             relpath = f.relative_to(project_dir)
+            # refresh=False: the postfix is drawn by the following update(), which respects tqdm's redraw interval
+            bar.set_postfix_str(_abbrev_path(str(relpath)), refresh=False)
             tf.add(f, arcname=f'project/{relpath}')
+            bar.update(1)
+        bar.set_postfix_str('', refresh=False)
 
     _logger.info(f'Runtime bundle created: {bundle_path}')
     return bundle_path

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -32,15 +32,26 @@ def _read_gitignore(project_dir: Path) -> list[str]:
     return gitignore.read_text().splitlines()
 
 
-def _collect_project_files(project_dir: Path, include: list[str] | None, exclude: list[str] | None) -> list[Path]:
-    if include is not None:
-        files = _resolve_patterns(project_dir, include)
+def _collect_project_files(project_dir: Path, exclude: list[str] | None, include: list[str] | None, include_only: list[str] | None) -> list[Path]:
+    if include_only is not None:
+        if include is not None or exclude is not None:
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_CONFIGURATION,
+                'Cannot specify both include_only and include/exclude in [pixeltable.database] configuration',
+            )
+        files = _resolve_patterns(project_dir, include_only)
+
     else:
         files = {p for p in project_dir.rglob('*') if p.is_file()}
+        # Apply .gitignore excludes
+        files -= _resolve_patterns(project_dir, _read_gitignore(project_dir))
+        # Apply explicit excludes
+        if exclude is not None:
+            files -= _resolve_patterns(project_dir, exclude)
+        # Apply explicit includes (which override excludes)
+        if include is not None:
+            files |= _resolve_patterns(project_dir, include)
 
-    files -= _resolve_patterns(project_dir, _read_gitignore(project_dir))
-    if exclude is not None:
-        files -= _resolve_patterns(project_dir, exclude)
     return sorted(files)
 
 
@@ -147,8 +158,9 @@ def build_db_runtime_bundle(project_dir: Path | None = None) -> Path:
         raise FileNotFoundError(f'Project directory does not exist: {project_dir}')
 
     runtime_cfg = _load_database_runtime_config(project_dir)
-    include = runtime_cfg.include if runtime_cfg else None
     exclude = runtime_cfg.exclude if runtime_cfg else None
+    include = runtime_cfg.include if runtime_cfg else None
+    include_only = runtime_cfg.include_only if runtime_cfg else None
     system_dependencies: list[str] = (runtime_cfg.system_dependencies or []) if runtime_cfg else []
 
     # Config override wins; otherwise use the deploy environment's version.
@@ -156,7 +168,7 @@ def build_db_runtime_bundle(project_dir: Path | None = None) -> Path:
         f'{sys.version_info.major}.{sys.version_info.minor}'
     )
 
-    files_set = set(_collect_project_files(project_dir, include, exclude))
+    files_set = set(_collect_project_files(project_dir, exclude, include, include_only))
     # Lock files are always bundled regardless of .gitignore — they control reproducible installs.
     has_lockfile = False
     for lock_name in ('uv.lock', 'poetry.lock', 'requirements.txt'):

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -244,7 +244,7 @@ def build_db_runtime_bundle(project_dir: Path | None = None, show_progress: bool
     print(f'A runtime bundle will be built containing {len(files)} files from {project_dir}.')
     print(
         'By default, all files not ignored by .gitignore are included; '
-        'you can override this with include/exclude in pixeltable.toml.'
+        'you can adjust this behavior with include/exclude in pixeltable.toml.'
     )
 
     conda_env_yaml = _export_conda_env()

--- a/pixeltable/serving/deploy.py
+++ b/pixeltable/serving/deploy.py
@@ -22,8 +22,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _resolve_patterns(project_dir: Path, patterns: list[str]) -> set[Path]:
-    """Files under project_dir matching patterns, which use git wildmatch syntax (`*`, `**`, `!`, `dir/`).
-    """
+    """Files under project_dir matching patterns, which use git wildmatch syntax (`*`, `**`, `!`, `dir/`)."""
     # 'gitignore' names the pattern dialect to parse `patterns` with; no .gitignore file is read here
     spec = PathSpec.from_lines('gitignore', patterns)
     return {p for p in project_dir.rglob('*') if p.is_file() and spec.match_file(p.relative_to(project_dir))}

--- a/pixeltable_cli/client/commands/db.py
+++ b/pixeltable_cli/client/commands/db.py
@@ -7,6 +7,7 @@ import json
 import sys
 import urllib.request
 from pathlib import Path
+from typing import IO, Any
 
 from ..hosted import (
     RUNTIME_POLL_INTERVAL,
@@ -192,9 +193,24 @@ def _delete(args: argparse.Namespace) -> None:
         print(f"Deleted database '{db}'.")
 
 
+class _ProgressReader:
+    """File-like wrapper that advances a progress bar as the wrapped file is read."""
+
+    def __init__(self, f: IO[bytes], bar: Any) -> None:
+        self._f = f
+        self._bar = bar
+
+    def read(self, size: int = -1) -> bytes:
+        data = self._f.read(size)
+        self._bar.update(len(data))
+        return data
+
+
 def _update_runtime(args: argparse.Namespace) -> None:
-    # imported lazily: build_db_runtime_bundle pulls in pixeltable, which the stdlib-only client avoids
+    # imported lazily: these pull in pixeltable and tqdm, which the stdlib-only client avoids
     # loading for the other db subcommands
+    from tqdm import tqdm
+
     from pixeltable.serving.deploy import build_db_runtime_bundle
 
     org, db = resolve_db_uri(args.db_uri, prog='pxt db update-runtime')
@@ -213,35 +229,34 @@ def _update_runtime(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    if not args.json_output:
-        print('Building runtime bundle...', end=' ', flush=True)
-    bundle_path = build_db_runtime_bundle(project_dir)
-    if not args.json_output:
-        size_mb = bundle_path.stat().st_size / (1024 * 1024)
-        print(f'done ({size_mb:.1f} MB)')
+    show_progress = not args.json_output
+    bundle_path = build_db_runtime_bundle(project_dir, show_progress=show_progress)
 
     try:
-        if not args.json_output:
-            print('Uploading bundle...', end=' ', flush=True)
         url_resp = get_request('/api/db/upload-url', {'org': org, 'db': db})
         presigned_url = url_resp['presigned_url']
         bundle_s3_key = url_resp['bundle_s3_key']
 
-        data = bundle_path.read_bytes()  # urllib wants a bytes-like body; the bundle is a small project tarball
-        req = urllib.request.Request(presigned_url, data=data, method='PUT')
-        req.add_header('Content-Type', 'application/octet-stream')
-        req.add_header('Content-Length', str(len(data)))
-        with urllib.request.urlopen(req, timeout=300) as r:
-            if r.status >= 400:
-                raise RuntimeError(f'Bundle upload failed: HTTP {r.status}')
-        if not args.json_output:
-            print('done')
+        bundle_size = bundle_path.stat().st_size
+        with (
+            bundle_path.open('rb') as f,
+            tqdm(
+                desc='Uploading runtime bundle', total=bundle_size, unit='B', unit_scale=True, disable=not show_progress
+            ) as bar,
+        ):
+            # urllib streams a file-like body in chunks, which lets the bar advance during the upload
+            req = urllib.request.Request(presigned_url, data=_ProgressReader(f, bar), method='PUT')
+            req.add_header('Content-Type', 'application/octet-stream')
+            req.add_header('Content-Length', str(bundle_size))
+            with urllib.request.urlopen(req, timeout=300) as r:
+                if r.status >= 400:
+                    raise RuntimeError(f'Bundle upload failed: HTTP {r.status}')
     finally:
         bundle_path.unlink(missing_ok=True)
 
     post_request('/api/db/update-runtime', {'org': org, 'db': db, 'bundle_s3_key': bundle_s3_key})
 
-    label = None if args.json_output else 'Waiting for runtime build...'
+    label = None if args.json_output else 'Waiting for runtime build (this may take 10 minutes or longer) ...'
     result = poll_state(
         '/api/db', {'org': org, 'db': db}, 'database', {'UPDATING'}, RUNTIME_POLL_INTERVAL, RUNTIME_POLL_TIMEOUT, label
     )

--- a/pixeltable_cli/client/commands/db.py
+++ b/pixeltable_cli/client/commands/db.py
@@ -196,6 +196,9 @@ def _delete(args: argparse.Namespace) -> None:
 class _ProgressReader:
     """File-like wrapper that advances a progress bar as the wrapped file is read."""
 
+    f: IO[bytes]
+    bar: Any
+
     def __init__(self, f: IO[bytes], bar: Any) -> None:
         self._f = f
         self._bar = bar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,9 @@ strict_optional = false
 warn_return_any = true
 warn_unused_ignores = true
 
+[tool.pixeltable.database]
+include = ['pixeltable/_version.py']  # in .gitignore but required for Pixeltable to function
+
 [tool.pyright]
 typeCheckingMode = "off"
 extraPaths = ["packages/opentelemetry-instrumentation-pixeltable/src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
     "pypdfium2>=4.30.0",
     "pathspec>=0.10.2",
     "psutil>=5.9",
+    "tqdm>=4.64",
     "typing-extensions>=4.15",
 ]
 
@@ -290,7 +291,9 @@ warn_return_any = true
 warn_unused_ignores = true
 
 [tool.pixeltable.database]
-include = ['pixeltable/_version.py']  # in .gitignore but required for Pixeltable to function
+# we need the repo for the uv-dynamic-versioning install, and pixeltable/_version.py in order for the
+# package to function. Both are ignored by default
+include = ['.git/**', 'pixeltable/_version.py']
 
 [tool.pyright]
 typeCheckingMode = "off"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,7 +330,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if metafunc.definition.get_closest_marker('local') is not None:
         # local-only: don't fork the axis; catalog_mode defaults to 'local' and the nodeid stays unparametrized
         return
-    metafunc.parametrize('catalog_mode', ['local', 'proxy', 'cloud'], indirect=True)
+    metafunc.parametrize('catalog_mode', ('local', 'proxy', 'cloud'), indirect=True)
 
 
 @pytest.fixture(scope='function')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,6 +297,10 @@ def cloud_db_base_uri(init_env: None) -> Iterator[str]:
         subprocess.run(('pxt', 'db', 'create', uri), text=True, timeout=900, check=True)
 
     try:
+        if use_temporary_db:
+            _logger.info('Updating runtime on test db: %s', uri)
+            subprocess.run(('pxt', 'db', 'update-runtime', uri), text=True, timeout=1800, check=True)
+
         _logger.info('Checking cloud db status: %s', uri)
         proc = subprocess.run(
             ('pxt', 'db', 'status', uri, '--json'), capture_output=True, text=True, timeout=60, check=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import platform
 import shutil
+import subprocess
 import sys
 import uuid
 from typing import Callable, Iterator
@@ -25,6 +26,7 @@ from pixeltable.env import LOG_FMT_STR, Env
 from pixeltable.functions.huggingface import clip, sentence_transformer
 from pixeltable.metadata.schema import base_metadata
 from pixeltable.runtime import get_runtime, reset_runtime
+from pixeltable.service import proxy_daemon
 from pixeltable.utils.filecache import FileCache
 from pixeltable.utils.local_store import LocalStore, TempStore
 from pixeltable.utils.sql import add_option_to_db_url
@@ -48,12 +50,6 @@ DO_RERUN: bool = True
 
 def pytest_addoption(parser: argparsing.Parser) -> None:
     parser.addoption('--no-rerun', action='store_true', default=False, help='Do not rerun any failed tests.')
-    parser.addoption(
-        '--cloud',
-        metavar='pxt://ORG:DB',
-        default=None,
-        help='Run tests against a cloud database, e.g. --cloud=pxt://pixeltable:clitest-e2e1',
-    )
     parser.addoption(
         '--keep-cloud-resources',
         action='store_true',
@@ -146,7 +142,6 @@ def init_env(tmp_path_factory: pytest.TempPathFactory, worker_id: int) -> None: 
     os.environ['PIXELTABLE_CONFIG'] = str(shared_home / 'config.toml')
     os.environ['PIXELTABLE_DB'] = _worker_db_name(worker_id)
     os.environ['PIXELTABLE_PGDATA'] = str(shared_home / 'pgdata')
-    os.environ['PIXELTABLE_API_URL'] = 'https://preprod-internal-api.pixeltable.com'
     os.environ['FIFTYONE_DATABASE_DIR'] = f'{home_dir}/.fiftyone'
     # Verbose logging, for this process and for every pixeltable process it spawns (the proxy daemon, the pxt CLI
     # daemon)
@@ -168,7 +163,6 @@ def init_env(tmp_path_factory: pytest.TempPathFactory, worker_id: int) -> None: 
         'PIXELTABLE_CONFIG',
         'PIXELTABLE_DB',
         'PIXELTABLE_PGDATA',
-        'PIXELTABLE_API_URL',
         'FIFTYONE_DATABASE_DIR',
         'HF_HOME',
         'PIXELTABLE_DB_CONNECT_STR',
@@ -286,7 +280,6 @@ def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
     # the proxy daemon serves over HTTP via fastapi/uvicorn (the serve extra); a minimal install omits them
     pytest.importorskip('fastapi')
     pytest.importorskip('uvicorn')
-    from pixeltable.service import proxy_daemon
 
     db = _worker_db_name(worker_id)
     proxy_daemon.start(db, test_mode=True)
@@ -296,6 +289,37 @@ def proxy_daemon_db(init_env: None, worker_id: str) -> Iterator[str]:
         # stop() rather than delete(): delete() would remove the daemon's logs, making it hard to debug CI failures.
         # The database will be cleared before the next test run.
         proxy_daemon.stop(db)
+
+
+@pytest.fixture(scope='session')
+def cloud_db_base_uri(init_env: None) -> Iterator[str]:
+    uri = os.environ.get('PXTTEST_CLOUD_DB_URI')
+
+    use_temporary_db = not uri
+    if use_temporary_db:
+        uri = f'pxt://pixeltable:pxttest-{uuid.uuid4().hex[:21]}'
+
+        _logger.info('Creating temporary cloud test db: %s', uri)
+        subprocess.run(
+            ('pxt', 'db', 'create', uri), env=os.environ, text=True, timeout=900, check=True
+        )
+
+    try:
+        _logger.info('Checking cloud db status: %s', uri)
+        res = subprocess.run(
+            ('pxt', 'db', 'status', uri, '--json'), capture_output=True, text=True, timeout=60, check=True
+        )
+        print(res.stdout)
+        assert 'AVAILABLE' in res.stdout
+
+        yield uri
+
+    finally:
+        if use_temporary_db:
+            _logger.info('Deleting temporary cloud test db: %s', uri)
+            proc = subprocess.run('pxt', 'db', 'delete', uri, timeout=900, check=False)
+            if proc.returncode != 0:
+                _logger.warning('Failed to delete cloud test db: %s', uri)
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
@@ -313,10 +337,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if metafunc.definition.get_closest_marker('local') is not None:
         # local-only: don't fork the axis; catalog_mode defaults to 'local' and the nodeid stays unparametrized
         return
-    if metafunc.config.getoption('--cloud', default=None) is not None:
-        metafunc.parametrize('catalog_mode', ['cloud'], indirect=True)
-    else:
-        metafunc.parametrize('catalog_mode', ['local', 'proxy'], indirect=True)
+    metafunc.parametrize('catalog_mode', ['local', 'proxy', 'cloud'], indirect=True)
 
 
 @pytest.fixture(scope='function')
@@ -343,29 +364,22 @@ def make_catalog_path(
     _reset_catalog_state()
 
     if catalog_mode == 'proxy':
-        from pixeltable.service import proxy_daemon
-
         db = request.getfixturevalue('proxy_daemon_db')
         proxy_daemon.reinitialize(db)
         prefix = f'pxt://local:{db}'
 
         def p(path: str) -> str:
             return f'{prefix}/{path}' if path else prefix
-    elif catalog_mode == 'cloud':
-        import uuid as _uuid
 
-        db_uri = request.config.getoption('--cloud')
-        # If db_uri has a sub-path (e.g. pxt://org:db/tests), create it first.
-        uri_path = db_uri[len('pxt://') :].split('/', 1)
-        if len(uri_path) > 1 and uri_path[1]:
-            pxt.create_dir(db_uri, if_exists='ignore')
-        # Each test run gets its own namespace so tests don't collide.
-        run_id = _uuid.uuid4().hex[:8]
-        prefix = f'{db_uri}/test_{run_id}'
+    elif catalog_mode == 'cloud':
+        cloud_db_base_uri = request.getfixturevalue('cloud_db_base_uri')
+        test_dir = uuid.uuid4().hex
+        prefix = f'{cloud_db_base_uri}/test_{test_dir}'
         pxt.create_dir(prefix)
 
         def p(path: str) -> str:
             return f'{prefix}/{path}' if path else prefix
+
     else:
 
         def p(path: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,12 +50,6 @@ DO_RERUN: bool = True
 
 def pytest_addoption(parser: argparsing.Parser) -> None:
     parser.addoption('--no-rerun', action='store_true', default=False, help='Do not rerun any failed tests.')
-    parser.addoption(
-        '--keep-cloud-resources',
-        action='store_true',
-        default=False,
-        help='Leave the hosted database and service created by the cloud e2e tests in place, for inspection.',
-    )
 
 
 def pytest_configure(config: PytestConfig) -> None:
@@ -309,8 +303,9 @@ def cloud_db_base_uri(init_env: None) -> Iterator[str]:
         res = subprocess.run(
             ('pxt', 'db', 'status', uri, '--json'), capture_output=True, text=True, timeout=60, check=True
         )
-        print(res.stdout)
-        assert 'AVAILABLE' in res.stdout
+        _logger.info(res.stdout.strip())
+        json_res = json.loads(res.stdout)
+        assert json_res['state'] == 'AVAILABLE', f"Cloud db is not ready: {uri}"
 
         yield uri
 
@@ -372,9 +367,14 @@ def make_catalog_path(
             return f'{prefix}/{path}' if path else prefix
 
     elif catalog_mode == 'cloud':
+        for required_cloud_env_var in ('PIXELTABLE_API_KEY', 'PIXELTABLE_API_URL', 'PIXELTABLE_CLOUD_HOST'):
+            if not os.environ.get(required_cloud_env_var):
+                pytest.skip(f'{required_cloud_env_var} is not set.')
+
         cloud_db_base_uri = request.getfixturevalue('cloud_db_base_uri')
         test_dir = uuid.uuid4().hex
         prefix = f'{cloud_db_base_uri}/test_{test_dir}'
+        _logger.info('Creating test directory in cloud catalog: %s', prefix)
         pxt.create_dir(prefix)
 
         def p(path: str) -> str:
@@ -388,6 +388,7 @@ def make_catalog_path(
     yield p
 
     if catalog_mode == 'cloud':
+        _logger.info('Dropping test directory in cloud catalog: %s', prefix)
         pxt.drop_dir(prefix, force=True, if_not_exists='ignore')
 
     _validate_catalog_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,25 +294,23 @@ def cloud_db_base_uri(init_env: None) -> Iterator[str]:
         uri = f'pxt://pixeltable:pxttest-{uuid.uuid4().hex[:21]}'
 
         _logger.info('Creating temporary cloud test db: %s', uri)
-        subprocess.run(
-            ('pxt', 'db', 'create', uri), env=os.environ, text=True, timeout=900, check=True
-        )
+        subprocess.run(('pxt', 'db', 'create', uri), text=True, timeout=900, check=True)
 
     try:
         _logger.info('Checking cloud db status: %s', uri)
-        res = subprocess.run(
+        proc = subprocess.run(
             ('pxt', 'db', 'status', uri, '--json'), capture_output=True, text=True, timeout=60, check=True
         )
-        _logger.info(res.stdout.strip())
-        json_res = json.loads(res.stdout)
-        assert json_res['state'] == 'AVAILABLE', f"Cloud db is not ready: {uri}"
+        _logger.info(proc.stdout.strip())
+        res = json.loads(proc.stdout)
+        assert res['state'] == 'AVAILABLE', f'Cloud db is not ready: {uri}'
 
         yield uri
 
     finally:
         if use_temporary_db:
             _logger.info('Deleting temporary cloud test db: %s', uri)
-            proc = subprocess.run('pxt', 'db', 'delete', uri, timeout=900, check=False)
+            proc = subprocess.run(('pxt', 'db', 'delete', uri), text=True, timeout=900, check=False)
             if proc.returncode != 0:
                 _logger.warning('Failed to delete cloud test db: %s', uri)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,11 +293,10 @@ def cloud_db_base_uri(init_env: None) -> Iterator[str]:
     if use_temporary_db:
         uri = f'pxt://pixeltable:pxttest-{uuid.uuid4().hex[:21]}'
 
-        _logger.info('Creating temporary cloud test db: %s', uri)
-        subprocess.run(('pxt', 'db', 'create', uri), text=True, timeout=900, check=True)
-
     try:
         if use_temporary_db:
+            _logger.info('Creating temporary cloud test db: %s', uri)
+            subprocess.run(('pxt', 'db', 'create', uri), text=True, timeout=900, check=True)
             _logger.info('Updating runtime on test db: %s', uri)
             subprocess.run(('pxt', 'db', 'update-runtime', uri), text=True, timeout=1800, check=True)
 

--- a/tests/serving/test_db_runtime_bundle.py
+++ b/tests/serving/test_db_runtime_bundle.py
@@ -66,26 +66,27 @@ class TestDbRuntimeBundle:
             with tar.extractfile(tar.getmember('project/udfs.py')) as f:
                 assert f.read().decode() == 'import pixeltable as pxt\n'
 
-    def test_bundle_include_exclude(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """include= limits which project files are bundled; exclude= removes matched files."""
-        (tmp_path / 'a_include.py').write_text('# included')
+    def test_bundle_include_exclude(self, tmp_path: Path) -> None:
+        (tmp_path / 'a_include.txt').write_text('# included by default')
+        (tmp_path / 'b_exclude.txt').write_text('# excluded explicitly')
+        (tmp_path / 'a_include.py').write_text('# exclude-then-include')
         (tmp_path / 'a_exclude.py').write_text('# excluded')
-        (tmp_path / 'b_exclude.txt').write_text('# excluded (not in include)')
 
         (tmp_path / 'pixeltable.toml').write_text(
             textwrap.dedent("""\
                 [pixeltable.database]
-                include = ["*.py", "*.toml"]
-                exclude = ["a_exclude.py"]
+                exclude = ["*.py", "b_exclude.txt"]
+                include = ["a_include.py"]
             """)
         )
-        monkeypatch.chdir(tmp_path)
+
         Config.init({}, reinit=True)
 
         bundle_path = build_db_runtime_bundle(tmp_path)
 
         with tarfile.open(bundle_path, 'r:bz2') as tar:
             members = tar.getnames()
+            assert 'project/a_include.txt' in members
             assert 'project/a_include.py' in members
             assert 'project/pixeltable.toml' in members
             assert 'project/a_exclude.py' not in members
@@ -98,6 +99,8 @@ class TestDbRuntimeBundle:
         (tmp_path / '__pycache__').mkdir()
         (tmp_path / '__pycache__' / 'app.cpython-311.pyc').write_bytes(b'\x00')
         (tmp_path / '.env').write_text('SECRET=abc')
+
+        Config.init({}, reinit=True)
 
         bundle_path = build_db_runtime_bundle(tmp_path)
 

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -23,19 +23,19 @@ class TestDirs:
         # the created dirs are verified to exist at the expected paths by the get_dir_contents checks below
 
         # invalid names
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Invalid path: 1dir'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*1dir'):
             pxt.create_dir(p('1dir'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Invalid path: _dir1'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*_dir1'):
             pxt.create_dir(p('_dir1'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Invalid path: dir 1'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*dir 1'):
             pxt.create_dir(p('dir 1'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: dir1..sub2'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*dir1..sub2'):
             pxt.create_dir(p('dir1..sub2'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: dir1.sub2.'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*dir1.sub2.'):
             pxt.create_dir(p('dir1.sub2.'))
         with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*dir1:sub2.'):
             pxt.create_dir(p('dir1:sub2.'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Versioned path not allowed here: .*dir1:120'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Versioned path not allowed here: .*dir1:120'):
             pxt.create_dir(p('dir1:120'))
 
         # existing dirs raise error by default
@@ -54,7 +54,7 @@ class TestDirs:
         with pxt_raises(pxt.ErrorCode.DIRECTORY_NOT_FOUND, match=r'does not exist. Create it first with:'):
             pxt.create_dir(p('dir2/sub2'))
         make_tbl(p('t2'))
-        with pxt_raises(pxt.ErrorCode.DIRECTORY_NOT_FOUND, match="Directory 't2' does not exist"):
+        with pxt_raises(pxt.ErrorCode.DIRECTORY_NOT_FOUND, match=r"Directory '.*t2' does not exist"):
             pxt.create_dir(p('t2/sub2'))
 
         # new client: force loading from store
@@ -215,12 +215,12 @@ class TestDirs:
         make_tbl(p('dir1/t1'))
 
         # bad name
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Invalid path: 1dir'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*1dir'):
             pxt.drop_dir(p('1dir'))
         # bad path
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: dir1..sub1'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*dir1..sub1'):
             pxt.drop_dir(p('dir1..sub1'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Versioned path not allowed here: .*dir1:120'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Versioned path not allowed here: .*dir1:120'):
             pxt.drop_dir(p('dir1:120'))
         # doesn't exist
         self._test_drop_if_not_exists(p, 'dir2')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -167,7 +167,7 @@ class TestTable:
             pxt.drop_table(p('test'))
         with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"Path '.*dir1/test2' does not exist"):
             pxt.drop_table(p('dir1/test2'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*\.test2'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*.test2'):
             pxt.drop_table(p('.test2'))
         with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Versioned path not allowed here: .*test2:120'):
             pxt.drop_table(p('test2:120'))
@@ -280,14 +280,14 @@ class TestTable:
         pxt.create_table(p('tbl3'), {'c1': pxt.Int | None})
         assert sorted(pxt.list_tables(p(''))) == sorted([p('tbl2'), p('tbl3')])
 
-        with pxt_raises(pxt.ErrorCode.PATH_ALREADY_EXISTS, match=r"Path 'tbl3' already exists."):
+        with pxt_raises(pxt.ErrorCode.PATH_ALREADY_EXISTS, match=r"Path '.*tbl3' already exists."):
             pxt.move(p('tbl2'), p('tbl3'))
         assert sorted(pxt.list_tables(p(''))) == sorted([p('tbl2'), p('tbl3')])
 
         pxt.move(p('tbl2'), p('tbl3'), if_exists='ignore')
         assert sorted(pxt.list_tables(p(''))) == sorted([p('tbl2'), p('tbl3')])
 
-        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"Path 'tbl1' does not exist."):
+        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"Path '.*tbl1' does not exist."):
             pxt.move(p('tbl1'), p('tbl4'))
         assert sorted(pxt.list_tables(p(''))) == sorted([p('tbl2'), p('tbl3')])
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -3908,6 +3908,11 @@ class TestTable:
         catalog_mode: CatalogMode,
     ) -> None:
         p = make_catalog_path
+
+        def l(path: str) -> str:
+            """Localized version of p(path), without the pxt://org:db/ prefix"""
+            return pxt.catalog.Path.localize(p(path))
+
         validate_repr(
             test_tbl,
             f"""
@@ -3930,7 +3935,7 @@ class TestTable:
         validate_repr(
             v,
             f"""
-            view '{p('test_view')}' (of 'test_tbl')
+            view '{p('test_view')}' (of '{l('test_tbl')}')
 
              Column Name                  Type    Source           Computed With                      Comment
             -------------------------------------------------------------------------------------------------
@@ -3952,7 +3957,7 @@ class TestTable:
         validate_repr(
             v2,
             f"""
-            view '{p('test_subview')}' (of 'test_view', 'test_tbl')
+            view '{p('test_subview')}' (of '{l('test_view')}', '{l('test_tbl')}')
             Where: ~(c1 == None)
 
              Column Name                  Type        Source           Computed With                      Comment
@@ -3981,7 +3986,7 @@ class TestTable:
         validate_repr(
             s1,
             f"""
-            snapshot '{p('test_snap1')}' (of 'test_subview:2', 'test_view:0', 'test_tbl:2')
+            snapshot '{p('test_snap1')}' (of '{l('test_subview:2')}', '{l('test_view:0')}', '{l('test_tbl:2')}')
             Where: ~(c1 == None)
 
              Column Name                  Type        Source           Computed With                      Comment
@@ -4006,7 +4011,7 @@ class TestTable:
         validate_repr(
             s2,
             f"""
-            snapshot '{p('test_snap2')}' (of 'test_tbl:2')
+            snapshot '{p('test_snap2')}' (of '{l('test_tbl:2')}')
 
              Column Name                  Type    Source           Computed With                      Comment
             -------------------------------------------------------------------------------------------------
@@ -4026,7 +4031,7 @@ class TestTable:
         validate_repr(
             s3,
             f"""
-            snapshot '{p('test_snap3')}' (of 'test_tbl:2')
+            snapshot '{p('test_snap3')}' (of '{l('test_tbl:2')}')
 
              Column Name                  Type      Source           Computed With                      Comment
             ---------------------------------------------------------------------------------------------------
@@ -4065,8 +4070,8 @@ class TestTable:
         iterator_view_1 = pxt.create_view(p('iterator_view_1'), s1, iterator=DummyIterator(s1.c2))
         validate_repr(
             iterator_view_1,
-            """
-            view 'iterator_view_1' (of 'test_subview:2', 'test_view:0', 'test_tbl:2')
+            f"""
+            view 'iterator_view_1' (of '{l('test_subview:2')}', '{l('test_view:0')}', '{l('test_tbl:2')}')
 
              Column Name                  Type           Source           Computed With                      Comment
             --------------------------------------------------------------------------------------------------------
@@ -4096,8 +4101,8 @@ class TestTable:
         iterator_view_2.add_computed_column(iterator_view_2_col_2=stock_price(iterator_view_2.iterator_view_2_col_1))
         validate_repr(
             iterator_view_2,
-            """
-            view 'iterator_view_2' (of 'iterator_view_1', 'test_subview:2', 'test_view:0', 'test_tbl:2')
+            f"""
+            view 'iterator_view_2' (of '{l('iterator_view_1')}', '{l('test_subview:2')}', '{l('test_view:0')}', '{l('test_tbl:2')}')
 
                         Column Name                  Type           Source                       Computed With                      Comment
             -------------------------------------------------------------------------------------------------------------------------------

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -125,9 +125,9 @@ class TestTable:
         tbl = pxt.create_table(p('test'), schema)
         _ = pxt.create_table(p('dir1/test'), schema)
 
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Invalid path: 1test'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*1test'):
             pxt.create_table(p('1test'), schema)
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Invalid path: bad name'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*bad name'):
             pxt.create_table(p('bad name'), {'c1': pxt.String | None})
         with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Versioned path not allowed here: .*test:120'):
             pxt.create_table(p('test:120'), schema)
@@ -139,7 +139,7 @@ class TestTable:
         _ = pxt.list_tables(p(''))
         _ = pxt.list_tables(p('dir1'))
 
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match='Invalid path: 1dir'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*1dir'):
             pxt.list_tables(p('1dir'))
         with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match='does not exist'):
             pxt.list_tables(p('dir2'))
@@ -163,11 +163,11 @@ class TestTable:
         pxt.create_dir(p('hyphenated-dir'))
         _ = pxt.create_table(p('hyphenated-dir/hyphenated-table'), schema)
 
-        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match="Path 'test' does not exist"):
+        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"Path '.*test' does not exist"):
             pxt.drop_table(p('test'))
-        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"Path 'dir1/test2' does not exist"):
+        with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"Path '.*dir1/test2' does not exist"):
             pxt.drop_table(p('dir1/test2'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .test2'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*\.test2'):
             pxt.drop_table(p('.test2'))
         with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Versioned path not allowed here: .*test2:120'):
             pxt.drop_table(p('test2:120'))

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -4242,31 +4242,28 @@ class TestTable:
 
         with pxt_raises(
             pxt.ErrorCode.UNSUPPORTED_OPERATION,
-            match="Cannot drop column 'c1' because the following views depend on it",
-        ) as e:
+            match=r"Cannot drop column 'c1' because the following views depend on it:\n"
+            r'view: .*view1, predicate: c1 % 2 == 0\n'
+            r'view: .*view2, predicate: \(c1 \+ vc1\) % 2 == 0\n'
+            r'view: .*view3, predicate: \(\(vc1 \+ vc2\) - \(c1 \+ c2\)\) % 5 == 0',
+        ):
             t.drop_column('c1')
 
-        assert 'view: view1, predicate: c1 % 2 == 0' in str(e.value).lower()
-        assert 'view: view2, predicate: (c1 + vc1) % 2 == 0' in str(e.value).lower()
-        assert 'view: view3, predicate: ((vc1 + vc2) - (c1 + c2)) % 5 == 0' in str(e.value).lower()
-
         with pxt_raises(
             pxt.ErrorCode.UNSUPPORTED_OPERATION,
-            match="Cannot drop column 'c2' because the following views depend on it",
-        ) as e:
+            match=r"Cannot drop column 'c2' because the following views depend on it:\n"
+            r'view: .*view3, predicate: \(\(vc1 \+ vc2\) - \(c1 \+ c2\)\) % 5 == 0\n'
+            r'view: .*view4, predicate: c2 / vc3 < 19',
+        ):
             t.drop_column('c2')
 
-        assert 'view: view3, predicate: ((vc1 + vc2) - (c1 + c2)) % 5 == 0' in str(e.value).lower()
-        assert 'view: view4, predicate: c2 / vc3 < 19' in str(e.value).lower()
-
         with pxt_raises(
             pxt.ErrorCode.UNSUPPORTED_OPERATION,
-            match="Cannot drop column 'vc1' because the following views depend on it",
-        ) as e:
+            match=r"Cannot drop column 'vc1' because the following views depend on it:\n"
+            r'view: .*view2, predicate: \(c1 \+ vc1\) % 2 == 0\n'
+            r'view: .*view3, predicate: \(\(vc1 \+ vc2\) - \(c1 \+ c2\)\) % 5 == 0',
+        ):
             v1.drop_column('vc1')
-
-        assert 'view: view2, predicate: (c1 + vc1) % 2 == 0' in str(e.value).lower()
-        assert 'view: view3, predicate: ((vc1 + vc2) - (c1 + c2)) % 5 == 0' in str(e.value).lower()
 
     def test_drop_last_column(self, make_catalog_path: Callable[[str], str], reload_tester: ReloadTester) -> None:
         p = make_catalog_path

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -167,7 +167,7 @@ class TestTable:
             pxt.drop_table(p('test'))
         with pxt_raises(pxt.ErrorCode.PATH_NOT_FOUND, match=r"Path '.*dir1/test2' does not exist"):
             pxt.drop_table(p('dir1/test2'))
-        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*.test2'):
+        with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Invalid path: .*\.test2'):
             pxt.drop_table(p('.test2'))
         with pxt_raises(pxt.ErrorCode.INVALID_PATH, match=r'Versioned path not allowed here: .*test2:120'):
             pxt.drop_table(p('test2:120'))

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -3909,7 +3909,7 @@ class TestTable:
     ) -> None:
         p = make_catalog_path
 
-        def l(path: str) -> str:
+        def loc(path: str) -> str:
             """Localized version of p(path), without the pxt://org:db/ prefix"""
             return pxt.catalog.Path.localize(p(path))
 
@@ -3935,7 +3935,7 @@ class TestTable:
         validate_repr(
             v,
             f"""
-            view '{p('test_view')}' (of '{l('test_tbl')}')
+            view '{p('test_view')}' (of '{loc('test_tbl')}')
 
              Column Name                  Type    Source           Computed With                      Comment
             -------------------------------------------------------------------------------------------------
@@ -3957,7 +3957,7 @@ class TestTable:
         validate_repr(
             v2,
             f"""
-            view '{p('test_subview')}' (of '{l('test_view')}', '{l('test_tbl')}')
+            view '{p('test_subview')}' (of '{loc('test_view')}', '{loc('test_tbl')}')
             Where: ~(c1 == None)
 
              Column Name                  Type        Source           Computed With                      Comment
@@ -3986,7 +3986,7 @@ class TestTable:
         validate_repr(
             s1,
             f"""
-            snapshot '{p('test_snap1')}' (of '{l('test_subview:2')}', '{l('test_view:0')}', '{l('test_tbl:2')}')
+            snapshot '{p('test_snap1')}' (of '{loc('test_subview:2')}', '{loc('test_view:0')}', '{loc('test_tbl:2')}')
             Where: ~(c1 == None)
 
              Column Name                  Type        Source           Computed With                      Comment
@@ -4011,7 +4011,7 @@ class TestTable:
         validate_repr(
             s2,
             f"""
-            snapshot '{p('test_snap2')}' (of '{l('test_tbl:2')}')
+            snapshot '{p('test_snap2')}' (of '{loc('test_tbl:2')}')
 
              Column Name                  Type    Source           Computed With                      Comment
             -------------------------------------------------------------------------------------------------
@@ -4031,7 +4031,7 @@ class TestTable:
         validate_repr(
             s3,
             f"""
-            snapshot '{p('test_snap3')}' (of '{l('test_tbl:2')}')
+            snapshot '{p('test_snap3')}' (of '{loc('test_tbl:2')}')
 
              Column Name                  Type      Source           Computed With                      Comment
             ---------------------------------------------------------------------------------------------------
@@ -4071,7 +4071,7 @@ class TestTable:
         validate_repr(
             iterator_view_1,
             f"""
-            view 'iterator_view_1' (of '{l('test_subview:2')}', '{l('test_view:0')}', '{l('test_tbl:2')}')
+            view 'iterator_view_1' (of '{loc('test_subview:2')}', '{loc('test_view:0')}', '{loc('test_tbl:2')}')
 
              Column Name                  Type           Source           Computed With                      Comment
             --------------------------------------------------------------------------------------------------------
@@ -4102,7 +4102,7 @@ class TestTable:
         validate_repr(
             iterator_view_2,
             f"""
-            view 'iterator_view_2' (of '{l('iterator_view_1')}', '{l('test_subview:2')}', '{l('test_view:0')}', '{l('test_tbl:2')}')
+            view 'iterator_view_2' (of '{loc('iterator_view_1')}', '{loc('test_subview:2')}', '{loc('test_view:0')}', '{loc('test_tbl:2')}')
 
                         Column Name                  Type           Source                       Computed With                      Comment
             -------------------------------------------------------------------------------------------------------------------------------

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -78,15 +78,47 @@ class TestView:
             join_df = t.join(u, on=t.c1 == u.c1)
             _ = pxt.create_view(p('join_view'), join_df)
 
+    def test_list_views(self, make_catalog_path: Callable[[str], str]) -> None:
+        p = make_catalog_path
+
+        def loc(path: str) -> str:
+            """Localized version of p(path), without the pxt://org:db/ prefix"""
+            return pxt.catalog.Path.localize(p(path))
+
+        t = pxt.create_table(p('tbl'), {'c1': pxt.Int | None})
+        # a hierarchy that both branches and nests: a subtree that gets traversed more than once shows up
+        # as a repeated path
+        v1 = pxt.create_view(p('v1'), t)
+        _ = pxt.create_view(p('v2'), t)
+        v1a = pxt.create_view(p('v1a'), v1)
+        v1b = pxt.create_view(p('v1b'), v1)
+        _ = pxt.create_view(p('v1a_i'), v1a)
+
+        assert sorted(t.list_views(recursive=False)) == [loc(path) for path in ('v1', 'v2')]
+        all_views = t.list_views()
+        assert sorted(all_views) == [loc(path) for path in ('v1', 'v1a', 'v1a_i', 'v1b', 'v2')]
+        # every view is listed exactly once, at every level of the hierarchy
+        assert len(all_views) == len(set(all_views))
+
+        assert sorted(v1.list_views(recursive=False)) == [loc(path) for path in ('v1a', 'v1b')]
+        assert sorted(v1.list_views()) == [loc(path) for path in ('v1a', 'v1a_i', 'v1b')]
+        assert v1a.list_views() == [loc('v1a_i')]
+        assert v1b.list_views() == []
+
     @pytest.mark.parametrize('do_reload_catalog', [False, True])
     def test_basic(self, do_reload_catalog: bool, make_catalog_path: Callable[[str], str]) -> None:
         p = make_catalog_path
+
+        def loc(path: str) -> str:
+            """Localized version of p(path), without the pxt://org:db/ prefix"""
+            return pxt.catalog.Path.localize(p(path))
+
         t = self.create_tbl(p)
 
         # create view with filter and computed columns
         schema: dict[str, Any] = {'v1': t.c3 * 2.0, 'v2': t.c6.f5}
         v = pxt.create_view(p('test_view'), t.where(t.c2 < 10), additional_columns=schema)
-        assert t.list_views() == ['test_view']
+        assert t.list_views() == [loc('test_view')]
         # TODO: test repr more thoroughly
         _ = repr(v)
         assert_resultset_eq(
@@ -211,7 +243,7 @@ class TestView:
         assert p('test_view_on_view') in pxt.list_tables(p(''))
         # if_exists='replace' cannot drop a view with a dependent view.
         # it should raise an error and recommend using 'replace_force'
-        with pxt_raises(pxt.ErrorCode.CONSTRAINT_VIOLATION, match="the following depend on it: 'test_view_on_view'"):
+        with pxt_raises(pxt.ErrorCode.CONSTRAINT_VIOLATION, match=r"the following depend on it: '.*test_view_on_view'"):
             v3 = pxt.create_view(p('test_view'), t, if_exists='replace')
         assert p('test_view_on_view') in pxt.list_tables(p(''))
         # past a handful of dependents the message lists the first few in sorted order and counts the rest;

--- a/uv.lock
+++ b/uv.lock
@@ -778,7 +778,7 @@ name = "blis"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f3/7c5a47a0d5ec0362bab29fd4f497b4b1975473bf30b7a02bc9c0b0e84f7a/blis-1.3.0.tar.gz", hash = "sha256:1695a87e3fc4c20d9b9140f5238cac0514c411b750e8cdcec5d8320c71f62e99", size = 2510328, upload-time = "2025-04-03T15:09:47.767Z" }
 wheels = [
@@ -1102,7 +1102,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.14'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -1141,8 +1141,8 @@ name = "confection"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "srsly", marker = "python_full_version < '3.14'" },
+    { name = "pydantic" },
+    { name = "srsly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/fb/c1744d131f0a8247a567b7c7dec3a84c16518e80b6af896d756f9c915833/confection-0.1.4.tar.gz", hash = "sha256:e80f22fd008b5231a2e8852fac6de9e28f2276a04031d0536cff74fe4a990c8f", size = 38679, upload-time = "2023-11-23T10:00:30.947Z" }
 wheels = [
@@ -1390,7 +1390,7 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/d6/753aecb3e8fcee80d20f9d32b4504276691c2f77fc10abbbd8e82197e24c/cuda_tile-1.3.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:59d9843fa723ceb4d680ec246e12e3ded857266e4c2bf5c5d21e530d6d765060", size = 245441, upload-time = "2026-04-20T15:51:06.618Z" },
@@ -1403,9 +1403,9 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cuda-tileiras", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cuda-tileiras", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/c9/1b8df78c55f7ef544e7b7aab381a99495650d49c65e3ba85189e888b89b7/cuda_tile-1.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:9825202c1175dcac6c2daafd176da4444801e13049b4e2688d92f5b582f6ea6d", size = 269373, upload-time = "2026-05-27T17:46:43.531Z" },
@@ -1431,7 +1431,7 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "cuda-toolkit", version = "13.3.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvvm", "tileiras"], marker = "sys_platform == 'win32'" },
+    { name = "cuda-toolkit", version = "13.3.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvvm", "tileiras"] },
 ]
 
 [[package]]
@@ -1454,37 +1454,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" } },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1503,19 +1503,19 @@ wheels = [
 
 [package.optional-dependencies]
 nvcc = [
-    { name = "nvidia-cuda-crt", marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-    { name = "nvidia-cuda-nvcc", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-    { name = "nvidia-cuda-runtime", version = "13.3.29", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
+    { name = "nvidia-cuda-crt", marker = "platform_machine == 'AMD64'" },
+    { name = "nvidia-cuda-nvcc", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
+    { name = "nvidia-cuda-runtime", version = "13.3.29", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
+    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
 ]
 nvvm = [
-    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
+    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
 ]
 tileiras = [
-    { name = "nvidia-cuda-nvcc", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-    { name = "nvidia-cuda-tileiras", version = "13.3.36", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
-    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvcc", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
+    { name = "nvidia-cuda-tileiras", version = "13.3.36", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
+    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'AMD64'" },
 ]
 
 [[package]]
@@ -1999,7 +1999,7 @@ name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future", marker = "python_full_version < '3.14'" },
+    { name = "future" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
 wheels = [
@@ -2311,7 +2311,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -2320,7 +2319,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -2329,7 +2327,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -2338,7 +2335,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -2347,7 +2343,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -2624,7 +2619,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -3011,7 +3006,7 @@ name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpointer", marker = "python_full_version < '3.14'" },
+    { name = "jsonpointer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
 wheels = [
@@ -3310,15 +3305,15 @@ name = "langchain-core"
 version = "1.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpatch", marker = "python_full_version < '3.14'" },
-    { name = "langchain-protocol", marker = "python_full_version < '3.14'" },
-    { name = "langsmith", marker = "python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "tenacity", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "uuid-utils", marker = "python_full_version < '3.14'" },
+    { name = "jsonpatch" },
+    { name = "langchain-protocol" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml", version = "6.0.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/a7/1652f8f00e2a3ed8714a57c902670897c6d001b96488abe49625d8c7fa1b/langchain_core-1.4.6.tar.gz", hash = "sha256:fb8547f83587c8f646f2136b106b732a974ffbff5537799125d16ed4c326eb63", size = 949354, upload-time = "2026-06-11T07:09:54.464Z" }
 wheels = [
@@ -3330,7 +3325,7 @@ name = "langchain-protocol"
 version = "0.0.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/e7/8300ba22d968653051fd06e3117d783872dddf3dcebdd6b1d386836eb43c/langchain_protocol-0.0.16.tar.gz", hash = "sha256:806c7cdd951b1c4f692fa40fce60821ff0f221d4360e27673ddf2c2b99c2b7ff", size = 5969, upload-time = "2026-05-28T23:05:11.121Z" }
 wheels = [
@@ -3342,7 +3337,7 @@ name = "langchain-text-splitters"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", marker = "python_full_version < '3.14'" },
+    { name = "langchain-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
 wheels = [
@@ -3363,16 +3358,16 @@ name = "langsmith"
 version = "0.8.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "python_full_version < '3.14'" },
-    { name = "orjson", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
-    { name = "requests-toolbelt", marker = "python_full_version < '3.14'" },
-    { name = "uuid-utils", marker = "python_full_version < '3.14'" },
-    { name = "websockets", marker = "python_full_version < '3.14'" },
-    { name = "xxhash", marker = "python_full_version < '3.14'" },
-    { name = "zstandard", marker = "python_full_version < '3.14'" },
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "uuid-utils" },
+    { name = "websockets" },
+    { name = "xxhash" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/0c/9e4284d9c279490a2407249bd780e1075c2dd29bf6fa77e2b71e91859227/langsmith-0.8.14.tar.gz", hash = "sha256:a3e8feb178540a2866ed39faf11521a4b9e476bf94ab3acdb1491ee6f804cfda", size = 4499898, upload-time = "2026-06-10T19:55:10.607Z" }
 wheels = [
@@ -3466,11 +3461,11 @@ name = "llama-cpp-python"
 version = "0.3.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "diskcache", marker = "sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'win32'" },
+    { name = "diskcache" },
+    { name = "jinja2" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/f7/ae8c53ec5b388b0f5c750ab6a20eb3a33546c91335a8067024f8e01e3524/llama_cpp_python-0.3.18.tar.gz", hash = "sha256:56e060193a4b54fb19ad80f7067a688c259c0224ca027efdfc97ab8a91b2b43d", size = 61684351, upload-time = "2026-03-24T10:01:07.433Z" }
 
@@ -3489,7 +3484,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/fe/bb185f11bad82f2637e3cd8cbf6b200cbb6ed56ac395de47ea05a60d4649/llguidance-1.7.6-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9c54c899db8cb4b4fba128a7d844730066576c70d806c95ada92b2bd2d6ab498", size = 3138127, upload-time = "2026-06-03T20:13:11.649Z" },
     { url = "https://files.pythonhosted.org/packages/51/b9/dc76d7716e04dc7b3427cae52eaa32bd20771382d4d1dd9f4538a9dd2086/llguidance-1.7.6-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:e70fa25ed550c2b50c2fd70baa9e2808b4ecb859d01e453bd5459aff62ba38c3", size = 2899993, upload-time = "2026-06-03T20:13:13.563Z" },
     { url = "https://files.pythonhosted.org/packages/1a/64/d74336f22242ef94356a456057d4ff1be7c1bc9c7dbc867171c6982a5512/llguidance-1.7.6-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:ceec951d29a74309984e3be0fe7f5f56c1362434cd937abd517b259a60908b1e", size = 3074809, upload-time = "2026-06-03T20:13:15.498Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e6/6b61cecced5233739bc85e463d68d67d4b4c29fb6f91bd12e6b6a65647e3/llguidance-1.7.6-cp39-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:e9f68206e0f3f89aceabb90aa1f8ed570db22fb7cb1fd9ebf96fa7727a65af55", size = 3603845, upload-time = "2026-06-03T20:13:19.473Z" },
     { url = "https://files.pythonhosted.org/packages/49/37/99d700f0e2c83acf25a8d8946b2bee9f5eac47bc530bfbd53ba3126c667f/llguidance-1.7.6-cp39-abi3-win_amd64.whl", hash = "sha256:ace7e81cd31950a87186356ab24bd7f75fbc10a05ca9d9f7f8748f931963f763", size = 2879207, upload-time = "2026-06-03T20:13:23.341Z" },
 ]
 
@@ -3657,11 +3651,11 @@ name = "magika"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "onnxruntime", version = "1.22.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'darwin')" },
-    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "click" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "onnxruntime", version = "1.22.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
 wheels = [
@@ -3676,7 +3670,7 @@ name = "mammoth"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cobble", marker = "python_full_version < '3.14'" },
+    { name = "cobble" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/3c/a58418d2af00f2da60d4a51e18cd0311307b72d48d2fffec36a97b4a5e44/mammoth-1.11.0.tar.gz", hash = "sha256:a0f59e442f34d5b6447f4b0999306cbf3e67aaabfa8cb516f878fb1456744637", size = 53142, upload-time = "2025-09-19T10:35:20.373Z" }
 wheels = [
@@ -3709,8 +3703,8 @@ name = "markdownify"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version < '3.14'" },
-    { name = "six", marker = "python_full_version < '3.14'" },
+    { name = "beautifulsoup4" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
 wheels = [
@@ -3722,13 +3716,13 @@ name = "markitdown"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4", marker = "python_full_version < '3.14'" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.14'" },
-    { name = "defusedxml", marker = "python_full_version < '3.14'" },
-    { name = "magika", marker = "python_full_version < '3.14'" },
-    { name = "markdownify", marker = "python_full_version < '3.14'" },
-    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "defusedxml" },
+    { name = "magika" },
+    { name = "markdownify" },
+    { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/4d/06567465c1886c2ea47bac24eab0c96bb6b4ecea47224323409dc9cbb614/markitdown-0.1.4.tar.gz", hash = "sha256:e72a481d1a50c82ff744e85e3289f79a940c5d0ad5ffa2b37c33de814c195bb1", size = 39951, upload-time = "2025-12-01T18:20:30.937Z" }
 wheels = [
@@ -3737,15 +3731,15 @@ wheels = [
 
 [package.optional-dependencies]
 docx = [
-    { name = "lxml", marker = "python_full_version < '3.14'" },
-    { name = "mammoth", marker = "python_full_version < '3.14'" },
+    { name = "lxml" },
+    { name = "mammoth" },
 ]
 pptx = [
-    { name = "python-pptx", marker = "python_full_version < '3.14'" },
+    { name = "python-pptx" },
 ]
 xlsx = [
-    { name = "openpyxl", marker = "python_full_version < '3.14'" },
-    { name = "pandas", marker = "python_full_version < '3.14'" },
+    { name = "openpyxl" },
+    { name = "pandas" },
 ]
 
 [[package]]
@@ -4619,10 +4613,10 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
     { name = "nvidia-cuda-runtime", version = "13.3.29", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a3/403638f80960e677ae8ecc78059d8c85dc2519b85ed8c0229840dc6f3b54/nvidia_cuda_nvcc-13.2.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:909140a1f942b943982b2eff120e618c94e29d75d9e33f5cd074f0e64eb411e8", size = 38716270, upload-time = "2026-07-16T09:37:12.754Z" },
@@ -4640,9 +4634,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "sys_platform == 'win32'" },
-    { name = "nvidia-cuda-runtime", version = "13.3.29", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime", version = "13.3.29", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/c2/831fa54020621a64d44cff47f1ed5eb0611794495fce01c857f6999d76b1/nvidia_cuda_nvcc-13.3.33-py3-none-win_amd64.whl", hash = "sha256:21c93aeef695a81b688137119f9120fe08a67292bf0ad730d94dc2b18bec23f0", size = 32723421, upload-time = "2026-05-26T17:01:47.511Z" },
@@ -4753,10 +4747,10 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin'" },
     { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/a2/ade26f7fb55a5bb87815f7650660463d6601db411d5a9228f414b3ed5dfe/nvidia_cuda_tileiras-13.2.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f79c6a9bf8583dae105cd67b985555f39f4576416664a86383ba892e8c346c9", size = 36418795, upload-time = "2026-07-16T09:43:35.006Z" },
@@ -4774,9 +4768,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-nvcc", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvcc", version = "13.3.33", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.3.33", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/b1/9dcc1aa140205c8f9ecdb671b488e1189462d870e5ed0eac02522722cb9a/nvidia_cuda_tileiras-13.3.36-py3-none-win_amd64.whl", hash = "sha256:0dd286086c6d273826218d02c076ddea8e285b50ee223bd1429756b706b7bbc7", size = 29715011, upload-time = "2026-05-26T17:05:29.974Z" },
@@ -4787,7 +4781,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -4821,7 +4815,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -4851,9 +4845,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -4865,7 +4859,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -5106,11 +5100,11 @@ name = "onnx"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "protobuf", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/19/8ea73a64b368b75fe339771a20a02bc61ea1f551484c9e3d9d0bfbd0450f/onnx-1.22.0.tar.gz", hash = "sha256:ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0", size = 12024721, upload-time = "2026-06-15T12:50:05.354Z" }
 wheels = [
@@ -5150,12 +5144,12 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "flatbuffers", marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "packaging", marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "protobuf", marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "sympy", marker = "(python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/da/c44bf9bd66cd6d9018a921f053f28d819445c4d84b4dd4777271b0fe52a2/onnxruntime-1.20.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6243e34d74423bdd1edf0ae9596dd61023b260f546ee17d701723915f06a9f7", size = 11955227, upload-time = "2024-11-21T00:48:54.556Z" },
@@ -5186,12 +5180,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'darwin')" },
-    { name = "flatbuffers", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'darwin')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'darwin')" },
-    { name = "packaging", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'darwin')" },
-    { name = "protobuf", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'darwin')" },
-    { name = "sympy", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'darwin')" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/08/c008711d1b92ff1272f4fea0fbee57723171f161d42e5c680625535280af/onnxruntime-1.22.0-cp311-cp311-macosx_13_0_universal2.whl", hash = "sha256:8d6725c5b9a681d8fe72f2960c191a96c256367887d076b08466f52b4e0991df", size = 34282151, upload-time = "2025-05-09T20:25:59.246Z" },
@@ -5208,9 +5202,9 @@ name = "onnxsim"
 version = "0.4.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "onnx", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "onnx" },
     { name = "rich", version = "13.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "rich", version = "14.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "rich", version = "14.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/9e/f34238413ebeda9a3a8802feeaa5013934455466b9ab390b48ad9c7e184f/onnxsim-0.4.36.tar.gz", hash = "sha256:6e0ee9d6d4a83042bdef7319fbe58352d9fda5f253386be2b267c7c27f0638ee", size = 20993703, upload-time = "2024-03-04T08:25:00.086Z" }
 wheels = [
@@ -5266,13 +5260,13 @@ name = "openai-whisper"
 version = "20250625"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "python_full_version < '3.14'" },
-    { name = "numba", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "tiktoken", marker = "python_full_version < '3.14'" },
-    { name = "torch", marker = "python_full_version < '3.14'" },
-    { name = "tqdm", marker = "python_full_version < '3.14'" },
-    { name = "triton", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform == 'linux2')" },
+    { name = "more-itertools" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "tiktoken" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'linux2'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz", hash = "sha256:37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96", size = 803191, upload-time = "2025-06-26T01:06:13.34Z" }
 
@@ -5281,7 +5275,7 @@ name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
@@ -5764,7 +5758,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5965,6 +5959,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tenacity" },
     { name = "toml" },
+    { name = "tqdm" },
     { name = "typing-extensions" },
     { name = "tzlocal" },
 ]
@@ -6124,6 +6119,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.40" },
     { name = "tenacity", specifier = ">=8.2" },
     { name = "toml", specifier = ">=0.10" },
+    { name = "tqdm", specifier = ">=4.64" },
     { name = "typing-extensions", specifier = ">=4.15" },
     { name = "tzlocal", specifier = ">=5.0" },
 ]
@@ -6281,21 +6277,21 @@ name = "pixeltable-yolox"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "loguru", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "ninja", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "loguru" },
+    { name = "ninja" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "onnx", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "onnxsim", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "opencv-python", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "psutil", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "pycocotools", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "tabulate", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "tensorboard", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "thop", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "torch", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "torchvision", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "tqdm", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "onnx" },
+    { name = "onnxsim" },
+    { name = "opencv-python" },
+    { name = "psutil" },
+    { name = "pycocotools" },
+    { name = "tabulate" },
+    { name = "tensorboard" },
+    { name = "thop" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/d7/dfddbe690fd0382a8c3d03f970d60b5069d2ab0669e5c3ccc1543d655324/pixeltable_yolox-0.4.2.tar.gz", hash = "sha256:e67e5643c93bac8f4132198a284533acd15f67b154bc700120b73c69c0d20f7c", size = 89052, upload-time = "2025-04-24T06:09:02.199Z" }
 wheels = [
@@ -6325,8 +6321,8 @@ name = "preshed"
 version = "3.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cymem", marker = "python_full_version < '3.14'" },
-    { name = "murmurhash", marker = "python_full_version < '3.14'" },
+    { name = "cymem" },
+    { name = "murmurhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/4e/76dbf784e7d4ed069f91a4c249b1d6ec6856ef0c0b2fd96992895d458b15/preshed-3.0.9.tar.gz", hash = "sha256:721863c5244ffcd2651ad0928951a2c7c77b102f4e11a251ad85d37ee7621660", size = 14478, upload-time = "2023-09-15T15:44:32.386Z" }
 wheels = [
@@ -7462,10 +7458,10 @@ name = "python-pptx"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", marker = "python_full_version < '3.14'" },
-    { name = "pillow", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "xlsxwriter", marker = "python_full_version < '3.14'" },
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "typing-extensions" },
+    { name = "xlsxwriter" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
@@ -7899,10 +7895,10 @@ name = "replicate"
 version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/fd/caf6c59a6b8007366bd52ab5a320bf8d828f3860a60039309cfc0e375ec9/replicate-1.0.7.tar.gz", hash = "sha256:d88cb2c37ba39fb370c87fc3291601c67aae64bb918a20a85b5ce399c23ee84c", size = 62226, upload-time = "2025-05-27T11:29:08.111Z" }
 wheels = [
@@ -7929,7 +7925,7 @@ name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -7969,8 +7965,8 @@ resolution-markers = [
     "(python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.14'" },
-    { name = "pygments", marker = "python_full_version >= '3.14'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/78/87d00a1df7c457ad9aa0139f01b8a11c67209f27f927c503b0109bf2ed6c/rich-13.9.1.tar.gz", hash = "sha256:097cffdf85db1babe30cc7deba5ab3a29e1b9885047dab24c57e9a7f8a9c1466", size = 222907, upload-time = "2024-10-01T13:36:29.793Z" }
 wheels = [
@@ -7999,8 +7995,8 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version < '3.14'" },
-    { name = "pygments", marker = "python_full_version < '3.14'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
@@ -8309,11 +8305,11 @@ name = "scenedetect"
 version = "0.6.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "click" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "platformdirs", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "tqdm", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "platformdirs" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/e77e1812ae89bc4864ff54efb6a8232eabebd471e372096cb711f03cca52/scenedetect-0.6.7.1.tar.gz", hash = "sha256:07833b0cb83a0106786a88136462580e9865e097f411f01501a688714c483a4e", size = 164208, upload-time = "2025-09-25T03:18:59.929Z" }
 wheels = [
@@ -8325,10 +8321,10 @@ name = "scikit-learn"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "scipy", marker = "python_full_version < '3.14'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.14'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/3b/29fa87e76b1d7b3b77cc1fcbe82e6e6b8cd704410705b008822de530277c/scikit_learn-1.7.0.tar.gz", hash = "sha256:c01e869b15aec88e2cdb73d27f15bdbe03bce8e2fb43afbe77c45d399e73a5a3", size = 7178217, upload-time = "2025-06-05T22:02:46.703Z" }
 wheels = [
@@ -8439,14 +8435,14 @@ name = "sentence-transformers"
 version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "scikit-learn", marker = "python_full_version < '3.14'" },
-    { name = "scipy", marker = "python_full_version < '3.14'" },
-    { name = "torch", marker = "python_full_version < '3.14'" },
-    { name = "tqdm", marker = "python_full_version < '3.14'" },
-    { name = "transformers", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/b0/fcc810aa1747e96eb2e342e16173dbebbff85b8ccd079f35b32874c5f6ce/sentence_transformers-5.4.0.tar.gz", hash = "sha256:ef0c129d653f736df5fd74d46af11a2234328a32cddb1d91a1975c5f6cccc194", size = 428330, upload-time = "2026-04-09T13:34:12.642Z" }
 wheels = [
@@ -8770,26 +8766,26 @@ name = "spacy"
 version = "3.8.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue", marker = "python_full_version < '3.14'" },
-    { name = "cymem", marker = "python_full_version < '3.14'" },
-    { name = "jinja2", marker = "python_full_version < '3.14'" },
-    { name = "langcodes", marker = "python_full_version < '3.14'" },
-    { name = "murmurhash", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "preshed", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "catalogue" },
+    { name = "cymem" },
+    { name = "jinja2" },
+    { name = "langcodes" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "requests" },
     { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "spacy-legacy", marker = "python_full_version < '3.14'" },
-    { name = "spacy-loggers", marker = "python_full_version < '3.14'" },
-    { name = "srsly", marker = "python_full_version < '3.14'" },
-    { name = "thinc", marker = "python_full_version < '3.14'" },
-    { name = "tqdm", marker = "python_full_version < '3.14'" },
-    { name = "typer", marker = "python_full_version < '3.14'" },
-    { name = "wasabi", marker = "python_full_version < '3.14'" },
-    { name = "weasel", marker = "python_full_version < '3.14'" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "spacy-legacy" },
+    { name = "spacy-loggers" },
+    { name = "srsly" },
+    { name = "thinc" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wasabi" },
+    { name = "weasel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/9e/fb4e1cefe3fbd51ea6a243e5a3d2bc629baa9a28930bf4be6fe5672fa1ca/spacy-3.8.7.tar.gz", hash = "sha256:700fd174c6c552276be142c48e70bb53cae24c4dd86003c4432af9cb93e4c908", size = 1316143, upload-time = "2025-05-23T08:55:39.538Z" }
 wheels = [
@@ -8904,7 +8900,7 @@ name = "srsly"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "catalogue", marker = "python_full_version < '3.14'" },
+    { name = "catalogue" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/eb51b1349f50bac0222398af0942613fdc9d1453ae67cbe4bf9936a1a54b/srsly-2.5.1.tar.gz", hash = "sha256:ab1b4bf6cf3e29da23dae0493dd1517fb787075206512351421b89b4fc27c77e", size = 466464, upload-time = "2025-01-17T09:26:26.919Z" }
 wheels = [
@@ -9026,18 +9022,18 @@ name = "tensorboard"
 version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "grpcio", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "markdown", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and sys_platform != 'win32') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and sys_platform != 'win32'" },
-    { name = "packaging", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "protobuf", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "packaging" },
+    { name = "protobuf" },
     { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform != 'win32') or (python_full_version == '3.12.*' and sys_platform == 'win32')" },
     { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "six", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "tensorboard-data-server", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
-    { name = "werkzeug", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "six" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/12/4f70e8e2ba0dbe72ea978429d8530b0333f0ed2140cc571a48802878ef99/tensorboard-2.19.0-py3-none-any.whl", hash = "sha256:5e71b98663a641a7ce8a6e70b0be8e1a4c0c45d48760b076383ac4755c35b9a0", size = 5503412, upload-time = "2025-02-12T08:17:27.21Z" },
@@ -9072,19 +9068,19 @@ name = "thinc"
 version = "8.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "blis", marker = "python_full_version < '3.14'" },
-    { name = "catalogue", marker = "python_full_version < '3.14'" },
-    { name = "confection", marker = "python_full_version < '3.14'" },
-    { name = "cymem", marker = "python_full_version < '3.14'" },
-    { name = "murmurhash", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "preshed", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "blis" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
     { name = "setuptools", version = "80.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "srsly", marker = "python_full_version < '3.14'" },
-    { name = "wasabi", marker = "python_full_version < '3.14'" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "srsly" },
+    { name = "wasabi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/f4/7607f76c2e156a34b1961a941eb8407b84da4f515cc0903b44d44edf4f45/thinc-8.3.6.tar.gz", hash = "sha256:49983f9b7ddc4343a9532694a9118dd216d7a600520a21849a43b6c268ec6cad", size = 194218, upload-time = "2025-04-04T11:50:45.751Z" }
 wheels = [
@@ -9116,7 +9112,7 @@ name = "thop"
 version = "0.1.1.post2209072238"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/0f/72beeab4ff5221dc47127c80f8834b4bcd0cb36f6ba91c0b1d04a1233403/thop-0.1.1.post2209072238-py3-none-any.whl", hash = "sha256:01473c225231927d2ad718351f78ebf7cffe6af3bed464c4f1ba1ef0f7cdda27", size = 15443, upload-time = "2022-09-07T14:38:37.211Z" },
@@ -9308,10 +9304,10 @@ name = "tokenspeed-mla"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cutlass-dsl", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "tokenspeed-triton", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "apache-tvm-ffi" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "tokenspeed-triton" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/20/4110d624d81d63f0bee2f19dba7ea0e1d8a31ea50147e6c1db82223c88a4/tokenspeed_mla-0.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:592590f36d85e624ecdc5e357ff35e29e761e6d879900dce8b67a6785c8ce75c", size = 743769, upload-time = "2026-05-13T03:30:54.486Z" },
@@ -9641,7 +9637,7 @@ name = "typer-slim"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typer", marker = "python_full_version < '3.14'" },
+    { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/22/b9c47b8655937b6877d40791b937931702ba9c5f9d28753199266aa96f50/typer_slim-0.23.1.tar.gz", hash = "sha256:dfe92a6317030ee2380f65bf92e540d7c77fefcc689e10d585b4925b45b5e06a", size = 4762, upload-time = "2026-02-13T10:04:26.416Z" }
 wheels = [
@@ -10059,16 +10055,16 @@ name = "voyageai"
 version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.14'" },
-    { name = "aiolimiter", marker = "python_full_version < '3.14'" },
-    { name = "ffmpeg-python", marker = "python_full_version < '3.14'" },
-    { name = "langchain-text-splitters", marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pillow", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
-    { name = "tenacity", marker = "python_full_version < '3.14'" },
-    { name = "tokenizers", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp" },
+    { name = "aiolimiter" },
+    { name = "ffmpeg-python" },
+    { name = "langchain-text-splitters" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "tokenizers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/16/1b46b3cd401e1717a68197c1fe336d7bb4e0a1833f8105e1738f5b1add05/voyageai-0.3.7.tar.gz", hash = "sha256:826cd97f97223f42b5babc5c459c9c80f3a8215ce5c0e007b0b276550f790d24", size = 26485, upload-time = "2025-12-16T18:43:05.26Z" }
 wheels = [
@@ -10080,7 +10076,7 @@ name = "wasabi"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/09/bbd7e880b56e825d5859a58adb1bd1feb45b604218706057ca1e3278fa62/wasabi-1.1.2.tar.gz", hash = "sha256:1aaef3aceaa32edb9c91330d29d3936c0c39fdb965743549c173cb54b16c30b5", size = 30158, upload-time = "2023-06-07T07:35:08.068Z" }
 wheels = [
@@ -10188,15 +10184,15 @@ name = "weasel"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpathlib", marker = "python_full_version < '3.14'" },
-    { name = "confection", marker = "python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
-    { name = "smart-open", marker = "python_full_version < '3.14'" },
-    { name = "srsly", marker = "python_full_version < '3.14'" },
-    { name = "typer-slim", marker = "python_full_version < '3.14'" },
-    { name = "wasabi", marker = "python_full_version < '3.14'" },
+    { name = "cloudpathlib" },
+    { name = "confection" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "smart-open" },
+    { name = "srsly" },
+    { name = "typer-slim" },
+    { name = "wasabi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/d7/edd9c24e60cf8e5de130aa2e8af3b01521f4d0216c371d01212f580d0d8e/weasel-0.4.3.tar.gz", hash = "sha256:f293d6174398e8f478c78481e00c503ee4b82ea7a3e6d0d6a01e46a6b1396845", size = 38733, upload-time = "2025-11-13T23:52:28.193Z" }
 wheels = [
@@ -10277,7 +10273,7 @@ name = "werkzeug"
 version = "3.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [


### PR DESCRIPTION
Adds a `'cloud'` catalog mode in addition to `'local'` and `'proxy'`. The cloud tests will be skipped unless `PIXELTABLE_API_KEY`, `PIXELTABLE_API_URL`, and `PIXELTABLE_CLOUD_HOST` are all present in the environment.

If `PXTTEST_CLOUD_DB_URI` is set, then the cloud db at that URI will be used for testing. If not, a temporary db will be created and populated with the local source tree via `update-runtime` (this will take around 15 minutes).

Contains fixes to `test_table.py` so that all but 9 tests pass in `'cloud'` mode (all of the failing tests are media related, to be addressed in a follow up).