### PR TITLE
[PXT-1348] Fix index diff management in schema update when redefining an index

### DIFF
--- a/pixeltable/catalog/model/declaration.py
+++ b/pixeltable/catalog/model/declaration.py
@@ -156,10 +156,10 @@ class EmbeddingIndex:
             object.__setattr__(self, 'name', fold_identifier(self.name))
 
     def resolved_embeddings(self) -> dict[ts.ColumnType.Type, func.Function]:
-        """The embedding function serving each column type, resolved as the index will store them.
+        """The embedding function serving each column type.
 
-        Resolution binds a function's defaults and picks the overload matching each type, so a function declared
-        bare renders the way the stored index renders it.
+        The functions are rendered the way index renders them: the resolution binds a function's defaults and picks the
+        overload matching each type.
         """
         from pixeltable import index
 
@@ -168,7 +168,7 @@ class EmbeddingIndex:
         )
 
     def as_fn_call(self) -> exprs.FunctionCall:
-        """The embedding call for the indexed column's own type, which is the one an index materializes."""
+        """The embedding call for the indexed column's own type, which is what the index materializes."""
         assert isinstance(self.column, exprs.ColumnRefByName)
         col_type = self.column.col_type
         embeddings = self.resolved_embeddings()
@@ -179,7 +179,7 @@ class EmbeddingIndex:
         return embeddings[col_type._type](self.column)
 
     def resolved_embedding_fns(self) -> list[str]:
-        """The rendered embedding functions, as an index's metadata records them."""
+        """The rendered embedding functions, as the index's metadata records them."""
         return [str(fn) for fn in self.resolved_embeddings().values()]
 
     def __repr__(self) -> str:

--- a/pixeltable/catalog/model/declaration.py
+++ b/pixeltable/catalog/model/declaration.py
@@ -155,26 +155,32 @@ class EmbeddingIndex:
             # This is a frozen dataclass, we have to use __setattr__ to update it.
             object.__setattr__(self, 'name', fold_identifier(self.name))
 
+    def resolved_embeddings(self) -> dict[ts.ColumnType.Type, func.Function]:
+        """The embedding function serving each column type, resolved as the index will store them.
+
+        Resolution binds a function's defaults and picks the overload matching each type, so a function declared
+        bare renders the way the stored index renders it.
+        """
+        from pixeltable import index
+
+        return index.EmbeddingIndex.resolve_embeddings(
+            self.embedding, self.string_embed, self.image_embed, self.audio_embed, self.video_embed, self.document_embed
+        )
+
     def as_fn_call(self) -> exprs.FunctionCall:
-        # Static resolution of the embedding function as a FunctionCall.
+        """The embedding call for the indexed column's own type, which is the one an index materializes."""
         assert isinstance(self.column, exprs.ColumnRefByName)
         col_type = self.column.col_type
-        if col_type.is_string_type() and self.string_embed is not None:
-            return self.string_embed(self.column)
-        elif col_type.is_image_type() and self.image_embed is not None:
-            return self.image_embed(self.column)
-        elif col_type.is_audio_type() and self.audio_embed is not None:
-            return self.audio_embed(self.column)
-        elif col_type.is_video_type() and self.video_embed is not None:
-            return self.video_embed(self.column)
-        elif col_type.is_document_type() and self.document_embed is not None:
-            return self.document_embed(self.column)
-        elif self.embedding is not None:
-            return self.embedding(self.column)
-        else:
+        embeddings = self.resolved_embeddings()
+        if col_type._type not in embeddings:
             raise excs.RequestError(
                 excs.ErrorCode.INVALID_SCHEMA, f'EmbeddingIndex has no embedding function defined for type: {col_type}'
             )
