### PR TITLE
retry ollama installation in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -185,8 +185,7 @@ jobs:
           conda-remove-defaults: true
       - name: Install ollama
         run: |
-          curl -fsSL https://ollama.com/install.sh | sh
-          ollama serve &  # Start the ollama server if it didn't start via install.sh
+          ./scripts/retry.sh 3 30 ./scripts/install-ollama.sh
           sleep 10  # Wait for the ollama server to start
           # Pull the models used for testing now, with retries, to safeguard against connection issues
           ./scripts/retry.sh 3 30 ollama pull 'qwen3:0.6b'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install ollama
         if: ${{ matrix.uv-options == '' && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.11' }}
         run: |
-          curl -fsSL https://ollama.com/install.sh | sh
+          ./scripts/retry.sh 3 30 ./scripts/install-ollama.sh
           sleep 10  # Wait for the ollama server to start
           # Pull the models used for testing now, with retries, to safeguard against connection issues
           ./scripts/retry.sh 3 30 ollama pull 'qwen3:0.6b'

--- a/scripts/install-ollama.sh
+++ b/scripts/install-ollama.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+# Installs ollama and starts the server with nohup (so that the server outlives this script)
+
+# Usage: install-ollama.sh
+
+curl -fsSL https://ollama.com/install.sh -o /tmp/install-ollama.sh
+
+sh /tmp/install-ollama.sh
+
+nohup ollama serve > /tmp/ollama-serve.log 2>&1 &


### PR DESCRIPTION
Motivation: retry when installation fails for whatever reason, e.g. https://github.com/pixeltable/pixeltable/actions/runs/32319391625/job/96278412936