### PR TITLE
Document Pydantic AI Harness Memory and Pixeltable catalog tools

### DIFF
--- a/docs/release/docs.json
+++ b/docs/release/docs.json
@@ -355,6 +355,12 @@
               "howto/providers/working-with-voyageai",
               "howto/working-with-fiftyone"
             ]
+          },
+          {
+            "group": "Libraries",
+            "pages": [
+              "libraries/pydantic-ai"
+            ]
           }
         ]
       },

--- a/docs/release/howto/coming-from.mdx
+++ b/docs/release/howto/coming-from.mdx
@@ -99,6 +99,28 @@ Defining the class does not create the table. Run `pxt schema update app.py my_a
 
     [Tool calling cookbook](/howto/cookbooks/agents/llm-tool-calling)
   </Tab>
+  <Tab title="Pydantic AI" icon="brain">
+    <div id="pydantic-ai" />
+
+    If you already run [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness), keep the agent and persist `Memory` in Pixeltable. The store creates the table on first use.
+
+    ```python
+    from pydantic_ai import Agent
+    from pydantic_ai_harness import Memory
+    from pydantic_ai_pixeltable import PixeltableMemoryStore
+
+    agent = Agent(
+        'openai:gpt-4o',
+        capabilities=[Memory(PixeltableMemoryStore(table_name='my_app.memory'))],
+    )
+    ```
+
+    `pip install pydantic-ai-pixeltable`. Use `.table` for Pixeltable queries and computed columns. This is a bridge, not the default Pixeltable agent.
+
+    A native agent stays on a `TableModel`. After `pxt schema update`, insert `{'message': '...'}` and read `response` and `tool_output`.
+
+    [Pydantic AI Harness library](/libraries/pydantic-ai) · [Tool calling cookbook](/howto/cookbooks/agents/llm-tool-calling)
+  </Tab>
   <Tab title="Scripts and Airflow" icon="gears">
     <div id="scripts-and-airflow" />
 

--- a/docs/release/howto/coming-from.mdx
+++ b/docs/release/howto/coming-from.mdx
@@ -112,14 +112,14 @@ Defining the class does not create the table. Run `pxt schema update app.py my_a
     agent = Agent(
         'openai:gpt-4o-mini',
         capabilities=[
-            Memory(PixeltableMemoryStore(table_name='my_app.memory')),
+            Memory(PixeltableMemoryStore(table_name='harness.memory')),
             Pixeltable(tables=['my_app.doc_chunks'], read_only=True),
             ToolOutputLimits(),
         ],
     )
     ```
 
-    `pip install pydantic-ai-pixeltable`. `Memory` is the notebook. `Pixeltable` searches a chunk view or other catalog table. Use `.table` for Pixeltable queries and computed columns. This is a bridge, not the default Pixeltable agent.
+    `pip install pydantic-ai-pixeltable`. `Memory` is the notebook; keep it at `harness.memory` so `pxt schema prune app.py my_app` does not drop it. `Pixeltable` searches a chunk view or other catalog table. Use `.table` for Pixeltable queries and computed columns. This is a bridge, not the default Pixeltable agent.
 
     A native agent stays on a `TableModel`. After `pxt schema update`, insert `{'message': '...'}` and read `response` and `tool_output`.
 

--- a/docs/release/howto/coming-from.mdx
+++ b/docs/release/howto/coming-from.mdx
@@ -102,20 +102,24 @@ Defining the class does not create the table. Run `pxt schema update app.py my_a
   <Tab title="Pydantic AI" icon="brain">
     <div id="pydantic-ai" />
 
-    If you already run [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness), keep the agent and persist `Memory` in Pixeltable. The store creates the table on first use.
+    If you already run [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness), keep the agent. Persist `Memory` in Pixeltable. Add `Pixeltable` when the agent must search tables you already have.
 
     ```python
     from pydantic_ai import Agent
-    from pydantic_ai_harness import Memory
-    from pydantic_ai_pixeltable import PixeltableMemoryStore
+    from pydantic_ai_harness import Memory, ToolOutputLimits
+    from pydantic_ai_pixeltable import Pixeltable, PixeltableMemoryStore
 
     agent = Agent(
-        'openai:gpt-4o',
-        capabilities=[Memory(PixeltableMemoryStore(table_name='my_app.memory'))],
+        'openai:gpt-4o-mini',
+        capabilities=[
+            Memory(PixeltableMemoryStore(table_name='my_app.memory')),
+            Pixeltable(tables=['my_app.doc_chunks'], read_only=True),
+            ToolOutputLimits(),
+        ],
     )
     ```
 
