### PR TITLE
Normalize kwarg order in FunctionCall deserialization

### DIFF
--- a/pixeltable/exprs/function_call.py
+++ b/pixeltable/exprs/function_call.py
@@ -292,7 +292,7 @@ class FunctionCall(Expr):
 
     def _print_args(self, start_idx: int = 0, inline: bool = True) -> str:
         arg_strs = [str(self.components[idx]) for idx in self.arg_idxs[start_idx:]]
-        arg_strs.extend([f'{param_name}={self.components[idx]}' for param_name, idx in self.kwarg_idxs.items()])
+        arg_strs.extend(f'{name}={self.components[idx]}' for name, idx in self.kwarg_idxs.items())
         if len(self.order_by) > 0:
             assert isinstance(self.fn, func.AggregateFunction)
             if self.fn.requires_order_by:
@@ -567,7 +567,9 @@ class FunctionCall(Expr):
         fn = func.Function.from_dict(d['fn'])
         return_type = ts.ColumnType.from_dict(d['return_type']) if d.get('return_type') is not None else None
         arg_idxs: list[int] = d['arg_idxs']
-        kwarg_idxs: dict[str, int] = d['kwarg_idxs']
+        # postgres may reorder the keys of a dict if stored in JSONB, so we normalize the dictionary order here;
+        # they are sorted by index order (the dictionary's integer values)
+        kwarg_idxs: dict[str, int] = dict(sorted(d['kwarg_idxs'].items(), key=lambda item: item[1]))
         group_by_start_idx: int = d['group_by_start_idx']
         group_by_stop_idx: int = d['group_by_stop_idx']
         order_by_start_idx: int = d['order_by_start_idx']

--- a/tests/test_exprs.py
+++ b/tests/test_exprs.py
@@ -1574,6 +1574,19 @@ class TestExprs:
             e_deserialized = Expr.deserialize(e_serialized)
             assert e.equals(e_deserialized)
 
+    def test_kwarg_order_after_reload(self, db_root: DatabaseRoot) -> None:
+        """A FunctionCall's kwargs are stored as a jsonb object, whose key order Postgres does not preserve."""
+        p = db_root.make_catalog_path
+        t = pxt.create_table(p('test'), {'x': pxt.Int | None})
+        expr = _kwarg_order_udf(t.x, gamma_delta=3, b=2, alpha=1)
+        t.add_computed_column(y=expr)
+        expected = '_kwarg_order_udf(x, gamma_delta=3, b=2, alpha=1)'
+        assert t.get_metadata()['columns']['y']['computed_with'] == expected
+
+        reload_catalog()
+        t = pxt.get_table(p('test'))
+        assert t.get_metadata()['columns']['y']['computed_with'] == expected
+
     @pytest.mark.db_roots('local', reason='TODO: convert')
     def test_print(
         self, test_tbl_exprs: list[exprs.Expr], img_tbl_exprs: list[exprs.Expr], multi_img_tbl_exprs: list[exprs.Expr]
@@ -2072,6 +2085,11 @@ class TestExprs:
 @pxt.udf
 def udf1(x: int, y: str) -> str:
     return f'{x} {y}'
+
+
+@pxt.udf
+def _kwarg_order_udf(x: int, *, alpha: int, b: int, gamma_delta: int) -> int:
+    return x + alpha + b + gamma_delta
 
 
 @pxt.udf


### PR DESCRIPTION
When a FunctionCall is stored in postgres, the JSONB dict does not preserve key order. As a result, the display_str() of a FunctionCall may change after a DB round trip.

This fix restores the original order of kwargs on deserialization. In particular, it provides a "quickfix" of PXT-1347. We may still want to do a more nuanced expr comparison for `pxt diff`, but we can reevaluate its priority now that the immediate bug is fixed.

In any case, we definitely want a normalized kwarg order for display purposes (tbl.describe(), etc)