### PR TITLE
Fix merge queue

### DIFF
--- a/docs/release/howto/cookbooks/agents/agentic-patterns.ipynb
+++ b/docs/release/howto/cookbooks/agents/agentic-patterns.ipynb
@@ -1618,7 +1618,7 @@
     ")\n",
     "react_steps.add_computed_column(\n",
     "    answer=react_steps.response.choices[0].message.content.astype(\n",
-    "        pxt.String\n",
+    "        pxt.String | None\n",
     "    )\n",
     ")\n",
     "react_steps.add_computed_column(\n",

--- a/scripts/prepare-nb-tests.sh
+++ b/scripts/prepare-nb-tests.sh
@@ -29,6 +29,7 @@ VERY_EXPENSIVE_NOTEBOOKS=(
     working-with-fal                # [PXT-1233] fal.ai integration failing on CI
     working-with-together           # Poor reliability
     working-with-replicate          # Unreliable
+    working-with-groq
 )
 
 # Notebooks that are skipped unless --include-expensive is passed: all notebooks that use HF models.


### PR DESCRIPTION
1. Fix an invalid type issue in agentic patterns nb -- the ongoing issue
2. Groq nb marked "very expensive". Some models got decommissioned which resulted in failures. The nb got fixed since then, but it doesn't need to be a merge blocker.