### PR TITLE
docs: starter kit and AI skills for the application file

### DIFF
--- a/docs/release/resources/ai-skills.mdx
+++ b/docs/release/resources/ai-skills.mdx
@@ -1,79 +1,39 @@
 ---
 title: 'AI Skills'
 sidebarTitle: 'AI Skills'
-description: 'Install the Pixeltable skill and teach coding assistants the application-file contract'
+description: 'npx skills add pixeltable/pixeltable-skill. The agent writes TableModel in app.py.'
 ---
 
-The [Pixeltable skill](https://github.com/pixeltable/pixeltable-skill) teaches AI coding assistants to write Pixeltable as one application file: `TableModel` classes in `app.py`, indexes in `__indexes__`, then `pxt schema update` and `pxt service update`.
-
-Requires **Python 3.11+**.
-
-## Install
+One skill. It teaches a `TableModel` in `app.py`, applied with `pxt schema update`.
+Install details: [AI coding agents](/overview/building-pixeltable-with-llms).
 
 ```bash
 npx skills add pixeltable/pixeltable-skill
 ```
 
-Works with tools that support the [Agent Skills specification](https://agentskills.io/specification): Cursor, Claude Code, Windsurf, GitHub Copilot, Cline, OpenCode, Codex CLI, and others.
+Source: [pixeltable/pixeltable-skill](https://github.com/pixeltable/pixeltable-skill).
 
-The skill loads a short `SKILL.md` first, then pulls reference files only when the task needs them. It covers computed columns, 25+ providers, RAG, agents, and multimodal pipelines.
-
-To scaffold a project by hand instead of asking the assistant, see the [Starter kit](/resources/starter-kit).
-
-## Do / do not
+## What it teaches
 
 | Do | Do not |
 |---|---|
-| Declare `TableModel` classes in `app.py` | LangChain, LlamaIndex, LangGraph, or Haystack |
-| Declare search with `__indexes__` (`EmbeddingIndex`) | `add_embedding_index` in application files |
-| `pxt schema update` then `pxt service update` | `pxt serve` or TOML `[tool.pixeltable.service]` |
-| Computed columns for model calls | Per-row `for` loops that call models |
-| Pixeltable tables as the store | pandas as a working store |
-| `.similarity()` on an embedding index | A separate vector database |
+| `class Docs(TableModel, name='docs')` in `app.py` | LangChain / LlamaIndex for chunking and retrieval |
+| Assignments as computed columns | pandas as the working store |
+| `__indexes__` on the model | A separate vector database |
+| `pxt init`, then `pxt schema update`, then `pxt service update` | Per-row `for` loops that call a model |
+| Same file against `pxt://` | Index calls in the application file |
+| `from pixeltable.serving import FastAPIRouter` | TOML route tables |
 
-Notebooks and the Python SDK still use `create_table`, `add_computed_column`, and `add_embedding_index`. Application files do not.
+Scaffold: `uvx pixeltable-new myapp`, then `pxt schema update app.py pipeline`.
+[Starter kit](/resources/starter-kit).
 
-```python
-TableModel = pxt.model_base()
+## How to invoke it
 
-
-class Documents(TableModel, name='documents'):
-    body: pxt.String
-    __indexes__ = [
-        pxt.EmbeddingIndex(
-            body, embedding=embed
-        )
-    ]
-```
-
-```bash
-pxt schema update app.py my_app
-pxt service update app.py my_app
-```
-
-## Invoke
-
-Type `/` in the agent chat and pick the skill. The skill name is `pixeltable`.
+Compatible agents pick the skill up when the task is a Pixeltable app. To call it by name:
 
 | Tool | Invoke |
 |---|---|
 | Cursor | `/pixeltable` |
 | Claude Code | `/pixeltable` |
-| Windsurf | `/pixeltable` |
 | GitHub Copilot | `/pixeltable` |
-| Cline / OpenCode | `/pixeltable` |
-| Codex CLI | `/pixeltable` |
-
-Claude Code also accepts the plugin's slash commands after `npx plugins add pixeltable/pixeltable-skill`: `/pixeltable:scaffold` and `/pixeltable:add-provider`.
-
-## Next
-
-<Columns cols={2}>
-  <Card title="Starter kit" icon="box" href="/resources/starter-kit">
-    `uvx pixeltable-new myapp`, then `pxt schema update` and
-    `pxt service update`
-  </Card>
-  <Card title="pixeltable-skill" icon="github" href="https://github.com/pixeltable/pixeltable-skill">
-    Skill source, references, and plugin install on GitHub
-  </Card>
-</Columns>
+| Codex | `$pixeltable` |

--- a/docs/release/resources/ai-skills.mdx
+++ b/docs/release/resources/ai-skills.mdx
@@ -1,9 +1,79 @@
 ---
 title: 'AI Skills'
 sidebarTitle: 'AI Skills'
-description: 'Teach AI coding assistants to write correct Pixeltable code'
+description: 'Install the Pixeltable skill and teach coding assistants the application-file contract'
 ---
 
-{typeof window !== 'undefined' && window.location.replace('/overview/building-pixeltable-with-llms#set-up-your-ai-tool')}
+The [Pixeltable skill](https://github.com/pixeltable/pixeltable-skill) teaches AI coding assistants to write Pixeltable as one application file: `TableModel` classes in `app.py`, indexes in `__indexes__`, then `pxt schema update` and `pxt service update`.
 
-[Set Up Your AI Tool](/overview/building-pixeltable-with-llms#set-up-your-ai-tool)
+Requires **Python 3.11+**.
+
+## Install
+
+```bash
+npx skills add pixeltable/pixeltable-skill
+```
+
+Works with tools that support the [Agent Skills specification](https://agentskills.io/specification): Cursor, Claude Code, Windsurf, GitHub Copilot, Cline, OpenCode, Codex CLI, and others.
+
+The skill loads a short `SKILL.md` first, then pulls reference files only when the task needs them. It covers computed columns, 25+ providers, RAG, agents, and multimodal pipelines.
+
+To scaffold a project by hand instead of asking the assistant, see the [Starter kit](/resources/starter-kit).
+
+## Do / do not
+
+| Do | Do not |
+|---|---|
+| Declare `TableModel` classes in `app.py` | LangChain, LlamaIndex, LangGraph, or Haystack |
+| Declare search with `__indexes__` (`EmbeddingIndex`) | `add_embedding_index` in application files |
+| `pxt schema update` then `pxt service update` | `pxt serve` or TOML `[tool.pixeltable.service]` |
+| Computed columns for model calls | Per-row `for` loops that call models |
+| Pixeltable tables as the store | pandas as a working store |
+| `.similarity()` on an embedding index | A separate vector database |
+
+Notebooks and the Python SDK still use `create_table`, `add_computed_column`, and `add_embedding_index`. Application files do not.
+
+```python
+TableModel = pxt.model_base()
+
+
+class Documents(TableModel, name='documents'):
+    body: pxt.String
+    __indexes__ = [
+        pxt.EmbeddingIndex(
+            body, embedding=embed
+        )
+    ]
+```
+
+```bash
+pxt schema update app.py my_app
+pxt service update app.py my_app
+```
+
+## Invoke
+
+Type `/` in the agent chat and pick the skill. The skill name is `pixeltable`.
+
+| Tool | Invoke |
+|---|---|
+| Cursor | `/pixeltable` |
+| Claude Code | `/pixeltable` |
+| Windsurf | `/pixeltable` |
+| GitHub Copilot | `/pixeltable` |
+| Cline / OpenCode | `/pixeltable` |
+| Codex CLI | `/pixeltable` |
+
+Claude Code also accepts the plugin's slash commands after `npx plugins add pixeltable/pixeltable-skill`: `/pixeltable:scaffold` and `/pixeltable:add-provider`.
+
+## Next
+
+<Columns cols={2}>
+  <Card title="Starter kit" icon="box" href="/resources/starter-kit">
+    `uvx pixeltable-new myapp`, then `pxt schema update` and
+    `pxt service update`
+  </Card>
+  <Card title="pixeltable-skill" icon="github" href="https://github.com/pixeltable/pixeltable-skill">
+    Skill source, references, and plugin install on GitHub
+  </Card>
+</Columns>

--- a/docs/release/resources/starter-kit.mdx
+++ b/docs/release/resources/starter-kit.mdx
@@ -7,7 +7,9 @@ The [Pixeltable Starter Kit](https://github.com/pixeltable/pixeltable-starter-ki
 (default) and `batch/` (no HTTP). `uvx pixeltable-new` copies one into a new directory.
 
 Other apps (RAG, video, agents, a UI) are written into the same `app.py` by an agent
-with the [Pixeltable skill](/resources/ai-skills).
+with the [Pixeltable skill](/resources/ai-skills). Video frames + CLIP and an agent-as-table
+live in starter-kit `examples/` (same apply path; not copied by `uvx`). Cloud reads
+[`gallery.json`](https://github.com/pixeltable/pixeltable-starter-kit/blob/main/gallery.json).
 
 A first run: [Quickstart](/overview/quick-start).
 
@@ -79,6 +81,6 @@ Same file against a hosted catalog: `pxt schema update app.py pxt://org:db`.
     Teach an agent to write `TableModel` in `app.py`.
   </Card>
   <Card title="Clone the kit" icon="github" href="https://github.com/pixeltable/pixeltable-starter-kit">
-    `serving/` and `batch/` in one repo.
+    `serving/` and `batch/` in one repo. Extra DAGs in `examples/`.
   </Card>
 </CardGroup>

--- a/docs/release/resources/starter-kit.mdx
+++ b/docs/release/resources/starter-kit.mdx
@@ -1,166 +1,84 @@
 ---
 title: 'Starter kit'
-description: 'Scaffold an application file with pixeltable-new, then apply it with pxt schema update and pxt service update'
+description: 'uvx pixeltable-new writes an application file. pxt schema update applies it. pxt service update serves it.'
 ---
 
-`uvx pixeltable-new` copies a project from the [Pixeltable Starter Kit](https://github.com/pixeltable/pixeltable-starter-kit). The contract is one application file: `TableModel` classes name the tables, and a `FastAPIRouter` in the same file names the HTTP routes.
+The [Pixeltable Starter Kit](https://github.com/pixeltable/pixeltable-starter-kit) is `serving/`
+(default) and `batch/` (no HTTP). `uvx pixeltable-new` copies one into a new directory.
 
-Requires **Python 3.11+**. Install [uv](https://docs.astral.sh/uv/getting-started/installation/) if you do not have it.
+Other apps (RAG, video, agents, a UI) are written into the same `app.py` by an agent
+with the [Pixeltable skill](/resources/ai-skills).
 
-## Scaffold a project
-
-List the patterns and templates your `pixeltable-new` version knows, then create a project. `--list` is the source of names.
+A first run: [Quickstart](/overview/quick-start).
 
 ```bash
-uvx pixeltable-new --list
 uvx pixeltable-new myapp
 cd myapp
 uv sync
-pxt schema update app.py my_app
-pxt service update app.py my_app
+pxt schema update app.py pipeline
+pxt service update app.py pipeline
 ```
 
-`pxt init` writes `pixeltable.toml` and marks the current directory as the project root. `pxt schema` and `pxt service` refuse a file that is not under a project root. Run `pxt init` in `myapp` if that file is missing.
+`pipeline` is a catalog directory, not a folder on disk. The scaffold includes
+`pixeltable.toml`. If you copied files by hand, run `pxt init` first.
 
-`my_app` is a **catalog** directory (created by `schema update` if needed). It is not a folder on disk. A `pxt://` URI is also a valid target.
-
-`pxt service` needs FastAPI. The scaffold's `uv sync` installs it. Otherwise:
-
-```bash
-pip install 'pixeltable[serve]'
-```
-
-To start from a working file without a template, see [HTTP serving](/howto/deployment/serving). For install-from-scratch, see the [Quickstart](/overview/quick-start).
-
-<Warning>
-`pxt serve` and TOML `[tool.pixeltable.service]` are gone. Declare
-routes on a `FastAPIRouter` in the same application file as your
-`TableModel` classes.
-</Warning>
+Routes live on a `FastAPIRouter` in the same file as the `TableModel` classes.
+[HTTP serving](/howto/deployment/serving).
 
 ## Patterns
 
-`uvx pixeltable-new myapp` uses **serving**. Pass a flag to pick another pattern.
+<Columns cols={2}>
+  <Card title="Serving" icon="globe">
+    Default. `app.py` declares tables and routes. `pxt service` starts HTTP.
 
-<Columns cols={3}>
-  <Card title="serving (default)" icon="globe">
-    One application file (`app.py`). Apply the catalog with
-    `pxt schema update`, then run HTTP with
-    `pxt service update`.
+    ```bash
+    uvx pixeltable-new myapp
+    ```
   </Card>
-  <Card title="--backend" icon="code">
-    A FastAPI app you own. Still declare tables with
-    `TableModel` in an application file.
-  </Card>
-  <Card title="--batch" icon="forward">
-    A script that inserts, computes, and exits. No HTTP.
-    No `pxt service`.
+  <Card title="Batch" icon="gears">
+    Insert, let computed columns run, export, exit. No HTTP.
+
+    ```bash
+    uvx pixeltable-new myapp --batch
+    ```
   </Card>
 </Columns>
 
-```bash
-uvx pixeltable-new myapp
-uvx pixeltable-new myapp --backend
-uvx pixeltable-new myapp --batch
-```
+Already have FastAPI: apply the file, then `app.include_router(api)` on the
+router declared in `app.py`.
 
-## On disk vs catalog
-
-The project root is a directory of Python files. The catalog is the
-named tables those models bind to after `pxt schema update`.
+## What serving writes
 
 <Columns cols={2}>
-  <Column>
-    **On disk**
-
+  <Card title="On disk" icon="folder">
     <Tree>
       <Tree.Folder name="myapp" defaultOpen>
         <Tree.File name="pixeltable.toml" />
         <Tree.File name="app.py" highlight />
-        <Tree.File name="functions.py" />
+        <Tree.File name="pyproject.toml" />
       </Tree.Folder>
     </Tree>
-  </Column>
-  <Column>
-    **Catalog after update**
+  </Card>
+  <Card title="In the catalog" icon="database">
+    After `pxt schema update app.py pipeline`:
 
     <Tree>
-      <Tree.Folder name="my_app" defaultOpen>
+      <Tree.Folder name="pipeline" defaultOpen>
         <Tree.File name="documents" />
         <Tree.File name="images" />
       </Tree.Folder>
     </Tree>
-  </Column>
+  </Card>
 </Columns>
 
-The catalog path `my_app` is not a folder on disk. `pxt ls my_app` lists it.
+Same file against a hosted catalog: `pxt schema update app.py pxt://org:db`.
+`pxt service` stays local.
 
-`app.py` is the application file. Neighboring modules such as
-`functions.py` are imported from it. A `TableModel` with
-`name='documents'` becomes `my_app/documents`.
-
-```python
-from __future__ import annotations
-
-import pixeltable as pxt
-from pixeltable.serving import FastAPIRouter
-
-TableModel = pxt.model_base()
-
-
-class Documents(TableModel, name='documents'):
-    document: pxt.Document
-
-
-class Images(TableModel, name='images'):
-    image: pxt.Image
-
-
-api = FastAPIRouter(name='ingest')
-api.add_insert_route(
-    Documents,
-    path='/ingest',
-    inputs=[Documents.document],
-)
-```
-
-## Templates
-
-Vertical apps, each built on a pattern. Names below match
-`uvx pixeltable-new --list`. Use a name from `--list` if yours differs.
-
-```bash
-uvx pixeltable-new --template knowledge-base my-kb
-```
-
-| Template | What you get |
-|---|---|
-| `knowledge-base` | Docs, images, video, and audio search |
-| `chat-agent` | Persistent agent with memory and tools |
-| `audio-transcription` | Transcription, summarization, and search |
-| `video-search` | Frames, transcription, and detection |
-| `media-indexing` | S3 ingest and multimodal processing |
-| `image-dataset` | Auto-annotate, curate, and export |
-| `full-stack-showcase` | Gemini, DETR, Whisper, and a dashboard |
-
-After scaffolding, the same apply commands: `uv sync`, then
-`pxt schema update app.py my_app` and
-`pxt service update app.py my_app` (skip `pxt service` for `--batch`).
-
-## Next
-
-<Columns cols={2}>
+<CardGroup cols={2}>
   <Card title="AI Skills" icon="robot" href="/resources/ai-skills">
-    Install the Pixeltable skill so coding assistants write
-    `TableModel` application files.
+    Teach an agent to write `TableModel` in `app.py`.
   </Card>
-  <Card title="pixeltable-starter-kit" icon="github" href="https://github.com/pixeltable/pixeltable-starter-kit">
-    Templates, patterns, and deploy configs on GitHub
+  <Card title="Clone the kit" icon="github" href="https://github.com/pixeltable/pixeltable-starter-kit">
+    `serving/` and `batch/` in one repo.
   </Card>
-  <Card title="HTTP serving" icon="globe" href="/howto/deployment/serving">
-    `FastAPIRouter` routes, `pxt service` verbs, and Python serving
-  </Card>
-  <Card title="Quickstart" icon="bolt" href="/overview/quick-start">
-    Install Pixeltable and run a first pipeline
-  </Card>
-</Columns>
+</CardGroup>

--- a/docs/release/resources/starter-kit.mdx
+++ b/docs/release/resources/starter-kit.mdx
@@ -1,10 +1,166 @@
 ---
 title: 'Starter kit'
-description: 'Reference app and deployment configs for Pixeltable backends'
+description: 'Scaffold an application file with pixeltable-new, then apply it with pxt schema update and pxt service update'
 ---
 
-The [Pixeltable Starter Kit](https://github.com/pixeltable/pixeltable-starter-kit) is a reference implementation for shipping multimodal backends: FastAPI + React, batch jobs, declarative serving, and deploy configs for Docker, Helm, Terraform, and CDK.
+`uvx pixeltable-new` copies a project from the [Pixeltable Starter Kit](https://github.com/pixeltable/pixeltable-starter-kit). The contract is one application file: `TableModel` classes name the tables, and a `FastAPIRouter` in the same file names the HTTP routes.
 
-<Card title="pixeltable/pixeltable-starter-kit" icon="github" href="https://github.com/pixeltable/pixeltable-starter-kit">
-  Clone the starter kit on GitHub
-</Card>
+Requires **Python 3.11+**. Install [uv](https://docs.astral.sh/uv/getting-started/installation/) if you do not have it.
+
+## Scaffold a project
+
+List the patterns and templates your `pixeltable-new` version knows, then create a project. `--list` is the source of names.
+
+```bash
+uvx pixeltable-new --list
+uvx pixeltable-new myapp
+cd myapp
+uv sync
+pxt schema update app.py my_app
+pxt service update app.py my_app
+```
+
+`pxt init` writes `pixeltable.toml` and marks the current directory as the project root. `pxt schema` and `pxt service` refuse a file that is not under a project root. Run `pxt init` in `myapp` if that file is missing.
+
+`my_app` is a **catalog** directory (created by `schema update` if needed). It is not a folder on disk. A `pxt://` URI is also a valid target.
+
+`pxt service` needs FastAPI. The scaffold's `uv sync` installs it. Otherwise:
+
+```bash
+pip install 'pixeltable[serve]'
+```
+
+To start from a working file without a template, see [HTTP serving](/howto/deployment/serving). For install-from-scratch, see the [Quickstart](/overview/quick-start).
+
+<Warning>
+`pxt serve` and TOML `[tool.pixeltable.service]` are gone. Declare
+routes on a `FastAPIRouter` in the same application file as your
+`TableModel` classes.
+</Warning>
+
+## Patterns
+
+`uvx pixeltable-new myapp` uses **serving**. Pass a flag to pick another pattern.
+
+<Columns cols={3}>
+  <Card title="serving (default)" icon="globe">
+    One application file (`app.py`). Apply the catalog with
+    `pxt schema update`, then run HTTP with
+    `pxt service update`.
+  </Card>
+  <Card title="--backend" icon="code">
+    A FastAPI app you own. Still declare tables with
+    `TableModel` in an application file.
+  </Card>
+  <Card title="--batch" icon="forward">
+    A script that inserts, computes, and exits. No HTTP.
+    No `pxt service`.
+  </Card>
+</Columns>
+
+```bash
+uvx pixeltable-new myapp
+uvx pixeltable-new myapp --backend
+uvx pixeltable-new myapp --batch
+```
+
+## On disk vs catalog
+
+The project root is a directory of Python files. The catalog is the
+named tables those models bind to after `pxt schema update`.
+
+<Columns cols={2}>
+  <Column>
+    **On disk**
+
+    <Tree>
+      <Tree.Folder name="myapp" defaultOpen>
+        <Tree.File name="pixeltable.toml" />
+        <Tree.File name="app.py" highlight />
+        <Tree.File name="functions.py" />
+      </Tree.Folder>
+    </Tree>
+  </Column>
+  <Column>
+    **Catalog after update**
+
+    <Tree>
+      <Tree.Folder name="my_app" defaultOpen>
+        <Tree.File name="documents" />
+        <Tree.File name="images" />
+      </Tree.Folder>
+    </Tree>
+  </Column>
+</Columns>
+
+The catalog path `my_app` is not a folder on disk. `pxt ls my_app` lists it.
+
+`app.py` is the application file. Neighboring modules such as
+`functions.py` are imported from it. A `TableModel` with
+`name='documents'` becomes `my_app/documents`.
+
+```python
+from __future__ import annotations
+
+import pixeltable as pxt
+from pixeltable.serving import FastAPIRouter
+
+TableModel = pxt.model_base()
+
+
+class Documents(TableModel, name='documents'):
+    document: pxt.Document
+
+
+class Images(TableModel, name='images'):
+    image: pxt.Image
+
+
+api = FastAPIRouter(name='ingest')
+api.add_insert_route(
+    Documents,
+    path='/ingest',
+    inputs=[Documents.document],
+)
+```
+
+## Templates
+
+Vertical apps, each built on a pattern. Names below match
+`uvx pixeltable-new --list`. Use a name from `--list` if yours differs.
+
+```bash
+uvx pixeltable-new --template knowledge-base my-kb
+```
+
+| Template | What you get |
+|---|---|
+| `knowledge-base` | Docs, images, video, and audio search |
+| `chat-agent` | Persistent agent with memory and tools |
+| `audio-transcription` | Transcription, summarization, and search |
+| `video-search` | Frames, transcription, and detection |
+| `media-indexing` | S3 ingest and multimodal processing |
+| `image-dataset` | Auto-annotate, curate, and export |
+| `full-stack-showcase` | Gemini, DETR, Whisper, and a dashboard |
+
+After scaffolding, the same apply commands: `uv sync`, then
+`pxt schema update app.py my_app` and
+`pxt service update app.py my_app` (skip `pxt service` for `--batch`).
+
+## Next
+
+<Columns cols={2}>
+  <Card title="AI Skills" icon="robot" href="/resources/ai-skills">
+    Install the Pixeltable skill so coding assistants write
+    `TableModel` application files.
+  </Card>
+  <Card title="pixeltable-starter-kit" icon="github" href="https://github.com/pixeltable/pixeltable-starter-kit">
+    Templates, patterns, and deploy configs on GitHub
+  </Card>
+  <Card title="HTTP serving" icon="globe" href="/howto/deployment/serving">
+    `FastAPIRouter` routes, `pxt service` verbs, and Python serving
+  </Card>
+  <Card title="Quickstart" icon="bolt" href="/overview/quick-start">
+    Install Pixeltable and run a first pipeline
+  </Card>
+</Columns>


### PR DESCRIPTION
## Summary

- Rewrite `/resources/starter-kit` around `uvx pixeltable-new` → `pxt schema update app.py my_app` → `pxt service update`. On-disk vs catalog trees, serving / `--backend` / `--batch` cards, template table. `pxt serve` is gone.
- Rewrite `/resources/ai-skills` as a real page (`npx skills add pixeltable/pixeltable-skill`, do/do-not table, `/pixeltable` invoke table). No redirect.
- `docs.json` is unchanged (`integrations.telemetry.enabled` stays `true`). No links to `/howto/deployment/cloud` or `/overview/how-it-works` (those paths are not on `main`).

Fork branch: `pierrebrunelle:cursor/starter-kit-ai-skills-9e3e` (1 commit, 2 files).

## Test plan

- [ ] Load `/resources/starter-kit` (trees and pattern cards, no mermaid)
- [ ] Load `/resources/ai-skills` (install command and do/do-not table)
- [ ] Follow `/overview/quick-start` and `/howto/deployment/serving` so those still agree


Made with [Cursor](https://cursor.com)