### PR TITLE
[PXT-1355] Flatten included FastAPI routers

### DIFF
--- a/pixeltable/utils/app_module.py
+++ b/pixeltable/utils/app_module.py
@@ -9,9 +9,10 @@ import re
 import sys
 import threading
 import traceback
+from collections.abc import Iterable
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pixeltable import exceptions as excs
 from pixeltable.catalog import ProhibitedWriteError, is_valid_identifier, model
@@ -334,7 +335,7 @@ def get_module_services(module: ModuleType, file: str) -> tuple[fastapi.FastAPI 
 
     if app is not None:
         # make sure every router is included in the application
-        app_endpoints = {id(route.endpoint) for route in app.routes if hasattr(route, 'endpoint')}
+        app_endpoints = {id(route.endpoint) for route in _app_routes(app) if hasattr(route, 'endpoint')}
         for name, router in routers.items():
             router_endpoints = {id(route.endpoint) for route in router.routes if hasattr(route, 'endpoint')}
             if not router_endpoints.issubset(app_endpoints):
@@ -370,9 +371,21 @@ def service_spec(name: str, service: FastAPIRouter | fastapi.FastAPI, routers: l
     return ServiceSpec(name=name, routes=routes, app_paths=_app_paths(service, routers))
 
 
+def _app_routes(app: fastapi.FastAPI) -> Iterable[Any]:
+    """app.routes, with every router that include_router() added expanded into its routes.
+
+    FastAPI 0.137 stores an included router as one tree node in app.routes instead of copying its routes in;
+    iter_route_contexts() (0.137.2+) flattens that tree, and earlier versions have nothing to flatten.
+    """
+    import fastapi.routing
+
+    flatten = getattr(fastapi.routing, 'iter_route_contexts', None)
+    return app.routes if flatten is None else flatten(app.routes)
+
+
 def _include_prefix(app: fastapi.FastAPI, router: FastAPIRouter) -> str:
     """The prefix that app adds to router's paths, empty when absent."""
-    app_paths = {id(getattr(route, 'endpoint', None)): getattr(route, 'path', '') for route in app.routes}
+    app_paths = {id(getattr(route, 'endpoint', None)): getattr(route, 'path', '') for route in _app_routes(app)}
     for route in router.routes:
         path = getattr(route, 'path', None)
         app_path = app_paths.get(id(getattr(route, 'endpoint', None)))
@@ -387,7 +400,7 @@ def _app_paths(app: fastapi.FastAPI, routers: list[FastAPIRouter]) -> list[str]:
         id(endpoint) for router in routers for endpoint in (getattr(r, 'endpoint', None) for r in router.routes)
     }
     included: set[str] = set()
-    for route in app.routes:
+    for route in _app_routes(app):
         path = getattr(route, 'path', None)
         if path is not None and id(getattr(route, 'endpoint', None)) in from_routers:
             # a route spells a path parameter with its converter, '/media/{path:path}', where the document

--- a/pixeltable/utils/app_module.py
+++ b/pixeltable/utils/app_module.py
@@ -372,11 +372,6 @@ def service_spec(name: str, service: FastAPIRouter | fastapi.FastAPI, routers: l
 
 
 def _app_routes(app: fastapi.FastAPI) -> Iterable[Any]:
-    """app.routes, with every router that include_router() added expanded into its routes.
-
-    FastAPI 0.137 stores an included router as one tree node in app.routes instead of copying its routes in;
-    iter_route_contexts() (0.137.2+) flattens that tree, and earlier versions have nothing to flatten.
-    """
     import fastapi.routing
 
     flatten = getattr(fastapi.routing, 'iter_route_contexts', None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
 [project.optional-dependencies]
 # `pxt service` hosts a user-defined FastAPI app and shells out to uvicorn; the daemon
 # behind `pxt ls`/`pxt describe`/etc. is stdlib-only and does not need this extra.
-serve = ["fastapi[standard]>=0.120.0"]
+serve = ["fastapi[standard]>=0.120.0,!=0.137.0,!=0.137.1"]
 # OpenTelemetry instrumentation. Core pixeltable carries no OTEL dependency; the instrumentation is a
 # separate distribution, opt-in via opentelemetry.instrumentation.pixeltable. The SDK and exporters live
 # here rather than in that package so it stays api-only, per contrib convention.
@@ -212,7 +212,7 @@ dev = [
     "nbqa>=1.9.1",
     "snowflake-sqlalchemy>=1.7.0",
     # fastapi powers `pxt service` (user-defined services); the pxt daemon itself is stdlib-only
-    "fastapi[standard]>=0.120.0",
+    "fastapi[standard]>=0.120.0,!=0.137.0,!=0.137.1",
     "imagehash>=4.3",
     "scipy>=1 ; python_version < '3.14'",
     "scipy>=1.17 ; python_version >= '3.14'",

--- a/uv.lock
+++ b/uv.lock
@@ -1787,7 +1787,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.135.3"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1796,15 +1796,16 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [package.optional-dependencies]
 standard = [
     { name = "email-validator" },
     { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastar" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic-extra-types" },
@@ -6086,7 +6087,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.10" },
     { name = "cloudpickle", specifier = ">=2.2.1" },
     { name = "deprecated", specifier = ">=1.2.15" },
-    { name = "fastapi", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.120.0" },
+    { name = "fastapi", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.120.0,!=0.137.0,!=0.137.1" },
     { name = "fasteners", specifier = ">=0.19" },
     { name = "ftfy", specifier = ">=6.2.0" },
     { name = "httpcore", specifier = ">=1.0.3" },
@@ -6140,7 +6141,7 @@ dev = [
     { name = "diffusers", specifier = ">=0.38" },
     { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "fal-client", specifier = ">=0.5.6" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.120.0" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.120.0,!=0.137.0,!=0.137.1" },
     { name = "fireworks-ai", specifier = ">=0.17.6" },
     { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "google-genai", specifier = ">=1.67.0" },


### PR DESCRIPTION
FastAPI 0.137 changed include_router() to store the included router as a single node in app.routes instead of copying its routes in. Pixeltable matches an application's routes against its FastAPIRouter by endpoint to confirm the router is included, to recover the include prefix, and to separate hand-written paths from router paths. On FastAPI 0.137 or newer that matching saw none of the router's routes, so pxt service check and pxt service update rejected any file using app.include_router(...) with "the FastAPI application does not include the router".

The three walks over app.routes now go through one helper that expands included routers with fastapi.routing.iter_route_contexts() when the installed FastAPI provides it (0.137.2 and later) and reads app.routes as before otherwise. FastAPI 0.137.0 and 0.137.1, which have the new structure but not the public expansion function, are excluded from the fastapi requirement.

Verified locally on FastAPI 0.120.4, 0.138.2 and 0.141.1 (the serving tests and the custom-app CLI tests pass on 0.141.1), and end to end on a hosted database with runtime images built on 0.136.3 and 0.141.1: service check, service update, requests to the prefixed router route and to a hand-written route, and service diff all succeed on both. uv.lock stays on 0.135.3 because vllm pins fastapi below 0.137, so CI exercises only the pre-0.137 path.

Also FYI the type hint can't be narrowed since we can't import the class RouteContext that newer versions of FastAPI return.