+        return embeddings[col_type._type](self.column)
+
+    def resolved_embedding_fns(self) -> list[str]:
+        """The rendered embedding functions, as an index's metadata records them."""
+        return [str(fn) for fn in self.resolved_embeddings().values()]
 
     def __repr__(self) -> str:
         embeds = [

--- a/pixeltable/catalog/model/diff.py
+++ b/pixeltable/catalog/model/diff.py
@@ -10,7 +10,7 @@ from pixeltable.types import ColumnSpec
 from pixeltable_cli.types import Resolution, SchemaChangeIndexRef, SchemaChangeOp, SchemaChangeOpDetails, TableDiff
 
 from ..globals import col_type_from_spec, fold_mapping_keys
-from ..table_metadata import ColumnMetadata, TableMetadata
+from ..table_metadata import ColumnMetadata, IndexMetadata, TableMetadata
 
 if TYPE_CHECKING:
     from .declaration import IndexDeclaration, TableModelMeta
@@ -188,7 +188,7 @@ def _as_idx_ref(idx: IndexDeclaration) -> SchemaChangeIndexRef:
         return SchemaChangeIndexRef(index_type='embedding', columns=[idx.column.name], name=idx.name)
 
 
-def _add_index_change(idx: IndexDeclaration) -> SchemaChangeOp:
+def _add_index_change(idx: IndexDeclaration, action: str = 'will be added') -> SchemaChangeOp:
     idx_ref = _as_idx_ref(idx)
     idx_name = idx_ref.name
     return SchemaChangeOp(
@@ -199,9 +199,9 @@ def _add_index_change(idx: IndexDeclaration) -> SchemaChangeOp:
         model=str(idx),
         existing=None,
         description=(
-            f'{type(idx).__name__} {idx_name!r} will be added'
+            f'{type(idx).__name__} {idx_name!r} {action}'
             if idx_name is not None
-            else f'{type(idx).__name__} on column(s) {idx_ref.columns!r} will be added'
+            else f'{type(idx).__name__} on column(s) {idx_ref.columns!r} {action}'
         ),
         details=SchemaChangeOpDetails(index_ref=idx_ref),
     )
@@ -414,7 +414,7 @@ def validate_models(registered_models: dict[str, TableModelMeta], catalog_dir: s
                         for i, idx_md in enumerate(existing_idxs)
                         if idx_md['name'] == idx.name and idx_md['index_type'] == 'embedding'
                     ]
-                    assert len(existing_named_idxs) <= 1
+                    assert len(existing_named_idxs) <= 1, existing_named_idxs
                     if len(existing_named_idxs) == 0:
                         ops.append(_add_index_change(idx))
                     else:
@@ -425,19 +425,11 @@ def validate_models(registered_models: dict[str, TableModelMeta], catalog_dir: s
                             or idx_md['parameters']['precision'] != idx.precision
                             or idx_md['parameters']['embedding'] != str(idx.as_fn_call())
                         ):
-                            idx_ref = _as_idx_ref(idx)
+                            # A different index with the same name: drop the old one, and add the new one.
                             ops.append(
-                                SchemaChangeOp(
-                                    target='index',
-                                    name=idx_ref.name,
-                                    op='alter',
-                                    severity='unsupported',
-                                    model=str(idx),
-                                    existing=idx_md,
-                                    description=f'named index {idx.name!r} has altered properties',
-                                    details=SchemaChangeOpDetails(index_ref=idx_ref),
-                                )
+                                _drop_index_change(idx_md, 'will be dropped and re-created from its new definition')
                             )
+                            ops.append(_add_index_change(idx, 'will be re-created'))
                         existing_idxs.pop(i)
                 else:
                     # Unnamed embedding index: check if an index of identical structure exists in the catalog.
@@ -458,22 +450,7 @@ def validate_models(registered_models: dict[str, TableModelMeta], catalog_dir: s
 
             # Any remaining items in existing_idxs are indexes that exist in the catalog but not in the model.
             for idx_md in existing_idxs:
-                idx_name = idx_md['name']
-                idx_ref = SchemaChangeIndexRef(
-                    index_type=idx_md['index_type'], columns=idx_md['columns'], name=idx_name
-                )
-                ops.append(
-                    SchemaChangeOp(
-                        target='index',
-                        name=idx_name,
-                        op='drop',
-                        severity='destructive',
-                        model=None,
-                        existing=None,
-                        description=f'index {idx_name!r} will be dropped',
-                        details=SchemaChangeOpDetails(index_ref=idx_ref),
-                    )
-                )
+                ops.append(_drop_index_change(idx_md, 'will be dropped'))
 
             results[name] = TableDiff(
                 path=bound_path,
@@ -489,6 +466,24 @@ def validate_models(registered_models: dict[str, TableModelMeta], catalog_dir: s
         return results
 
     return op()
+
+
+def _drop_index_change(idx_md: IndexMetadata, action: str) -> SchemaChangeOp:
+    idx_ref = SchemaChangeIndexRef(index_type=idx_md['index_type'], columns=idx_md['columns'], name=idx_md['name'])
+    if len(idx_md['columns']) == 1:
+        cols = f'column {idx_md["columns"][0]!r}'
+    else:
+        cols = f'columns {", ".join(repr(col_name) for col_name in idx_md["columns"])}'
+    return SchemaChangeOp(
+        target='index',
+        name=idx_md['name'],
+        op='drop',
+        severity='destructive',
+        model=None,
+        existing=None,
+        description=f'index {idx_md["name"]!r} on {cols} {action}',
+        details=SchemaChangeOpDetails(index_ref=idx_ref),
+    )
 
 
 def format_diff(name: str, diff: TableDiff) -> list[str]:
@@ -543,22 +538,29 @@ def format_diff(name: str, diff: TableDiff) -> list[str]:
         for c in dropped_cols:
             detail.append(f'    {c.name!r}')
 
-    new_idxs = by('index', op='add')
+    # Present an index drop+add with the same name as one replacement
+    added_idxs = by('index', op='add')
+    dropped_idxs = by('index', op='drop')
+    replaced_names = {c.name for c in added_idxs if c.name is not None} & {
+        c.name for c in dropped_idxs if c.name is not None
+    }
+
+    new_idxs = [c for c in added_idxs if c.name not in replaced_names]
     if len(new_idxs) > 0:
         detail.append('  the following indexes are new to the model, and will be ADDED:')
         for c in new_idxs:
             detail.append(f'    {c.model}')
 
-    dropped_idxs = by('index', op='drop')
-    if len(dropped_idxs) > 0:
-        detail.append('  the following indexes are no longer in the model, and will be DROPPED:')
-        for c in dropped_idxs:
-            detail.append(f'    {c.name!r}')
+    replaced_idxs = [c for c in added_idxs if c.name in replaced_names]
+    if len(replaced_idxs) > 0:
+        detail.append('  the following indexes have changed, and will be REPLACED:')
+        for c in replaced_idxs:
+            detail.append(f'    {c.model}')
 
-    changed_idxs = by('index', op='alter')
-    if len(changed_idxs) > 0:
-        detail.append('  the following named indexes have altered properties (FATAL):')
-        for c in changed_idxs:
+    removed_idxs = [c for c in dropped_idxs if c.name not in replaced_names]
+    if len(removed_idxs) > 0:
+        detail.append('  the following indexes are no longer in the model, and will be DROPPED:')
+        for c in removed_idxs:
             detail.append(f'    {c.name!r}')
 
     return [f'{kind.capitalize()} {name!r} (from model `{diff.model_cls}`) has differences:', *detail]

--- a/pixeltable/catalog/model/diff.py
+++ b/pixeltable/catalog/model/diff.py
@@ -424,6 +424,7 @@ def validate_models(registered_models: dict[str, TableModelMeta], catalog_dir: s
                             or idx_md['parameters']['metric'] != idx.metric
                             or idx_md['parameters']['precision'] != idx.precision
                             or idx_md['parameters']['embedding'] != str(idx.as_fn_call())
+                            or idx_md['parameters']['embedding_functions'] != idx.resolved_embedding_fns()
                         ):
                             # A different index with the same name: drop the old one, and add the new one.
                             ops.append(
@@ -441,6 +442,7 @@ def validate_models(registered_models: dict[str, TableModelMeta], catalog_dir: s
                         and idx_md['parameters']['metric'] == idx.metric
                         and idx_md['parameters']['precision'] == idx.precision
                         and idx_md['parameters']['embedding'] == str(idx.as_fn_call())
+                        and idx_md['parameters']['embedding_functions'] == idx.resolved_embedding_fns()
                     ]
                     assert len(matching_idxs) <= 1
                     if len(matching_idxs) == 0:

--- a/pixeltable/index/embedding_index.py
+++ b/pixeltable/index/embedding_index.py
@@ -87,42 +87,9 @@ class EmbeddingIndex(IndexBase):
                 excs.ErrorCode.INVALID_ARGUMENT, f'Invalid metric {metric}, must be one of {metric_names}'
             )
 
-        self.embeddings = {}
-
-        # Resolve the specific embedding functions corresponding to the user-provided embedding functions.
-        # For string embeddings, for example, `string_embed` will be used if specified; otherwise, `embed` will
-        # be used as a fallback, if it has a matching signature.
-
-        for embed_type, embed_fn in (
-            (ts.ColumnType.Type.STRING, string_embed),
-            (ts.ColumnType.Type.IMAGE, image_embed),
-            (ts.ColumnType.Type.AUDIO, audio_embed),
-            (ts.ColumnType.Type.VIDEO, video_embed),
-            (ts.ColumnType.Type.DOCUMENT, document_embed),
-        ):
-            if embed_fn is not None:
-                # Embedding function for the requisite type is specified directly; it MUST be valid.
-                resolved_fn = self._resolve_embedding_fn(embed_fn, embed_type)
-                if resolved_fn is None:
-                    raise excs.RequestError(
-                        excs.ErrorCode.INVALID_CONFIGURATION,
-                        f'The function `{embed_fn.name}` is not a valid {embed_type.name.lower()} '
-                        f'embedding: it must take a single {embed_type.name.lower()} parameter',
-                    )
-                self.embeddings[embed_type] = resolved_fn
-            elif embed is not None:
-                # General `embed` is specified; see if it has a matching signature.
-                resolved_fn = self._resolve_embedding_fn(embed, embed_type)
-                if resolved_fn is not None:
-                    self.embeddings[embed_type] = resolved_fn
-
-        if embed is not None and len(self.embeddings) == 0:
-            # `embed` was specified and contains no matching signatures.
-            raise excs.RequestError(
-                excs.ErrorCode.INVALID_CONFIGURATION,
-                f'The function `{embed.name}` is not a valid embedding: '
-                'it must take a single string, image, audio, video, or document parameter',
-            )
+        self.embeddings = self.resolve_embeddings(
+            embed, string_embed, image_embed, audio_embed, video_embed, document_embed
+        )
 
         # an embedding index is persisted, so its function must be storable
         for embed_type, resolved_fn in self.embeddings.items():
@@ -303,6 +270,54 @@ class EmbeddingIndex(IndexBase):
     @classmethod
     def display_name(cls) -> str:
         return 'embedding'
+
+    @classmethod
+    def resolve_embeddings(
+        cls,
+        embed: func.Function | None = None,
+        string_embed: func.Function | None = None,
+        image_embed: func.Function | None = None,
+        audio_embed: func.Function | None = None,
+        video_embed: func.Function | None = None,
+        document_embed: func.Function | None = None,
+    ) -> dict[ts.ColumnType.Type, func.Function]:
+        """The embedding function serving each column type.
+
+        A per-type function is used where one is given; otherwise `embed` serves every type whose signature it
+        matches.
+        """
+        embeddings: dict[ts.ColumnType.Type, func.Function] = {}
+        for embed_type, embed_fn in (
+            (ts.ColumnType.Type.STRING, string_embed),
+            (ts.ColumnType.Type.IMAGE, image_embed),
+            (ts.ColumnType.Type.AUDIO, audio_embed),
+            (ts.ColumnType.Type.VIDEO, video_embed),
+            (ts.ColumnType.Type.DOCUMENT, document_embed),
+        ):
+            if embed_fn is not None:
+                # Embedding function for the requisite type is specified directly; it MUST be valid.
+                resolved_fn = cls._resolve_embedding_fn(embed_fn, embed_type)
+                if resolved_fn is None:
+                    raise excs.RequestError(
+                        excs.ErrorCode.INVALID_CONFIGURATION,
+                        f'The function `{embed_fn.name}` is not a valid {embed_type.name.lower()} '
+                        f'embedding: it must take a single {embed_type.name.lower()} parameter',
+                    )
+                embeddings[embed_type] = resolved_fn
+            elif embed is not None:
+                # General `embed` is specified; see if it has a matching signature.
+                resolved_fn = cls._resolve_embedding_fn(embed, embed_type)
+                if resolved_fn is not None:
+                    embeddings[embed_type] = resolved_fn
+
+        if embed is not None and len(embeddings) == 0:
+            # `embed` was specified and contains no matching signatures.
+            raise excs.RequestError(
+                excs.ErrorCode.INVALID_CONFIGURATION,
+                f'The function `{embed.name}` is not a valid embedding: '
+                'it must take a single string, image, audio, video, or document parameter',
+            )
+        return embeddings
 
     @classmethod
     def _resolve_embedding_fn(cls, embed_fn: func.Function, expected_type: ts.ColumnType.Type) -> func.Function | None:

--- a/tests/pixeltable_cli/test_schema.py
+++ b/tests/pixeltable_cli/test_schema.py
@@ -371,7 +371,7 @@ class TestSchema:
         r = cli('schema', 'update', str(schema_file), target, '--allow-destructive', '-f')
         assert r.returncode == 0
 
-        # one index of that name remains, built from the new definition, and it answers a similarity query
+        # one index of that name remains, built from the new definition
         notes = pxt.get_table(f'{target}/notes')
         indexes = notes.get_metadata()['indexes']
         assert set(indexes.keys()) == {'ix'}

--- a/tests/pixeltable_cli/test_schema.py
+++ b/tests/pixeltable_cli/test_schema.py
@@ -309,6 +309,76 @@ class TestSchema:
         assert "column 'author' will be added  safe" in r.stdout
         assert "column 'body' will be dropped  DESTRUCTIVE" in r.stdout
 
+    def test_diff_replaces_index(
+        self, cli: PxtRunner, apps: Callable[[str], str], db_root: DatabaseRoot, project_dir: pathlib.Path
+    ) -> None:
+        """A named embedding index whose definition changed is replaced."""
+        p = db_root.make_catalog_path
+        apps('udfs.py')  # the schema below imports its embedding udf
+        schema_template = dedent(
+            """
+            from __future__ import annotations
+
+            import pixeltable as pxt
+            from apps.udfs import dummy_embedding
+            from pixeltable import EmbeddingIndex
+
+            TableModel = pxt.model_base()
+
+
+            class Notes(TableModel, name='notes'):
+                note_id: pxt.Int
+                body: pxt.String
+
+                __indexes__ = [{index}]
+            """
+        )
+        schema_file = project_dir / 'app_schema.py'
+        schema_file.write_text(
+            schema_template.format(index="EmbeddingIndex(body, embedding=dummy_embedding, name='ix')")
+        )
+        target = p('index_replace')
+        cli('schema', 'update', str(schema_file), target)
+        notes = pxt.get_table(f'{target}/notes')
+        indexes = notes.get_metadata()['indexes']
+        assert set(indexes.keys()) == {'ix'}
+        assert indexes['ix']['parameters']['precision'] == 'fp16'
+
+        # the same index name, with different properties
+        schema_file.write_text(
+            schema_template.format(index="EmbeddingIndex(body, embedding=dummy_embedding, precision='fp32', name='ix')")
+        )
+
+        r = cli('schema', 'diff', str(schema_file), target, '--json', check=False)
+        assert r.returncode == 2
+        tbl = r.json['tables'][0]
+        assert tbl['resolution'] == 'update_destructive'
+        assert [(op['op'], op['target'], op['name']) for op in tbl['ops']] == [
+            ('drop', 'index', 'ix'),
+            ('add', 'index', 'ix'),
+        ]
+
+        r = cli('schema', 'diff', str(schema_file), target, check=False)
+        assert (
+            re.search(
+                r"index 'ix' on column 'body' will be dropped and re-created from its new definition\s+DESTRUCTIVE",
+                r.stdout,
+            )
+            is not None
+        ), r.stdout
+        assert re.search(r"EmbeddingIndex 'ix' will be re-created\s+safe", r.stdout) is not None, r.stdout
+
+        r = cli('schema', 'update', str(schema_file), target, '--allow-destructive', '-f')
+        assert r.returncode == 0
+
+        # one index of that name remains, built from the new definition, and it answers a similarity query
+        notes = pxt.get_table(f'{target}/notes')
+        indexes = notes.get_metadata()['indexes']
+        assert set(indexes.keys()) == {'ix'}
+        assert indexes['ix']['parameters']['precision'] == 'fp32'
+
+        assert_in_agreement(cli, str(schema_file), target)
+
     def test_iterator_view_indexes(self, cli: PxtRunner, apps: Callable[[str], str], db_root: DatabaseRoot) -> None:
         """A schema that declares an iterator view and indexes over what the iterator produces."""
         skip_test_if_not_installed('spacy')  # the view's iterator splits on sentences

--- a/tests/test_table_model.py
+++ b/tests/test_table_model.py
@@ -1847,7 +1847,11 @@ class TestTableModel:
             __indexes__ = [EmbeddingIndex(text, embedding=dummy_embedding.using(n=32), name='ix')]
 
         TableModel.create_all(p(''))
-        ExampleTable.insert([{'id': 1, 'text': 'one sentence'}, {'id': 2, 'text': 'zero sentence'}])
+
+        idx_md = ExampleTable.get_metadata()['indexes']
+        assert set(idx_md.keys()) == {'ix'}
+        assert idx_md['ix']['parameters']['embedding'] == 'dummy_embedding(text, n=32)'
+        assert idx_md['ix']['parameters']['precision'] == 'fp16'
 
         TableModelV2 = pxt.model_base()
 
@@ -1874,7 +1878,7 @@ class TestTableModel:
 
     def test_diff_resolves_bare_embedding_fn(self, db_root: DatabaseRoot) -> None:
         """An index stores its embedding function resolved, with defaults bound. A model that declares the same
-        function bare has to resolve to that same call, or an unchanged model reads as a changed one forever."""
+        function bare has to resolve to that same call."""
         p = db_root.make_catalog_path
         TableModel = pxt.model_base()
 
@@ -1886,7 +1890,6 @@ class TestTableModel:
             __indexes__ = [EmbeddingIndex(img, image_embed=local_embedding, name='ix')]
 
         TableModel.create_all(p(''))
-        ExampleTable.insert([{'id': 1, 'img': get_image_files()[0]}])
         assert ExampleTable.get_metadata()['indexes']['ix']['parameters']['embedding'] == (
             f'local_embedding(img, dim={LOCAL_EMBED_DIM})'
         )

--- a/tests/test_table_model.py
+++ b/tests/test_table_model.py
@@ -18,6 +18,7 @@ from pixeltable.config import Config
 from pixeltable_cli.types import TableDiff
 
 from .utils import (
+    LOCAL_EMBED_DIM,
     DatabaseRoot,
     assert_resultset_eq,
     assert_table_metadata_eq,
@@ -25,6 +26,7 @@ from .utils import (
     capture_console_output,
     dummy_embedding,
     get_image_files,
+    local_embedding,
     pxt_raises,
     reload_catalog,
     reload_env,
@@ -1871,6 +1873,83 @@ class TestTableModel:
         assert idx_md['ix']['parameters']['embedding'] == 'dummy_embedding(text, n=64)'
         assert idx_md['ix']['parameters']['precision'] == 'fp32'
 
+        assert TableModelV2.get_model_diff(p(''))['test_table'].resolution == 'up_to_date'
+
+    def test_diff_resolves_bare_embedding_fn(self, db_root: DatabaseRoot) -> None:
+        """An index stores its embedding function resolved, with defaults bound. A model that declares the same
+        function bare has to resolve to that same call, or an unchanged model reads as a changed one forever."""
+        p = db_root.make_catalog_path
+        TableModel = pxt.model_base()
+
+        # local_embedding carries a default `dim`, which resolution binds; the declaration leaves it implicit
+        class ExampleTable(TableModel, name='test_table'):
+            id: pxt.Int
+            img: pxt.Image | None
+
+            __indexes__ = [EmbeddingIndex(img, image_embed=local_embedding, name='ix')]
+
+        TableModel.create_all(p(''))
+        ExampleTable.insert([{'id': 1, 'img': get_image_files()[0]}])
+        assert ExampleTable.get_metadata()['indexes']['ix']['parameters']['embedding'] == (
+            f'local_embedding(img, dim={LOCAL_EMBED_DIM})'
+        )
+
+        TableModelV2 = pxt.model_base()
+
+        class ExampleTableV2(TableModelV2, name='test_table'):
+            id: pxt.Int
+            img: pxt.Image | None
+
+            __indexes__ = [EmbeddingIndex(img, image_embed=local_embedding, name='ix')]
+
+        assert TableModelV2.get_model_diff(p(''))['test_table'].resolution == 'up_to_date'
+
+    def test_update_all_replaces_index_on_query_side_embedding(self, db_root: DatabaseRoot) -> None:
+        """An image index's string_embed serves only similarity queries, so a change to it alters nothing the
+        indexed column's own embedding records, however the diff has to catch it anyway."""
+        p = db_root.make_catalog_path
+        TableModel = pxt.model_base()
+
+        class ExampleTable(TableModel, name='test_table'):
+            id: pxt.Int
+            img: pxt.Image | None
+
+            __indexes__ = [
+                EmbeddingIndex(
+                    img,
+                    image_embed=dummy_embedding.using(n=512),
+                    string_embed=local_embedding.using(dim=512),
+                    name='ix',
+                )
+            ]
+
+        TableModel.create_all(p(''))
+        ExampleTable.insert([{'id': 1, 'img': get_image_files()[0]}])
+
+        TableModelV2 = pxt.model_base()
+
+        class ExampleTableV2(TableModelV2, name='test_table'):
+            id: pxt.Int
+            img: pxt.Image | None
+
+            # only string_embed changes
+            __indexes__ = [
+                EmbeddingIndex(
+                    img, image_embed=dummy_embedding.using(n=512), string_embed=dummy_embedding.using(n=512), name='ix'
+                )
+            ]
+
+        diff = TableModelV2.get_model_diff(p(''))['test_table']
+        assert diff.resolution == 'update_destructive'
+        assert len(diff.ops) == 2, diff.ops
+        assert (diff.ops[0].target, diff.ops[0].name, diff.ops[0].op) == ('index', 'ix', 'drop')
+        assert (diff.ops[1].target, diff.ops[1].name, diff.ops[1].op) == ('index', 'ix', 'add')
+
+        TableModelV2.update_all(p(''), allow_destructive=True)
+
+        params = ExampleTableV2.get_metadata()['indexes']['ix']['parameters']
+        assert params['embedding'] == 'dummy_embedding(img, n=512)'
+        assert params['embedding_functions'] == ['dummy_embedding(text, n=512)', 'dummy_embedding(img, n=512)']
         assert TableModelV2.get_model_diff(p(''))['test_table'].resolution == 'up_to_date'
 
     def test_update_all_errors(self, db_root: DatabaseRoot) -> None:

--- a/tests/test_table_model.py
+++ b/tests/test_table_model.py
@@ -1905,8 +1905,8 @@ class TestTableModel:
         assert TableModelV2.get_model_diff(p(''))['test_table'].resolution == 'up_to_date'
 
     def test_update_all_replaces_index_on_query_side_embedding(self, db_root: DatabaseRoot) -> None:
-        """An image index's string_embed serves only similarity queries, so a change to it alters nothing the
-        indexed column's own embedding records, however the diff has to catch it anyway."""
+        """An image index's `string_embed` serves only similarity queries, so changing it does not alter the indexed
+        column's own embedding records; however, the diff must catch it."""
         p = db_root.make_catalog_path
         TableModel = pxt.model_base()
 

--- a/tests/test_table_model.py
+++ b/tests/test_table_model.py
@@ -1258,10 +1258,10 @@ class TestTableModel:
                 'value'
               the following indexes are new to the model, and will be ADDED:
                 EmbeddingIndex(column=image, embedding=dummy_embedding(text, n=256), name='idx4')
+              the following indexes have changed, and will be REPLACED:
+                EmbeddingIndex(column=image, embedding=dummy_embedding(text, n=1024), precision='fp32', name='idx3')
               the following indexes are no longer in the model, and will be DROPPED:
                 'idx2'
-              the following named indexes have altered properties (FATAL):
-                'idx3'
             View 'test_view' (from model `ExampleViewV2`) has differences:
               iterator mismatch (FATAL):
                 model iterator   : tile_iterator(image, [128, 128])
@@ -1418,28 +1418,26 @@ class TestTableModel:
                         'details': {},
                     },
                     {
-                        'description': "named index 'idx3' has altered properties",
+                        'target': 'index',
+                        'name': 'idx3',
+                        'op': 'drop',
+                        'severity': 'destructive',
+                        'model': None,
+                        'existing': None,
+                        'description': "index 'idx3' on column 'image' will be dropped and re-created "
+                        'from its new definition',
                         'details': {'index_ref': {'index_type': 'embedding', 'columns': ['image'], 'name': 'idx3'}},
-                        'existing': {
-                            'columns': ['image'],
-                            'index_type': 'embedding',
-                            'name': 'idx3',
-                            'parameters': {
-                                'embedding': 'dummy_embedding(image, n=1024)',
-                                'embedding_functions': [
-                                    'dummy_embedding(text, n=1024)',
-                                    'dummy_embedding(img, n=1024)',
-                                ],
-                                'metric': 'cosine',
-                                'precision': 'fp16',
-                            },
-                        },
+                    },
+                    {
+                        'target': 'index',
+                        'name': 'idx3',
+                        'op': 'add',
+                        'severity': 'additive',
                         'model': 'EmbeddingIndex(column=image, embedding=dummy_embedding(text, '
                         "n=1024), precision='fp32', name='idx3')",
-                        'name': 'idx3',
-                        'op': 'alter',
-                        'severity': 'unsupported',
-                        'target': 'index',
+                        'existing': None,
+                        'description': "EmbeddingIndex 'idx3' will be re-created",
+                        'details': {'index_ref': {'index_type': 'embedding', 'columns': ['image'], 'name': 'idx3'}},
                     },
                     {
                         'target': 'index',
@@ -1458,7 +1456,7 @@ class TestTableModel:
                         'severity': 'destructive',
                         'model': None,
                         'existing': None,
-                        'description': "index 'idx2' will be dropped",
+                        'description': "index 'idx2' on column 'image' will be dropped",
                         'details': {'index_ref': {'index_type': 'embedding', 'columns': ['image'], 'name': 'idx2'}},
                     },
                 ],
@@ -1834,6 +1832,46 @@ class TestTableModel:
             tbl.insert([{'id': 5, 'value': 5.0, 'image': images[0], 'label': 'five'}]), expected_rows
         )
         assert tbl.where(tbl.id == 5).collect()['doubled'] == [10.0]
+
+    def test_update_all_replaces_index(self, db_root: DatabaseRoot) -> None:
+        """A named embedding index whose definition changed is replaced."""
+        p = db_root.make_catalog_path
+        TableModel = pxt.model_base()
+
+        class ExampleTable(TableModel, name='test_table'):
+            id: pxt.Int
+            text: pxt.String | None
+
+            __indexes__ = [EmbeddingIndex(text, embedding=dummy_embedding.using(n=32), name='ix')]
+
+        TableModel.create_all(p(''))
+        ExampleTable.insert([{'id': 1, 'text': 'one sentence'}, {'id': 2, 'text': 'zero sentence'}])
+
+        TableModelV2 = pxt.model_base()
+
+        class ExampleTableV2(TableModelV2, name='test_table'):
+            id: pxt.Int
+            text: pxt.String | None
+
+            __indexes__ = [EmbeddingIndex(text, embedding=dummy_embedding.using(n=64), precision='fp32', name='ix')]
+
+        diff = TableModelV2.get_model_diff(p(''))['test_table']
+        assert diff.resolution == 'update_destructive'
+        assert len(diff.ops) == 2, diff.ops
+        assert (diff.ops[0].target, diff.ops[0].name, diff.ops[0].op) == ('index', 'ix', 'drop')
+        assert (diff.ops[1].target, diff.ops[1].name, diff.ops[1].op) == ('index', 'ix', 'add')
+
+        with pxt_raises(excs.ErrorCode.DESTRUCTIVE_SCHEMA_CHANGE, match='destructive'):
+            TableModelV2.update_all(p(''))
+
+        TableModelV2.update_all(p(''), allow_destructive=True)
+
+        idx_md = ExampleTableV2.get_metadata()['indexes']
+        assert set(idx_md.keys()) == {'ix'}
+        assert idx_md['ix']['parameters']['embedding'] == 'dummy_embedding(text, n=64)'
+        assert idx_md['ix']['parameters']['precision'] == 'fp32'
+
+        assert TableModelV2.get_model_diff(p(''))['test_table'].resolution == 'up_to_date'
 
     def test_update_all_errors(self, db_root: DatabaseRoot) -> None:
         """`update_all()` raises an error if a model's schema is inconsistent with the existing table."""

--- a/tests/test_table_model.py
+++ b/tests/test_table_model.py
@@ -1861,9 +1861,6 @@ class TestTableModel:
         assert (diff.ops[0].target, diff.ops[0].name, diff.ops[0].op) == ('index', 'ix', 'drop')
         assert (diff.ops[1].target, diff.ops[1].name, diff.ops[1].op) == ('index', 'ix', 'add')
 
-        with pxt_raises(excs.ErrorCode.DESTRUCTIVE_SCHEMA_CHANGE, match='destructive'):
-            TableModelV2.update_all(p(''))
-
         TableModelV2.update_all(p(''), allow_destructive=True)
 
         idx_md = ExampleTableV2.get_metadata()['indexes']


### PR DESCRIPTION
Also in this pr: detect query-side embedding changes in the schema diff (diff should catch a `string_embed`-only update on an embedding index on an `image` column).