### PR TITLE
Update Groq examples to openai/gpt-oss-20b

### DIFF
--- a/docs/release/howto/providers/working-with-groq.ipynb
+++ b/docs/release/howto/providers/working-with-groq.ipynb
@@ -140,7 +140,7 @@
     "t.add_computed_column(\n",
     "    output=groq.chat_completions(\n",
     "        messages=messages,\n",
-    "        model='llama-3.3-70b-versatile',\n",
+    "        model='openai/gpt-oss-20b',\n",
     "        model_kwargs={\n",
     "            # Optional dict with parameters for the Groq API\n",
     "            'max_tokens': 300,\n",

--- a/pixeltable/functions/groq.py
+++ b/pixeltable/functions/groq.py
@@ -63,12 +63,12 @@ async def chat_completions(
         A dictionary containing the response and other metadata.
 
     Examples:
-        Add a computed column that applies the model `llama-3.1-8b-instant`
+        Add a computed column that applies the model `openai/gpt-oss-20b`
         to an existing Pixeltable column `tbl.prompt` of the table `tbl`:
 
         >>> messages = [{'role': 'user', 'content': tbl.prompt}]
         ... tbl.add_computed_column(
-        ...     response=chat_completions(messages, model='llama-3.1-8b-instant')
+        ...     response=chat_completions(messages, model='openai/gpt-oss-20b')
         ... )
     """
     if model_kwargs is None:

--- a/scripts/prepare-nb-tests.sh
+++ b/scripts/prepare-nb-tests.sh
@@ -29,6 +29,7 @@ VERY_EXPENSIVE_NOTEBOOKS=(
     working-with-fal                # [PXT-1233] fal.ai integration failing on CI
     working-with-together           # Poor reliability
     working-with-replicate          # Unreliable
+    working-with-groq               # Unreliable; Groq decommissions models (404s in merge queue)
 )
 
 # Notebooks that are skipped unless --include-expensive is passed: all notebooks that use HF models.

--- a/scripts/prepare-nb-tests.sh
+++ b/scripts/prepare-nb-tests.sh
@@ -29,7 +29,6 @@ VERY_EXPENSIVE_NOTEBOOKS=(
     working-with-fal                # [PXT-1233] fal.ai integration failing on CI
     working-with-together           # Poor reliability
     working-with-replicate          # Unreliable
-    working-with-groq               # Unreliable; Groq decommissions models (404s in merge queue)
 )
 
 # Notebooks that are skipped unless --include-expensive is passed: all notebooks that use HF models.

--- a/tests/functions/test_groq.py
+++ b/tests/functions/test_groq.py
@@ -19,11 +19,11 @@ class TestGroq:
 
         t = pxt.create_table('test_tbl', {'input': pxt.String | None})
         msgs = [{'role': 'user', 'content': t.input}]
-        t.add_computed_column(output=chat_completions(messages=msgs, model='llama-3.1-8b-instant'))
+        t.add_computed_column(output=chat_completions(messages=msgs, model='openai/gpt-oss-20b'))
         t.add_computed_column(
             output2=chat_completions(
                 messages=msgs,
-                model='llama-3.1-8b-instant',
+                model='openai/gpt-oss-20b',
                 model_kwargs={
                     'temperature': 0.8,
                     'top_p': 0.95,
@@ -47,9 +47,7 @@ class TestGroq:
         t = pxt.create_table('test_tbl', {'prompt': pxt.String | None})
         messages = [{'role': 'user', 'content': t.prompt}]
         t.add_computed_column(
-            response=groq.chat_completions(
-                model='llama-3.1-8b-instant', messages=messages, tools=tools, tool_choice=None
-            )
+            response=groq.chat_completions(model='openai/gpt-oss-20b', messages=messages, tools=tools, tool_choice=None)
         )
         t.add_computed_column(tool_calls=groq.invoke_tools(tools, t.response))
 

--- a/tool/perftest_providers.py
+++ b/tool/perftest_providers.py
@@ -73,7 +73,7 @@ def create_provider_configs(max_tokens: int) -> dict[str, ProviderConfig]:
         'groq': ProviderConfig(
             prompt_udf=create_chatgpt_prompt,
             udf=pxtf.groq.chat_completions,
-            default_model='llama-3.1-8b-instant',
+            default_model='openai/gpt-oss-20b',
             kwargs={'model_kwargs': {'max_tokens': max_tokens, 'temperature': 0.7}},
         ),
         'mistralai': ProviderConfig(


### PR DESCRIPTION
## Summary
- Groq shut down `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` on 2026-08-16 ([deprecations](https://console.groq.com/docs/deprecations)). That 404'd merge-queue notebook tests ([job](https://github.com/pixeltable/pixeltable/actions/runs/32302499151/job/96228067986)).
- Point the Groq notebook, unit tests, docstring, and perftest default at Groq's current production replacement: `openai/gpt-oss-20b`.
- The notebook stays in merge-queue tests. This is a model-ID fix, not an exclusion.

## Test plan
- [ ] Merge-queue `notebooks+` still runs `working-with-groq.ipynb` and it passes against `openai/gpt-oss-20b`
- [ ] Optional: `pytest tests/functions/test_groq.py` with `GROQ_API_KEY`