### PR TITLE
slimtest target extended to include more core tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -227,7 +227,7 @@ jobs:
         # The pxt daemon serves the SPA bundle when the dashboard feature flag is enabled;
         # tests/pixeltable_cli/test_smoke.py exercises that path. The build output is gitignored,
         # so CI has to produce it before the test job runs.
-        if: ${{ matrix.test-category == 'py' && matrix.build-dashboard == 'true' }}
+        if: ${{ matrix.test-category == 'py' }}
         run: |
           conda install -y -c conda-forge nodejs
           cd dashboard && npm install --silent && npm run build

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,11 @@ fullpytest: install
 slimpytest: install
 	@echo 'Running `pytest` on a slim configuration ...'
 	@$(ULIMIT_CMD) pytest $(PYTEST_COMMON_ARGS) \
-	    tests/test_{alter_column,catalog,dirs,env,exprs,function,index,operational_table,snapshot,table,table_model,types,view}.py
+	    tests/test_{alter_column,array_type,catalog,component_view,concurrent,concurrent_model,config,dirs,env}.py \
+	    tests/test_{exceptions,exprs,fault_injection,file_cache,function,history,index,iterator,mcp,path}.py \
+	    tests/test_{primary_key_index,query,sample,snapshot,table,table_model,table_model_2,types,view}.py \
+	    tests/serving/test_fastapi.py \
+	    tests/pixeltable_cli/test_{bridge,internals,schema,serve_deploy,smoke}.py
 
 .PHONY: nbtest
 nbtest: install

--- a/tool/ci_tool.py
+++ b/tool/ci_tool.py
@@ -24,47 +24,41 @@ VERY_EXPENSIVE_PYTEST = "-m 'not benchmark and not cloud_e2e'"
 
 # The core-functionality test modules that PR checks run on every push. This mirrors the `slimpytest` target in the
 # Makefile.
-SLIM_TESTS = ' '.join(
-    (
-        *(
-            f'tests/test_{name}.py'
-            for name in (
-                'alter_column',
-                'array_type',
-                'catalog',
-                'component_view',
-                'concurrent',
-                'concurrent_model',
-                'config',
-                'dirs',
-                'env',
-                'exceptions',
-                'exprs',
-                'fault_injection',
-                'file_cache',
-                'function',
-                'history',
-                'index',
-                'iterator',
-                'mcp',
-                'path',
-                'primary_key_index',
-                'query',
-                'sample',
-                'snapshot',
-                'table',
-                'table_model',
-                'table_model_2',
-                'types',
-                'view',
-            )
-        ),
-        'tests/serving/test_fastapi.py',
-        *(
-            f'tests/pixeltable_cli/test_{name}.py'
-            for name in ('bridge', 'internals', 'schema', 'serve_deploy', 'smoke')
-        ),
-    )
+SLIM_TESTS = (
+    'tests/test_alter_column.py '
+    'tests/test_array_type.py '
+    'tests/test_catalog.py '
+    'tests/test_component_view.py '
+    'tests/test_concurrent.py '
+    'tests/test_concurrent_model.py '
+    'tests/test_config.py '
+    'tests/test_dirs.py '
+    'tests/test_env.py '
+    'tests/test_exceptions.py '
+    'tests/test_exprs.py '
+    'tests/test_fault_injection.py '
+    'tests/test_file_cache.py '
+    'tests/test_function.py '
+    'tests/test_history.py '
+    'tests/test_index.py '
+    'tests/test_iterator.py '
+    'tests/test_mcp.py '
+    'tests/test_path.py '
+    'tests/test_primary_key_index.py '
+    'tests/test_query.py '
+    'tests/test_sample.py '
+    'tests/test_snapshot.py '
+    'tests/test_table.py '
+    'tests/test_table_model.py '
+    'tests/test_table_model_2.py '
+    'tests/test_types.py '
+    'tests/test_view.py '
+    'tests/serving/test_fastapi.py '
+    'tests/pixeltable_cli/test_bridge.py '
+    'tests/pixeltable_cli/test_internals.py '
+    'tests/pixeltable_cli/test_schema.py '
+    'tests/pixeltable_cli/test_serve_deploy.py '
+    'tests/pixeltable_cli/test_smoke.py'
 )
 
 MAIN_PLATFORM = 'ubuntu-24.04'

--- a/tool/ci_tool.py
+++ b/tool/ci_tool.py
@@ -75,7 +75,6 @@ class MatrixConfig(NamedTuple):
     uv_options: str = ''
     pytest_options: str = DEFAULT_PYTEST
     pre_test_cmd: str = ''  # Extra bash command to be run just before tests
-    build_dashboard: bool = True  # Whether this config runs tests that need the dashboard SPA bundle
 
     @property
     def display_name(self) -> str:
@@ -91,7 +90,6 @@ class MatrixConfig(NamedTuple):
             'uv-options': self.uv_options,
             'pytest-options': self.pytest_options,
             'pre-test-cmd': self.pre_test_cmd,
-            'build-dashboard': str(self.build_dashboard).lower(),
         }
 
 
@@ -123,9 +121,7 @@ def generate_matrix(args: argparse.Namespace) -> None:
     if trigger == 'pull_request':
         # On every push to a PR we run only the slim tests. It is strictly a subset of what the merge queue runs.
         configs.extend(
-            MatrixConfig(
-                'slim', 'py', platform, '3.11', pytest_options=f'{DEFAULT_PYTEST} {SLIM_TESTS}', build_dashboard=False
-            )
+            MatrixConfig('slim', 'py', platform, '3.11', pytest_options=f'{DEFAULT_PYTEST} {SLIM_TESTS}')
             for platform in (MAIN_PLATFORM, *BASIC_PLATFORMS)
         )
 