-    `pip install pydantic-ai-pixeltable`. Use `.table` for Pixeltable queries and computed columns. This is a bridge, not the default Pixeltable agent.
+    `pip install pydantic-ai-pixeltable`. `Memory` is the notebook. `Pixeltable` searches a chunk view or other catalog table. Use `.table` for Pixeltable queries and computed columns. This is a bridge, not the default Pixeltable agent.
 
     A native agent stays on a `TableModel`. After `pxt schema update`, insert `{'message': '...'}` and read `response` and `tool_output`.
 

--- a/docs/release/libraries/pydantic-ai.mdx
+++ b/docs/release/libraries/pydantic-ai.mdx
@@ -1,19 +1,21 @@
 ---
 title: 'Pydantic AI Harness'
-description: 'Persist Pydantic AI Harness memory in a Pixeltable table'
+description: 'Persist Pydantic AI Harness memory in Pixeltable and search your tables'
 ---
 
 <Card title="pydantic-ai-pixeltable" icon="github" href="https://github.com/pixeltable/pydantic-ai-pixeltable">
   Source, tests, and release history
 </Card>
 
-`pydantic-ai-pixeltable` is a [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness) `MemoryStore`. Keep the `Memory` capability. Swap `FileStore` or `PostgresMemoryStore` for a Pixeltable table.
+`pydantic-ai-pixeltable` is a [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness) bridge. Keep the `Memory` capability and persist the notebook in a Pixeltable table. Add a separate `Pixeltable` capability when the agent must search tables you already have.
 
 This is an interoperability bridge. Native Pixeltable agents still use a `TableModel` and computed columns. Typed insert/`to_pydantic()` is a different page: [Working with Pydantic](/howto/providers/working-with-pydantic).
 
 ## When to use
 
 Use this package when a Pydantic AI agent already runs on Harness `Memory` and you want that notebook in Pixeltable: versions, queries, and computed columns on `.table`.
