### PR TITLE
[PXT-1361] Fix unnecessary memory pressure when multiple insert plans are executed sequentially

### DIFF
--- a/pixeltable/exec/in_memory_data_node.py
+++ b/pixeltable/exec/in_memory_data_node.py
@@ -88,6 +88,10 @@ class InMemoryDataNode(ExecNode):
                 output_row[col_info.slot_idx] = None
             self.output_batch.add_row(output_row)
 
+    def _close(self) -> None:
+        # Free up memory taken by the last output batch. This can be significant if images are present.
+        self.output_batch = None
+
     async def __aiter__(self) -> AsyncIterator[DataRowBatch]:
         _logger.debug(f'InMemoryDataNode: created row batch with {len(self.output_batch)} rows')
         yield self.output_batch

--- a/pixeltable/exec/in_memory_data_node.py
+++ b/pixeltable/exec/in_memory_data_node.py
@@ -89,7 +89,7 @@ class InMemoryDataNode(ExecNode):
             self.output_batch.add_row(output_row)
 
     def _close(self) -> None:
-        # Free up memory taken by the last output batch. This can be significant if images are present.
+        # Free up memory taken by the last output batch. This can be significant if it has images.
         self.output_batch = None
 
     async def __aiter__(self) -> AsyncIterator[DataRowBatch]:

--- a/pixeltable/exec/in_memory_data_node.py
+++ b/pixeltable/exec/in_memory_data_node.py
@@ -48,7 +48,7 @@ class InMemoryDataNode(ExecNode):
 
     def _open(self) -> None:
         """Create row batch and populate with self.input_rows"""
-        assert not self._is_closed, "InMemoryDataNode is not reusable"
+        assert not self._is_closed, 'InMemoryDataNode is not reusable'
 
         # input rows can only provide values for this table's columns
         user_cols_by_name = {

--- a/pixeltable/exec/in_memory_data_node.py
+++ b/pixeltable/exec/in_memory_data_node.py
@@ -24,6 +24,7 @@ class InMemoryDataNode(ExecNode):
     input_rows: list[dict[str, Any]]
     set_pk: bool  # if True, assign synthetic pks (input row position); needed for iterator expansion
     output_batch: DataRowBatch | None
+    _is_closed: bool
 
     # output_exprs is declared in the superclass, but we redeclare it here with a more specific type
     output_exprs: list[exprs.ColumnRef]
@@ -43,9 +44,12 @@ class InMemoryDataNode(ExecNode):
         self.input_rows = rows
         self.set_pk = set_pk
         self.output_batch = None
+        self._is_closed = False
 
     def _open(self) -> None:
         """Create row batch and populate with self.input_rows"""
+        assert not self._is_closed, "InMemoryDataNode is not reusable"
+
         # input rows can only provide values for this table's columns
         user_cols_by_name = {
             col_ref.col.name: exprs.ColumnSlotIdx(col_ref.col, col_ref.slot_idx)
@@ -89,8 +93,11 @@ class InMemoryDataNode(ExecNode):
             self.output_batch.add_row(output_row)
 
     def _close(self) -> None:
-        # Free up memory taken by the last output batch. This can be significant if it has images.
+        # Release references to input rows and the last output batch. When images are present, this may free up
+        # a significant amount of memory.
+        self.input_rows = []
         self.output_batch = None
+        self._is_closed = True
 
     async def __aiter__(self) -> AsyncIterator[DataRowBatch]:
         _logger.debug(f'InMemoryDataNode: created row batch with {len(self.output_batch)} rows')


### PR DESCRIPTION
# The problem

Every `ExprEvalNode` creates a refcount loop around itself: `ExprEvalNode` has `ExprEvalCtx`, which holds `slot_evaluators`, that each has the original `ExprEvalNode` as `dispatcher`. There's also the second loop through the node's schedulers. It's not a bug or a memory leak per se -- the full GC (2 gen) takes care of them.

In a regular insert plan, `ExprEvalNode` also holds a reference to `InMemoryDataNode` (as an input node) that holds the row data batch, including inserted images.

So here's what happens if the workload simply inserts individual rows with images one by one. We accumulate these `ExprEvalNode`+`InMemoryDataNode` instances with the images dangling off of them in memory until full GC runs. However there aren't enough allocations happening to trigger the full GC frequently enough, and only the refcount-based GC runs. Python runtime doesn't take into account the memory pressure when deciding to run full GC (besides, the images are allocated on C heap anyway). The host eventually runs out of memory and kills the app (but not the container).

# The fix

Cleanup `InMemoryDataNode`'s output batch when it's closed. This resolves the immediate issue.

What that doesn't fix is the retention of `ExprEvalNode` and company in memory after the plan is done. If that becomes a problem, we can try to fix it by cleaning up `ExprEvalCtx`'s slot evaluators and `ExprEvalNode`'s schedulers explicitly when the node is being closed. Alternatively, slot evaluators and schedulers can use a weakref to dispatcher instead.

Verified manually.