### PR TITLE
Refactor `pxt db` CLI tests

### DIFF
--- a/pixeltable/service/db.py
+++ b/pixeltable/service/db.py
@@ -55,7 +55,7 @@ _DB_DESTRUCTIVE_HINT = "Re-run 'pxt db update' with --allow-destructive to apply
 _ENV_BINDING = 'env:'
 
 # how long a hosted database may stay in a transitional state before an update gives up on it
-_DB_SETTLE_TIMEOUT = 1200.0
+_DB_SETTLE_TIMEOUT = 3600.0
 _DB_POLL_INTERVAL = 5.0
 
 # the states a database passes through while it applies something

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,8 +300,10 @@ ignore_missing_imports = true
 [[tool.pixeltable.database]]
 # we need the repo for the uv-dynamic-versioning install, and pixeltable/_version.py in order for the
 # package to function. Both are ignored by default
+name = 'pxt://pixeltable:pxttest'
 include = ['.git/**', 'pixeltable/_version.py']
 system_dependencies = ["libiconv", "ffmpeg==6.1.1=gpl*"]
+uv_options = "--no-dev"
 
 [tool.pyright]
 typeCheckingMode = "off"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,12 +370,6 @@ def served_project() -> pathlib.Path | None:
     return None
 
 
-@pytest.fixture(scope='session')
-def hosted_image() -> None:
-    """Build the hosted database's image. The CLI package overrides this; elsewhere it does nothing."""
-    return None
-
-
 @pytest.fixture(scope='function')
 def db_root(
     init_env: None, served_project: pathlib.Path | None, request: pytest.FixtureRequest
@@ -412,8 +406,6 @@ def db_root(
         case 'cloud':
             base_uri = os.environ.get('PXTTEST_CLOUD_DB_URI')
             assert base_uri, 'This should have been intercepted in pytest_generate_tests().'
-            # a hosted database runs its image's project, so the image must hold this session's project
-            request.getfixturevalue('hosted_image')
             test_dir = uuid.uuid4().hex
             prefix = f'{base_uri}/test_{test_dir}'
             _logger.info('Creating test directory in cloud catalog: %s', prefix)

--- a/tests/pixeltable_cli/conftest.py
+++ b/tests/pixeltable_cli/conftest.py
@@ -161,6 +161,8 @@ _RUN_TIMEOUT_SECS = 300
 # an image build runs CodeBuild, which takes minutes
 _IMAGE_BUILD_TIMEOUT_SECS = 1800
 
+_WHEEL_SUBDIR = 'wheels'
+
 
 def _as_text(stream: bytes | str | None) -> str:
     """Normalize captured output: TimeoutExpired carries bytes even when the run was text=True."""
@@ -178,7 +180,39 @@ def _copy_app_corpus(session_project: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture(scope='session')
-def hosted_image(session_project: pathlib.Path) -> None:
+def pixeltable_wheel(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    """A wheel built from this working tree, for a project to install in place of the released pixeltable."""
+    repo_root = pathlib.Path(__file__).parents[2]
+    out_dir = tmp_path_factory.mktemp('pxt_wheel')
+    r = subprocess.run(
+        ['uv', 'build', '--wheel', '-o', str(out_dir), str(repo_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_RUN_TIMEOUT_SECS,
+    )
+    assert r.returncode == 0, f'building a pixeltable wheel from {repo_root} failed:\n{r.stderr}'
+    wheels = list(out_dir.glob('*.whl'))
+    assert len(wheels) == 1, f'expected one wheel in {out_dir}, found {wheels}'
+    return wheels[0]
+
+
+def write_requirements(project: pathlib.Path, wheel: pathlib.Path, *extra: str) -> None:
+    """Write project's requirements.txt, installing pixeltable from wheel rather than from PyPI.
+
+    The wheel is copied into the project so that the archive carries it, and named by a path relative to
+    the project root, which is where the image build runs pip.
+    """
+    wheel_dir = project / _WHEEL_SUBDIR
+    wheel_dir.mkdir(exist_ok=True)
+    shutil.copy(wheel, wheel_dir / wheel.name)
+    (project / 'requirements.txt').write_text(
+        '\n'.join([f'./{_WHEEL_SUBDIR}/{wheel.name}', *extra]) + '\n', encoding='utf-8'
+    )
+
+
+@pytest.fixture(scope='session')
+def hosted_image(session_project: pathlib.Path, pixeltable_wheel: pathlib.Path) -> None:
     """Build the hosted database's image from this session's project, once.
 
     A hosted database runs the project its image was built from, so a udf a hosted table refers to has to
@@ -191,16 +225,14 @@ def hosted_image(session_project: pathlib.Path) -> None:
     _copy_app_corpus(session_project)
     entry = f'[[pixeltable.database]]\nname = {json.dumps(db_uri)}\n'
     (session_project / 'pixeltable.toml').write_text(entry, encoding='utf-8')
-    # Naming pixeltable installs its dependencies; the build then reinstalls pixeltable itself from the
-    # base image's wheel, so the pod runs this tree rather than the release named here.
     # The sentence splitter loads en_core_web_sm and does not fetch it, so the project names it too.
-    requirements = (
-        'pixeltable\n'
-        'spacy\n'
+    write_requirements(
+        session_project,
+        pixeltable_wheel,
+        'spacy',
         'en_core_web_sm @ '
-        'https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl\n'
+        'https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl',
     )
-    (session_project / 'requirements.txt').write_text(requirements, encoding='utf-8')
     r = subprocess.run(
         ['pxt', 'db', 'update', db_uri, '-f'],
         cwd=session_project,

--- a/tests/pixeltable_cli/conftest.py
+++ b/tests/pixeltable_cli/conftest.py
@@ -330,6 +330,7 @@ def cli(pxt_daemon: int, db_root: DatabaseRoot, session_project: pathlib.Path) -
         print(f'Finished in {time.monotonic() - started:.1f}s (rc={r.returncode}): pxt {" ".join(args)}', flush=True)
         if check and r.returncode != 0:
             raise AssertionError(f'pxt {args} failed (rc={r.returncode}): {r.stderr}')
+        print(r.stdout)
         return PxtResult(r.returncode, r.stdout, r.stderr)
 
     return _run

--- a/tests/pixeltable_cli/conftest.py
+++ b/tests/pixeltable_cli/conftest.py
@@ -158,9 +158,6 @@ PxtRunner = Callable[..., PxtResult]
 
 _RUN_TIMEOUT_SECS = 300
 
-# an image build runs CodeBuild, which takes minutes
-_IMAGE_BUILD_TIMEOUT_SECS = 1800
-
 _WHEEL_SUBDIR = 'wheels'
 
 
@@ -209,40 +206,6 @@ def write_requirements(project: pathlib.Path, wheel: pathlib.Path, *extra: str) 
     (project / 'requirements.txt').write_text(
         '\n'.join([f'./{_WHEEL_SUBDIR}/{wheel.name}', *extra]) + '\n', encoding='utf-8'
     )
-
-
-@pytest.fixture(scope='session')
-def hosted_image(session_project: pathlib.Path, pixeltable_wheel: pathlib.Path) -> None:
-    """Build the hosted database's image from this session's project, once.
-
-    A hosted database runs the project its image was built from, so a udf a hosted table refers to has to
-    be in that image. A module a test writes for itself never is, which is what the db_roots markers on
-    those tests record.
-    """
-    db_uri = os.environ.get('PXTTEST_CLOUD_DB_URI')
-    if db_uri is None:
-        return
-    _copy_app_corpus(session_project)
-    entry = f'[[pixeltable.database]]\nname = {json.dumps(db_uri)}\n'
-    (session_project / 'pixeltable.toml').write_text(entry, encoding='utf-8')
-    # The sentence splitter loads en_core_web_sm and does not fetch it, so the project names it too.
-    write_requirements(
-        session_project,
-        pixeltable_wheel,
-        'spacy',
-        'en_core_web_sm @ '
-        'https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl',
-    )
-    r = subprocess.run(
-        ['pxt', 'db', 'update', db_uri, '-f'],
-        cwd=session_project,
-        capture_output=True,
-        text=True,
-        timeout=_IMAGE_BUILD_TIMEOUT_SECS,
-        check=False,
-    )
-    if r.returncode != 0:
-        raise AssertionError(f'building the image for {db_uri} failed (rc={r.returncode}):\n{r.stderr}')
 
 
 @pytest.fixture

--- a/tests/pixeltable_cli/conftest.py
+++ b/tests/pixeltable_cli/conftest.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Iterator
 import pytest
 
 from pixeltable.config import Config
+from pixeltable_cli.client.utils import is_running
 
 from ..utils import DatabaseRoot
 
@@ -108,12 +109,11 @@ def pxt_daemon(
             stdin=subprocess.DEVNULL,
         )
     try:
-        from pixeltable_cli.client.utils import is_running
-
         os.environ['PXT_PORT'] = str(port)
         # Allow for a cold pixeltable import in the daemon subprocess, which on a loaded CI runner can run
         # well past a warm import; matches the client's own startup health timeout.
         startup_timeout = 45
+        print(f'Waiting for the test daemon on port {port}, serving {session_project}', flush=True)
         deadline = time.time() + startup_timeout
         while time.time() < deadline:
             if is_running():
@@ -132,6 +132,7 @@ def pxt_daemon(
         # provoke that restart here, with the environment this fixture started the daemon with.
         subprocess.run(['pxt', 'ls', '/'], env=env, capture_output=True, check=False, timeout=60)
         assert is_running()
+        print(f'Test daemon is up on port {port}; log at {log_path}', flush=True)
         yield port
     finally:
         # a test may have restarted the daemon, in which case the process answering on the port is not the
@@ -181,9 +182,9 @@ def pixeltable_wheel(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
     """A wheel built from this working tree, for a project to install in place of the released pixeltable."""
     repo_root = pathlib.Path(__file__).parents[2]
     out_dir = tmp_path_factory.mktemp('pxt_wheel')
+    print(f'Building a Pixeltable wheel from {repo_root}', flush=True)
     r = subprocess.run(
         ['uv', 'build', '--wheel', '-o', str(out_dir), str(repo_root)],
-        capture_output=True,
         text=True,
         check=False,
         timeout=_RUN_TIMEOUT_SECS,
@@ -306,6 +307,8 @@ def cli(pxt_daemon: int, db_root: DatabaseRoot, session_project: pathlib.Path) -
                 env.pop(name, None)
             else:
                 env[name] = value
+        print(f'Running: pxt {" ".join(args)}', flush=True)
+        started = time.monotonic()
         try:
             r = subprocess.run(
                 ['pxt', *args],
@@ -324,6 +327,7 @@ def cli(pxt_daemon: int, db_root: DatabaseRoot, session_project: pathlib.Path) -
                 f'--- stdout ---\n{_as_text(exc.stdout)}\n'
                 f'--- stderr ---\n{_as_text(exc.stderr)}'
             ) from exc
+        print(f'Finished in {time.monotonic() - started:.1f}s (rc={r.returncode}): pxt {" ".join(args)}', flush=True)
         if check and r.returncode != 0:
             raise AssertionError(f'pxt {args} failed (rc={r.returncode}): {r.stderr}')
         return PxtResult(r.returncode, r.stdout, r.stderr)

--- a/tests/pixeltable_cli/test_db.py
+++ b/tests/pixeltable_cli/test_db.py
@@ -7,7 +7,6 @@ which takes minutes. They run against the session's hosted database, the one the
 """
 
 import json
-import os
 import pathlib
 import shutil
 import uuid
@@ -16,8 +15,7 @@ from typing import Any
 import pytest
 
 from ..utils import DatabaseRoot
-
-from .conftest import PxtRunner
+from .conftest import PxtRunner, write_requirements
 
 pytestmark = [
     pytest.mark.remote_api,
@@ -37,7 +35,7 @@ _APP_FILE = 'basic.py'  # the corpus file the project holds
 
 
 @pytest.fixture
-def project(tmp_path: pathlib.Path) -> pathlib.Path:
+def project(tmp_path: pathlib.Path, pixeltable_wheel: pathlib.Path) -> pathlib.Path:
     """A project of the test's own, holding an application file from the corpus and a lockfile.
 
     Outside the session's project, so that the archive holds these files and nothing else: the client hands
@@ -47,7 +45,7 @@ def project(tmp_path: pathlib.Path) -> pathlib.Path:
     root.mkdir()
     (root / 'pixeltable.toml').write_text('', encoding='utf-8')
     shutil.copy(pathlib.Path(__file__).parent / 'apps' / _APP_FILE, root / _APP_FILE)
-    (root / 'requirements.txt').write_text('pixeltable\n', encoding='utf-8')
+    write_requirements(root, pixeltable_wheel)
     return root
 
 

--- a/tests/pixeltable_cli/test_db.py
+++ b/tests/pixeltable_cli/test_db.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import pytest
 
+from ..utils import DatabaseRoot
+
 from .conftest import PxtRunner
 
 pytestmark = [
@@ -34,21 +36,6 @@ _BUILD_TIMEOUT = 1800.0
 _APP_FILE = 'basic.py'  # the corpus file the project holds
 
 
-@pytest.fixture(autouse=True)
-def hosted_environment() -> None:
-    """Skip the test unless the session names a hosted database to act on."""
-    if os.environ.get('PXTTEST_CLOUD_DB_URI') is None:
-        pytest.skip('PXTTEST_CLOUD_DB_URI is not set.')
-
-
-@pytest.fixture
-def hosted_db() -> str:
-    """The hosted database these tests act on, which is the one the cloud catalog tests read."""
-    uri = os.environ.get('PXTTEST_CLOUD_DB_URI')
-    assert uri is not None  # hosted_environment() skipped the test otherwise
-    return uri
-
-
 @pytest.fixture
 def project(tmp_path: pathlib.Path) -> pathlib.Path:
     """A project of the test's own, holding an application file from the corpus and a lockfile.
@@ -65,12 +52,12 @@ def project(tmp_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture
-def current_db(cli: PxtRunner, project: pathlib.Path, hosted_db: str) -> str:
+def current_db(cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> str:
     """A hosted database running an image built from this project."""
-    create_project_config(cli, project, hosted_db)
-    applied = db_update(cli, project, hosted_db)
+    create_project_config(cli, project, db_root.prefix)
+    applied = db_update(cli, project, db_root.prefix)
     assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
-    return hosted_db
+    return db_root.prefix
 
 
 def create_project_config(cli: PxtRunner, project: pathlib.Path, db_uri: str, **settings: Any) -> None:
@@ -110,6 +97,7 @@ def get_target_ops(plan: dict[str, Any], target: str) -> list[dict[str, Any]]:
     return [op for op in plan['ops'] if op['target'] == target]
 
 
+@pytest.mark.db_roots('cloud', reason='Uses the CLI to drive cloud DBs through the control plane')
 class TestDb:
     def test_create(self, cli: PxtRunner, project: pathlib.Path) -> None:
         """A database the control plane does not hold is planned as a create, and the update makes it."""
@@ -130,25 +118,25 @@ class TestDb:
         finally:
             cli('db', 'delete', absent, cwd=project, check=False)
 
-    def test_update_builds_the_image(self, cli: PxtRunner, project: pathlib.Path, hosted_db: str) -> None:
+    def test_update_builds_the_image(self, cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> None:
         """Every update builds the image, since the database reports no fingerprint to compare."""
-        create_project_config(cli, project, hosted_db)
+        create_project_config(cli, project, db_root.prefix)
 
-        plan = db_diff(cli, project, hosted_db)
+        plan = db_diff(cli, project, db_root.prefix)
         assert plan['resolution'] == 'update_additive'
         assert [op['name'] for op in get_target_ops(plan, 'image')] == ['image']
         assert plan['summary']['rebuild']
         assert plan['returncode'] == EXIT_CHANGES_PENDING
 
-        applied = db_update(cli, project, hosted_db)
+        applied = db_update(cli, project, db_root.prefix)
         assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
 
         # and the next diff plans the same build, since there is still nothing to compare
-        assert get_target_ops(db_diff(cli, project, hosted_db), 'image') != []
+        assert get_target_ops(db_diff(cli, project, db_root.prefix), 'image') != []
 
-    def test_status_list(self, cli: PxtRunner, project: pathlib.Path, hosted_db: str) -> None:
-        name = hosted_db.rsplit(':', 1)[-1]
-        status = db_status(cli, project, hosted_db)
+    def test_status_list(self, cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> None:
+        name = db_root.prefix.rsplit(':', 1)[-1]
+        status = db_status(cli, project, db_root.prefix)
         assert status['state'] == 'AVAILABLE', status
         listed = cli('db', 'list', 'pxt://pixeltable', '--json', cwd=project).json
         assert name in [entry['db_name'] for entry in listed], listed
@@ -166,8 +154,8 @@ class TestDb:
         assert [op['target'] for op in ops] == ['image']
         assert all(op['status'] == 'applied' for op in ops), ops
 
-    def test_errors(self, cli: PxtRunner, project: pathlib.Path, hosted_db: str) -> None:
-        create_project_config(cli, project, hosted_db)
+    def test_errors(self, cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> None:
+        create_project_config(cli, project, db_root.prefix)
 
         not_a_uri = cli('db', 'diff', 'my_dir', cwd=project, check=False)
         assert 'URI must be pxt://org:db' in not_a_uri.stderr, not_a_uri.stderr

--- a/tests/pixeltable_cli/test_db.py
+++ b/tests/pixeltable_cli/test_db.py
@@ -1,20 +1,18 @@
 """`pxt db` against a hosted database.
 
 Every scenario drives the CLI the way a user does: a project with a [[pixeltable.database]] entry, and the
-`pxt db` verbs reading and applying it. They need a control plane, so the module is skipped unless the cloud
-environment is configured, and it is marked expensive: applying what an entry declares rebuilds an image,
-which takes minutes. They run against the session's hosted database, the one the cloud catalog tests use.
+`pxt db` verbs reading and applying it. They need a control plane, and are marked expensive: applying what
+an entry declares rebuilds an image, which takes minutes.
 """
 
 import json
 import pathlib
 import shutil
 import uuid
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 
-from ..utils import DatabaseRoot
 from .conftest import PxtRunner, write_requirements
 
 pytestmark = [
@@ -50,12 +48,22 @@ def project(tmp_path: pathlib.Path, pixeltable_wheel: pathlib.Path) -> pathlib.P
 
 
 @pytest.fixture
-def current_db(cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> str:
-    """A hosted database running an image built from this project."""
-    create_project_config(cli, project, db_root.prefix)
-    applied = db_update(cli, project, db_root.prefix)
+def test_db_uri(cli: PxtRunner, project: pathlib.Path) -> Iterator[str]:
+    """A database URI of the test's own, naming nothing until the test creates it, deleted when it ends."""
+    uri = f'pxt://pixeltable:pxttest-{uuid.uuid4().hex[:12]}'
+    try:
+        yield uri
+    finally:
+        cli('db', 'delete', uri, cwd=project, check=False)
+
+
+@pytest.fixture
+def current_db(cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> str:
+    """A database of the test's own, running an image built from this project."""
+    create_project_config(cli, project, test_db_uri)
+    applied = db_update(cli, project, test_db_uri)
     assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
-    return db_root.prefix
+    return test_db_uri
 
 
 def create_project_config(cli: PxtRunner, project: pathlib.Path, db_uri: str, **settings: Any) -> None:
@@ -63,7 +71,7 @@ def create_project_config(cli: PxtRunner, project: pathlib.Path, db_uri: str, **
     lines = ['[[pixeltable.database]]', f'name = {json.dumps(db_uri)}']
     for key, value in settings.items():
         if isinstance(value, dict):
-            lines += [f'{key}.{name} = {json.dumps(bound)}' for name, bound in value.items()]
+            lines.extend(f'{key}.{name} = {json.dumps(bound)}' for name, bound in value.items())
         else:
             lines.append(f'{key} = {json.dumps(value)}')
     (project / 'pixeltable.toml').write_text('\n'.join(lines) + '\n', encoding='utf-8')
@@ -95,46 +103,39 @@ def get_target_ops(plan: dict[str, Any], target: str) -> list[dict[str, Any]]:
     return [op for op in plan['ops'] if op['target'] == target]
 
 
-@pytest.mark.db_roots('cloud', reason='Uses the CLI to drive cloud DBs through the control plane')
 class TestDb:
-    def test_create(self, cli: PxtRunner, project: pathlib.Path) -> None:
+    def test_create(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
         """A database the control plane does not hold is planned as a create, and the update makes it."""
-        absent = f'pxt://pixeltable:pxttest-gone-{uuid.uuid4().hex[:12]}'
-        create_project_config(cli, project, absent)
+        create_project_config(cli, project, test_db_uri)
 
-        plan = db_diff(cli, project, absent)
+        plan = db_diff(cli, project, test_db_uri)
         assert plan['resolution'] == 'create'
         assert not plan['exists']
         assert plan['state'] is None
         assert plan['ops'] == []
         assert plan['returncode'] == EXIT_CHANGES_PENDING
 
-        try:
-            applied = db_update(cli, project, absent)
-            assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
-            assert db_status(cli, project, absent)['state'] == 'AVAILABLE'
-        finally:
-            cli('db', 'delete', absent, cwd=project, check=False)
+        applied = db_update(cli, project, test_db_uri)
+        assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
+        assert db_status(cli, project, test_db_uri)['state'] == 'AVAILABLE'
 
-    def test_update_builds_the_image(self, cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> None:
+    def test_update_builds_the_image(self, cli: PxtRunner, project: pathlib.Path, current_db: str) -> None:
         """Every update builds the image, since the database reports no fingerprint to compare."""
-        create_project_config(cli, project, db_root.prefix)
-
-        plan = db_diff(cli, project, db_root.prefix)
+        plan = db_diff(cli, project, current_db)
         assert plan['resolution'] == 'update_additive'
         assert [op['name'] for op in get_target_ops(plan, 'image')] == ['image']
         assert plan['summary']['rebuild']
         assert plan['returncode'] == EXIT_CHANGES_PENDING
 
-        applied = db_update(cli, project, db_root.prefix)
+        applied = db_update(cli, project, current_db)
         assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
 
         # and the next diff plans the same build, since there is still nothing to compare
-        assert get_target_ops(db_diff(cli, project, db_root.prefix), 'image') != []
+        assert get_target_ops(db_diff(cli, project, current_db), 'image') != []
 
-    def test_status_list(self, cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> None:
-        name = db_root.prefix.rsplit(':', 1)[-1]
-        status = db_status(cli, project, db_root.prefix)
+    def test_status_list(self, cli: PxtRunner, project: pathlib.Path, current_db: str) -> None:
+        name = current_db.rsplit(':', 1)[-1]
+        status = db_status(cli, project, current_db)
         assert status['state'] == 'AVAILABLE', status
         listed = cli('db', 'list', 'pxt://pixeltable', '--json', cwd=project).json
         assert name in [entry['db_name'] for entry in listed], listed
@@ -152,18 +153,17 @@ class TestDb:
         assert [op['target'] for op in ops] == ['image']
         assert all(op['status'] == 'applied' for op in ops), ops
 
-    def test_errors(self, cli: PxtRunner, project: pathlib.Path, db_root: DatabaseRoot) -> None:
-        create_project_config(cli, project, db_root.prefix)
+    def test_errors(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
+        create_project_config(cli, project, test_db_uri)
 
         not_a_uri = cli('db', 'diff', 'my_dir', cwd=project, check=False)
         assert 'URI must be pxt://org:db' in not_a_uri.stderr, not_a_uri.stderr
 
-        undeclared = cli('db', 'diff', 'pxt://pixeltable:pxttest-undeclared', cwd=project, check=False)
+        undeclared = cli('db', 'diff', f'pxt://pixeltable:pxttest-undeclared', cwd=project, check=False)
         assert undeclared.returncode == EXIT_ERROR
         assert '[[pixeltable.database]]' in undeclared.stderr, undeclared.stderr
 
-        absent = f'pxt://pixeltable:pxttest-gone-{uuid.uuid4().hex[:12]}'
-        create_project_config(cli, project, absent)
-        never_built = cli('db', 'build-image', absent, cwd=project, check=False)
+        # own_db is declared but never created, so there is no image to build
+        never_built = cli('db', 'build-image', test_db_uri, cwd=project, check=False)
         assert never_built.returncode == EXIT_ERROR
         assert 'pxt db update' in never_built.stderr, never_built.stderr

--- a/tests/pixeltable_cli/test_db.py
+++ b/tests/pixeltable_cli/test_db.py
@@ -13,6 +13,8 @@ from typing import Any, Iterator
 
 import pytest
 
+from tests.utils import skip_test_if_no_config
+
 from .conftest import PxtRunner, write_requirements
 
 # the exit statuses `pxt db diff` and `pxt db update` document
@@ -88,10 +90,11 @@ def get_target_ops(plan: dict[str, Any], target: str) -> list[dict[str, Any]]:
     return [op for op in plan['ops'] if op['target'] == target]
 
 
-@pytest.mark.expensive
+@pytest.mark.very_expensive
 @pytest.mark.db_roots('local', reason='These tests have no catalog operations')
 class TestDb:
     def test_db_ops(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
+        skip_test_if_no_config('api_key')
         create_project_config(cli, project, test_db_uri)
 
         # `db update`: Check that its first use is planned as a create
@@ -139,6 +142,7 @@ class TestDb:
         assert all(op['status'] == 'applied' for op in ops), ops
 
     def test_db_errors(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
+        skip_test_if_no_config('api_key')
         create_project_config(cli, project, test_db_uri)
 
         not_a_uri = cli('db', 'diff', 'my_dir', cwd=project, check=False)

--- a/tests/pixeltable_cli/test_db.py
+++ b/tests/pixeltable_cli/test_db.py
@@ -16,7 +16,6 @@ import pytest
 from .conftest import PxtRunner, write_requirements
 
 pytestmark = [
-    pytest.mark.remote_api,
     pytest.mark.expensive,
     pytest.mark.db_roots('local', reason='pxt db acts on a hosted database, not on the catalog a test runs against'),
 ]
@@ -159,7 +158,7 @@ class TestDb:
         not_a_uri = cli('db', 'diff', 'my_dir', cwd=project, check=False)
         assert 'URI must be pxt://org:db' in not_a_uri.stderr, not_a_uri.stderr
 
-        undeclared = cli('db', 'diff', f'pxt://pixeltable:pxttest-undeclared', cwd=project, check=False)
+        undeclared = cli('db', 'diff', 'pxt://pixeltable:pxttest-undeclared', cwd=project, check=False)
         assert undeclared.returncode == EXIT_ERROR
         assert '[[pixeltable.database]]' in undeclared.stderr, undeclared.stderr
 

--- a/tests/pixeltable_cli/test_db.py
+++ b/tests/pixeltable_cli/test_db.py
@@ -15,11 +15,6 @@ import pytest
 
 from .conftest import PxtRunner, write_requirements
 
-pytestmark = [
-    pytest.mark.expensive,
-    pytest.mark.db_roots('local', reason='pxt db acts on a hosted database, not on the catalog a test runs against'),
-]
-
 # the exit statuses `pxt db diff` and `pxt db update` document
 EXIT_IN_AGREEMENT = 0
 EXIT_ERROR = 1
@@ -54,15 +49,6 @@ def test_db_uri(cli: PxtRunner, project: pathlib.Path) -> Iterator[str]:
         yield uri
     finally:
         cli('db', 'delete', uri, cwd=project, check=False)
-
-
-@pytest.fixture
-def current_db(cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> str:
-    """A database of the test's own, running an image built from this project."""
-    create_project_config(cli, project, test_db_uri)
-    applied = db_update(cli, project, test_db_uri)
-    assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
-    return test_db_uri
 
 
 def create_project_config(cli: PxtRunner, project: pathlib.Path, db_uri: str, **settings: Any) -> None:
@@ -102,11 +88,13 @@ def get_target_ops(plan: dict[str, Any], target: str) -> list[dict[str, Any]]:
     return [op for op in plan['ops'] if op['target'] == target]
 
 
+@pytest.mark.expensive
+@pytest.mark.db_roots('local', reason='These tests have no catalog operations')
 class TestDb:
-    def test_create(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
-        """A database the control plane does not hold is planned as a create, and the update makes it."""
+    def test_db_ops(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
         create_project_config(cli, project, test_db_uri)
 
+        # `db update`: Check that its first use is planned as a create
         plan = db_diff(cli, project, test_db_uri)
         assert plan['resolution'] == 'create'
         assert not plan['exists']
@@ -118,41 +106,39 @@ class TestDb:
         assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
         assert db_status(cli, project, test_db_uri)['state'] == 'AVAILABLE'
 
-    def test_update_builds_the_image(self, cli: PxtRunner, project: pathlib.Path, current_db: str) -> None:
-        """Every update builds the image, since the database reports no fingerprint to compare."""
-        plan = db_diff(cli, project, current_db)
+        # `db update`: Check that a second call is planned as an update
+        # Every update rebuilds the image, since the database reports no fingerprint to compare
+        plan = db_diff(cli, project, test_db_uri)
         assert plan['resolution'] == 'update_additive'
         assert [op['name'] for op in get_target_ops(plan, 'image')] == ['image']
         assert plan['summary']['rebuild']
         assert plan['returncode'] == EXIT_CHANGES_PENDING
 
-        applied = db_update(cli, project, current_db)
+        applied = db_update(cli, project, test_db_uri)
         assert all(op['status'] == 'applied' for op in applied['ops']), applied['ops']
 
-        # and the next diff plans the same build, since there is still nothing to compare
-        assert get_target_ops(db_diff(cli, project, current_db), 'image') != []
+        # `db update`: And the next diff plans the same build, since the database reports no fingerprint to compare
+        assert get_target_ops(db_diff(cli, project, test_db_uri), 'image') != []
 
-    def test_status_list(self, cli: PxtRunner, project: pathlib.Path, current_db: str) -> None:
-        name = current_db.rsplit(':', 1)[-1]
-        status = db_status(cli, project, current_db)
+        # Check that the database is listed in the org's databases
+        status = db_status(cli, project, test_db_uri)
         assert status['state'] == 'AVAILABLE', status
         listed = cli('db', 'list', 'pxt://pixeltable', '--json', cwd=project).json
-        assert name in [entry['db_name'] for entry in listed], listed
+        test_db_name = test_db_uri.rsplit(':', 1)[-1]
+        assert test_db_name in [entry['db_name'] for entry in listed], listed
 
-    def test_dry_run(self, cli: PxtRunner, project: pathlib.Path, current_db: str) -> None:
-        """A dry run reports what an update would do and leaves the database alone."""
-        planned = db_update(cli, project, current_db, '-n')
+        # `db update`: Check that a dry run of an update is planned as an update, but not applied
+        planned = db_update(cli, project, test_db_uri, '-n')
         assert planned['returncode'] == EXIT_CHANGES_PENDING
         assert all(op['status'] is None for op in planned['ops']), planned['ops']
         assert get_target_ops(planned, 'image') != []
 
-    def test_build_image(self, cli: PxtRunner, project: pathlib.Path, current_db: str) -> None:
-        """build-image sends whatever the project holds and builds it."""
-        ops = cli('db', 'build-image', current_db, '--json', cwd=project, timeout=_BUILD_TIMEOUT).json
+        # `db build-image`: Sends whatever the project holds and builds it
+        ops = cli('db', 'build-image', test_db_uri, '--json', cwd=project, timeout=_BUILD_TIMEOUT).json
         assert [op['target'] for op in ops] == ['image']
         assert all(op['status'] == 'applied' for op in ops), ops
 
-    def test_errors(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
+    def test_db_errors(self, cli: PxtRunner, project: pathlib.Path, test_db_uri: str) -> None:
         create_project_config(cli, project, test_db_uri)
 
         not_a_uri = cli('db', 'diff', 'my_dir', cwd=project, check=False)
@@ -162,7 +148,7 @@ class TestDb:
         assert undeclared.returncode == EXIT_ERROR
         assert '[[pixeltable.database]]' in undeclared.stderr, undeclared.stderr
 
-        # own_db is declared but never created, so there is no image to build
+        # test_db_uri is declared but never created, so there is no image to build
         never_built = cli('db', 'build-image', test_db_uri, cwd=project, check=False)
         assert never_built.returncode == EXIT_ERROR
         assert 'pxt db update' in never_built.stderr, never_built.stderr


### PR DESCRIPTION
- New architecture for `pxt db` CLI tests: build a Pixeltable wheel as text fixture, include it in the archive for the test project, and refer directly to the wheel in `requirements.txt` (so that no special logic is required on the control plane)
- Reorganize `test_db.py` to avoid repeated unnecessary DB creation, reducing test running times
- Avoid overloaded use of `PXTTEST_CLOUD_DB_URI` in `test_db.py`