--- a/tool/ci_tool.py
+++ b/tool/ci_tool.py
@@ -25,40 +25,40 @@ VERY_EXPENSIVE_PYTEST = "-m 'not benchmark and not cloud_e2e'"
 # The core-functionality test modules that PR checks run on every push. This mirrors the `slimpytest` target in the
 # Makefile.
 SLIM_TESTS = (
-    'tests/test_alter_column.py '
-    'tests/test_array_type.py '
-    'tests/test_catalog.py '
-    'tests/test_component_view.py '
-    'tests/test_concurrent.py '
-    'tests/test_concurrent_model.py '
-    'tests/test_config.py '
-    'tests/test_dirs.py '
-    'tests/test_env.py '
-    'tests/test_exceptions.py '
-    'tests/test_exprs.py '
-    'tests/test_fault_injection.py '
-    'tests/test_file_cache.py '
-    'tests/test_function.py '
-    'tests/test_history.py '
-    'tests/test_index.py '
-    'tests/test_iterator.py '
-    'tests/test_mcp.py '
-    'tests/test_path.py '
-    'tests/test_primary_key_index.py '
-    'tests/test_query.py '
-    'tests/test_sample.py '
-    'tests/test_snapshot.py '
-    'tests/test_table.py '
-    'tests/test_table_model.py '
-    'tests/test_table_model_2.py '
-    'tests/test_types.py '
-    'tests/test_view.py '
-    'tests/serving/test_fastapi.py '
-    'tests/pixeltable_cli/test_bridge.py '
-    'tests/pixeltable_cli/test_internals.py '
-    'tests/pixeltable_cli/test_schema.py '
-    'tests/pixeltable_cli/test_serve_deploy.py '
-    'tests/pixeltable_cli/test_smoke.py'
+    'tests/test_alter_column.py',
+    'tests/test_array_type.py',
+    'tests/test_catalog.py',
+    'tests/test_component_view.py',
+    'tests/test_concurrent.py',
+    'tests/test_concurrent_model.py',
+    'tests/test_config.py',
+    'tests/test_dirs.py',
+    'tests/test_env.py',
+    'tests/test_exceptions.py',
+    'tests/test_exprs.py',
+    'tests/test_fault_injection.py',
+    'tests/test_file_cache.py',
+    'tests/test_function.py',
+    'tests/test_history.py',
+    'tests/test_index.py',
+    'tests/test_iterator.py',
+    'tests/test_mcp.py',
+    'tests/test_path.py',
+    'tests/test_primary_key_index.py',
+    'tests/test_query.py',
+    'tests/test_sample.py',
+    'tests/test_snapshot.py',
+    'tests/test_table.py',
+    'tests/test_table_model.py',
+    'tests/test_table_model_2.py',
+    'tests/test_types.py',
+    'tests/test_view.py',
+    'tests/serving/test_fastapi.py',
+    'tests/pixeltable_cli/test_bridge.py',
+    'tests/pixeltable_cli/test_internals.py',
+    'tests/pixeltable_cli/test_schema.py',
+    'tests/pixeltable_cli/test_serve_deploy.py',
+    'tests/pixeltable_cli/test_smoke.py',
 )
 
 MAIN_PLATFORM = 'ubuntu-24.04'
@@ -120,8 +120,9 @@ def generate_matrix(args: argparse.Namespace) -> None:
 
     if trigger == 'pull_request':
         # On every push to a PR we run only the slim tests. It is strictly a subset of what the merge queue runs.
+        slim_pytest = DEFAULT_PYTEST + ' ' + ' '.join(SLIM_TESTS)
         configs.extend(
-            MatrixConfig('slim', 'py', platform, '3.11', pytest_options=f'{DEFAULT_PYTEST} {SLIM_TESTS}')
+            MatrixConfig('slim', 'py', platform, '3.11', pytest_options=slim_pytest)
             for platform in (MAIN_PLATFORM, *BASIC_PLATFORMS)
         )
 

--- a/tool/ci_tool.py
+++ b/tool/ci_tool.py
@@ -25,21 +25,45 @@ VERY_EXPENSIVE_PYTEST = "-m 'not benchmark and not cloud_e2e'"
 # The core-functionality test modules that PR checks run on every push. This mirrors the `slimpytest` target in the
 # Makefile.
 SLIM_TESTS = ' '.join(
-    f'tests/test_{name}.py'
-    for name in (
-        'alter_column',
-        'catalog',
-        'dirs',
-        'env',
-        'exprs',
-        'function',
-        'index',
-        'operational_table',
-        'snapshot',
-        'table',
-        'table_model',
-        'types',
-        'view',
+    (
+        *(
+            f'tests/test_{name}.py'
+            for name in (
+                'alter_column',
+                'array_type',
+                'catalog',
+                'component_view',
+                'concurrent',
+                'concurrent_model',
+                'config',
+                'dirs',
+                'env',
+                'exceptions',
+                'exprs',
+                'fault_injection',
+                'file_cache',
+                'function',
+                'history',
+                'index',
+                'iterator',
+                'mcp',
+                'path',
+                'primary_key_index',
+                'query',
+                'sample',
+                'snapshot',
+                'table',
+                'table_model',
+                'table_model_2',
+                'types',
+                'view',
+            )
+        ),
+        'tests/serving/test_fastapi.py',
+        *(
+            f'tests/pixeltable_cli/test_{name}.py'
+            for name in ('bridge', 'internals', 'schema', 'serve_deploy', 'smoke')
+        ),
     )
 )
 


### PR DESCRIPTION
`test_operational_table` removal is intentional -- this test is going away soon.

`TestDashboard` (in `test_smoke.py`) requires the dashboard. `build-dashboard` in the test matrix became always True, so I got rid of it.