+
+Use `Pixeltable(tables=[...])` when the same agent must retrieve from a handbook, chunk view, or other catalog table. Do not put that corpus in Memory files.
 
 Do not add this package to start a new Pixeltable agent. Insert a row and let computed columns run the turn. See [Migrate](/howto/coming-from#pydantic-ai).
 
@@ -24,6 +26,27 @@ pip install pydantic-ai-pixeltable
 ```
 
 Requires Pixeltable >= 0.6.8 and pydantic-ai-harness >= 0.29.0.
+
+## Two layers
+
+`Memory` is the short notebook (`MEMORY.md` and other path-addressed files). `Pixeltable` searches application tables. Pair them. `ToolOutputLimits` bounds oversized tool returns.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import Memory, ToolOutputLimits
+from pydantic_ai_pixeltable import Pixeltable, PixeltableMemoryStore
+
+agent = Agent(
+    'openai:gpt-4o-mini',
+    capabilities=[
+        Memory(PixeltableMemoryStore(table_name='harness.memory')),
+        Pixeltable(tables=['my_app.doc_chunks'], read_only=True),
+        ToolOutputLimits(),
+    ],
+)
+```
+
+`tables` is an allowlist of table paths or directory prefixes. Omit it only for local use against the whole catalog.
 
 ## Persist Harness memory
 
@@ -53,6 +76,26 @@ t.where(t.kind == 'file').select(t.path, t.content, t.version).collect()
 ```
 
 File rows have `kind == 'file'`. Do not write paths whose first segment is `__meta__` or `__op__`; those rows hold the generation counter and operation receipts.
+
+## Search your Pixeltable tables
+
+`Pixeltable` does not create tables. Point it at a chunk view (or any table) that already has an embedding index. A handbook stays `pxt.Document` rows; the agent searches the splitter view.
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.document import document_splitter
+
+docs = pxt.create_table('my_app.docs', {'doc': pxt.Document}, if_exists='ignore')
+chunks = pxt.create_view(
+    'my_app.doc_chunks',
+    docs,
+    iterator=document_splitter(docs.doc, separators='paragraph'),
+    if_exists='ignore',
+)
+chunks.add_embedding_index('text', embedding=your_embed_fn, if_exists='ignore')
+```
+
+The capability tools are `list_tables`, `describe_table`, `query_table`, and `similarity_search`. `query_table` filters with equality only (`{'status': 'open'}`). `similarity_search` calls `column.similarity(string=query)`. Both cap rows and serialized characters. Media columns are returned as file URLs, not blobs. `read_only=False` is not implemented.
 
 ## See also
 

--- a/docs/release/libraries/pydantic-ai.mdx
+++ b/docs/release/libraries/pydantic-ai.mdx
@@ -1,0 +1,62 @@
+---
+title: 'Pydantic AI Harness'
+description: 'Persist Pydantic AI Harness memory in a Pixeltable table'
+---
+
+<Card title="pydantic-ai-pixeltable" icon="github" href="https://github.com/pixeltable/pydantic-ai-pixeltable">
+  Source, tests, and release history
+</Card>
+
+`pydantic-ai-pixeltable` is a [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness) `MemoryStore`. Keep the `Memory` capability. Swap `FileStore` or `PostgresMemoryStore` for a Pixeltable table.
+
+This is an interoperability bridge. Native Pixeltable agents still use a `TableModel` and computed columns. Typed insert/`to_pydantic()` is a different page: [Working with Pydantic](/howto/providers/working-with-pydantic).
+
+## When to use
+
+Use this package when a Pydantic AI agent already runs on Harness `Memory` and you want that notebook in Pixeltable: versions, queries, and computed columns on `.table`.
+
+Do not add this package to start a new Pixeltable agent. Insert a row and let computed columns run the turn. See [Migrate](/howto/coming-from#pydantic-ai).
+
+## Installation
+
+```bash
+pip install pydantic-ai-pixeltable
+```
+
+Requires Pixeltable >= 0.6.8 and pydantic-ai-harness >= 0.29.0.
+
+## Persist Harness memory
+
+The store creates the table on first use. You do not run `pxt schema update` for this table.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import Memory
+from pydantic_ai_pixeltable import PixeltableMemoryStore
+
+agent = Agent(
+    'openai:gpt-4o',
+    capabilities=[Memory(PixeltableMemoryStore(table_name='harness.memory'))],
+)
+```
+
+`Memory` keeps the notebook tools, injection, and compare-and-set retries. This package stores paths, versions, and operation receipts.
+
+## Escape hatch: `.table`
+
+```python
+from pydantic_ai_pixeltable import PixeltableMemoryStore
+
+store = PixeltableMemoryStore(table_name='harness.memory')
+t = store.table
+t.where(t.kind == 'file').select(t.path, t.content, t.version).collect()
+```
+
+File rows have `kind == 'file'`. Do not write paths whose first segment is `__meta__` or `__op__`; those rows hold the generation counter and operation receipts.
+
+## See also
+
+- [pydantic-ai-pixeltable on GitHub](https://github.com/pixeltable/pydantic-ai-pixeltable)
+- [Pydantic AI Harness](https://github.com/pydantic/pydantic-ai-harness)
+- [Migrate from your stack](/howto/coming-from#pydantic-ai)
+- [Tool calling cookbook](/howto/cookbooks/agents/llm-tool-calling)

--- a/docs/release/libraries/pydantic-ai.mdx
+++ b/docs/release/libraries/pydantic-ai.mdx
@@ -46,7 +46,11 @@ agent = Agent(
 )
 ```
 
-`tables` is an allowlist of table paths or directory prefixes. Omit it only for local use against the whole catalog.
+`tables` is a required allowlist of table paths or directory prefixes. Pass `tables=['*']` to allow the whole catalog.
+
+Two `Pixeltable(...)` instances share `id='pixeltable'` and merge. Give one a different `id` if you need both. Tool names match [pydantic-ai-chdb](https://ai.pydantic.dev/capabilities/third-party/). Wrap one side in [`PrefixTools`](https://ai.pydantic.dev/capabilities/prefix-tools/) when you pair them.
+
+A YAML spec can construct `Pixeltable` (`from_spec`, with `custom_capability_types=[Pixeltable]`). `Memory(PixeltableMemoryStore)` is Python-only. The package talks to the local catalog.
 
 ## Persist Harness memory
 
@@ -63,7 +67,7 @@ agent = Agent(
 )
 ```
 
-`Memory` keeps the notebook tools, injection, and compare-and-set retries. This package stores paths, versions, and operation receipts.
+`Memory` keeps the notebook tools, injection, and compare-and-set retries. This package stores paths, versions, and operation receipts. Receipts are a second write after the file mutation, not one SQL transaction and not a FileStore crash journal. A crash between those steps can raise `MemoryConflictError` on replay.
 
 ## Escape hatch: `.table`
 
@@ -79,23 +83,39 @@ File rows have `kind == 'file'`. Do not write paths whose first segment is `__me
 
 ## Search your Pixeltable tables
 
-`Pixeltable` does not create tables. Point it at a chunk view (or any table) that already has an embedding index. A handbook stays `pxt.Document` rows; the agent searches the splitter view.
+`Pixeltable` does not create tables. Point it at a chunk view that already has an embedding index. A handbook stays `pxt.Document` rows; the agent searches the splitter view.
+
+In `app.py`, declare the handbook and index on a `TableModel`. Create them with `pxt schema update`:
 
 ```python
 import pixeltable as pxt
-from pixeltable.functions.document import document_splitter
+import pixeltable.functions as pxtf
+from pixeltable.functions.huggingface import sentence_transformer
 
-docs = pxt.create_table('my_app.docs', {'doc': pxt.Document}, if_exists='ignore')
-chunks = pxt.create_view(
-    'my_app.doc_chunks',
-    docs,
-    iterator=document_splitter(docs.doc, separators='paragraph'),
-    if_exists='ignore',
-)
-chunks.add_embedding_index('text', embedding=your_embed_fn, if_exists='ignore')
+TableModel = pxt.model_base()
+embed_fn = sentence_transformer.using(model_id='intfloat/multilingual-e5-large-instruct')
+
+
+class Docs(TableModel, name='docs'):
+    document: pxt.Document
+
+
+class Chunks(
+    TableModel,
+    name='doc_chunks',
+    base=Docs,
+    iterator=pxtf.document.document_splitter(Docs.document, separators='paragraph'),
+):
+    __indexes__ = [pxt.EmbeddingIndex(text, embedding=embed_fn, name='chunks_embed')]  # type: ignore[name-defined]
 ```
 
-The capability tools are `list_tables`, `describe_table`, `query_table`, and `similarity_search`. `query_table` filters with equality only (`{'status': 'open'}`). `similarity_search` calls `column.similarity(string=query)`. Both cap rows and serialized characters. Media columns are returned as file URLs, not blobs. `read_only=False` is not implemented.
+```bash
+pxt schema update app.py my_app
+```
+
+A notebook or REPL can still call `create_table`, `create_view`, and `add_embedding_index`. Do not put those calls in `app.py`.
+
+The capability tools are `list_tables`, `describe_table`, `query_table`, and `similarity_search`. `query_table` filters with equality only (`{'status': 'open'}`). `similarity_search` calls `column.similarity(string=query)`. Both cap rows and serialized characters. Default columns skip media, array, and binary; a named media column comes back as a file URL, not a blob. `read_only=False` is not implemented.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Add a Libraries page for `pydantic-ai-pixeltable`: Harness `Memory` on a Pixeltable table, plus a separate read-only `Pixeltable` capability for catalog RAG.
- Require `tables=...` (`['*']` is the whole-catalog opt-in). Keep the notebook at `harness.memory` so `pxt schema prune app.py my_app` does not drop it.
- Show the handbook as a `TableModel` + splitter view + `__indexes__`. Label `create_table` / `add_embedding_index` as notebook or REPL. Named media columns return file URLs; default columns skip media.
- Note YAML `from_spec` for `Pixeltable`, Python-only `Memory(PixeltableMemoryStore)`, `id='pixeltable'` merge, PrefixTools vs chDB, and two-phase receipts (no FileStore journal).
- Add a Pydantic AI tab on Migrate. Wire an Integrations → Libraries nav group. Does not change `integrations.telemetry.enabled`.

Package: https://github.com/pixeltable/pydantic-ai-pixeltable

## Test plan
- [ ] Confirm `/libraries/pydantic-ai` is in the Integrations sidebar
- [ ] Confirm the Pydantic AI tab on `/howto/coming-from` uses `harness.memory` and the `#pydantic-ai` anchor
- [ ] Confirm the handbook snippet is `TableModel` + `__indexes__`, not `create_table` in `app.py`
- [ ] Confirm the page distinguishes this bridge from Working with Pydantic (`to_pydantic()`)
- [ ] Confirm `integrations.telemetry.enabled` is still `true`