### PR TITLE
[PXT-1378] insert(Query) / create_table(source=Query) crashes with AssertionError on any join

### DIFF
--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -84,10 +84,12 @@ class RowBuilder:
 
     input_exprs: ExprSet
 
-    tbl: catalog.TableVersion | None  # reference table of the RowBuilder; used to identify pk columns for writes
+    tbl: catalog.TableVersion | None  # the table the output columns are written to; None for a read-only plan
     for_view_load: bool  # True if this RowBuilder represents a view load
 
-    table_columns: dict[catalog.Column, int | None]  # value: slot idx, if the result of an expr
+    # value: slot idx, if the result of an expr, or None if it's an identity column, i.e. if its value is simply copied
+    # from the input
+    table_columns: dict[catalog.Column, int | None]
     default_eval_ctx: EvalCtx
     unstored_iter_args: dict[UUID, Expr]
     unstored_iter_outputs: dict[UUID, list['ColumnRef']]
@@ -203,7 +205,7 @@ class RowBuilder:
                 else:
                     self.input_exprs.add(expr)
 
-            self.add_table_column(col, expr.slot_idx, allow_unstored=allow_unstored)
+            self._add_table_column(col, expr.slot_idx, allow_unstored=allow_unstored)
             self.output_exprs.add(expr)
 
         # default eval ctx: all output exprs
@@ -307,16 +309,33 @@ class RowBuilder:
         self.row_batch_output_map = None
         self.row_batch_col_types = None
 
-    def add_table_column(self, col: catalog.Column, slot_idx: int, *, allow_unstored: bool = False) -> None:
+    def set_table_output(
+        self,
+        tbl: catalog.TableVersion,
+        *,
+        identity_cols: Sequence[catalog.Column] = (),
+        expr_cols: Sequence[tuple[catalog.Column, int]] = (),
+    ) -> None:
+        """Record the table that receives the output columns, together with those columns.
+
+        Args:
+            tbl: the table the rows are written to
+            identity_cols: columns carried over from the input rows verbatim, not produced by an expr
+            expr_cols: columns paired with the slot idx of the expr that produces the value
+        """
+        assert self.tbl is None
+        assert len(self.table_columns) == 0
+        assert set(identity_cols).isdisjoint(col for col, _ in expr_cols), (tbl, identity_cols, expr_cols)
+        self.tbl = tbl
+        for col in identity_cols:
+            self.table_columns[col] = None
+        for col, slot_idx in expr_cols:
+            self._add_table_column(col, slot_idx)
+
+    def _add_table_column(self, col: catalog.Column, slot_idx: int, *, allow_unstored: bool = False) -> None:
         """Record an output column for which the value is produced via expr evaluation."""
-        assert self.tbl is not None
         assert allow_unstored or col.is_stored, col
         self.table_columns[col] = slot_idx
-
-    def add_table_columns(self, cols: list[catalog.Column]) -> None:
-        """Record output columns whose values are materialized into DataRow.cell_vals"""
-        for col in cols:
-            self.table_columns[col] = None
 
     @property
     def media_output_col_info(self) -> list[ColumnSlotIdx]:

--- a/pixeltable/exprs/row_builder.py
+++ b/pixeltable/exprs/row_builder.py
@@ -84,6 +84,7 @@ class RowBuilder:
 
     input_exprs: ExprSet
 
+    # TODO(PXT-1392): RowBuilder has 2 jobs: a query evaluation plan, and a table write spec. It needs a refactoring.
     tbl: catalog.TableVersion | None  # the table the output columns are written to; None for a read-only plan
     for_view_load: bool  # True if this RowBuilder represents a view load
 

--- a/pixeltable/plan.py
+++ b/pixeltable/plan.py
@@ -410,13 +410,12 @@ class Planner:
         # the pre-compile copies and don't carry slot_idx).
         compiled = query._create_query_plan()
         plan: exec.ExecNode = compiled.exec_root
-
-        needs_cell_materialization = False
-        for col_name, expr in zip(compiled.select_list_schema.keys(), compiled.select_list_exprs):
-            assert col_name in tbl.cols_by_name
-            col = tbl.cols_by_name[col_name]
-            plan.row_builder.add_table_column(col, expr.slot_idx)
-            needs_cell_materialization = needs_cell_materialization or col.col_type.needs_cell_materialization()
+        output_cols = [tbl.cols_by_name.get(col_name) for col_name in compiled.select_list_schema]
+        assert all(col is not None for col in output_cols)
+        plan.row_builder.set_table_output(
+            tbl, expr_cols=[(col, e.slot_idx) for col, e in zip(output_cols, compiled.select_list_exprs)]
+        )
+        needs_cell_materialization = any(col.col_type.needs_cell_materialization() for col in output_cols)
 
         if needs_cell_materialization:
             plan = exec.CellMaterializationNode(plan)
@@ -534,9 +533,11 @@ class Planner:
         )
 
         # Register output columns with the row builder
-        plan.row_builder.add_table_columns(identity_cols)
-        for i, col in enumerate(evaluated_cols):
-            plan.row_builder.add_table_column(col, select_list[i].slot_idx)
+        plan.row_builder.set_table_output(
+            target,
+            identity_cols=identity_cols,
+            expr_cols=[(col, select_list[i].slot_idx) for i, col in enumerate(evaluated_cols)],
+        )
 
         plan = cls._add_cell_materialization_node(plan)
         plan = cls._add_save_node(plan)
@@ -738,7 +739,7 @@ class Planner:
         # Undo-col remapping expressions (eval_cols not in recomputed_cols) stay in sql_exprs.
         recomputed_expr_ids = {expr.id for col, expr in zip(eval_cols, eval_exprs) if col in recomputed_cols}
         sql_exprs = [e for e in all_sql_exprs if e.id not in recomputed_expr_ids]
-        row_builder = exprs.RowBuilder(analyzer.all_exprs, [], sql_exprs, target)
+        row_builder = exprs.RowBuilder(analyzer.all_exprs, [], sql_exprs)
         analyzer.finalize(row_builder)
 
         cell_md_col_refs = cls._cell_md_col_refs(sql_exprs)
@@ -761,9 +762,11 @@ class Planner:
 
         # Register output columns with the row builder
         row_builder.set_slot_idxs(select_list, remove_duplicates=False)
-        plan.row_builder.add_table_columns(identity_cols)
-        for i, col in enumerate(evaluated_cols):
-            plan.row_builder.add_table_column(col, select_list[i].slot_idx)
+        plan.row_builder.set_table_output(
+            target,
+            identity_cols=identity_cols,
+            expr_cols=[(col, select_list[i].slot_idx) for i, col in enumerate(evaluated_cols)],
+        )
         ctx = exec.ExecContext(row_builder)
         # TODO: correct batch size?
         ctx.batch_size = 0
@@ -817,8 +820,9 @@ class Planner:
             deleted_at_current_version=[view.tbl_version],
         )
         # Register output columns with the row builder
-        for i, col in enumerate(evaluated_cols):
-            plan.row_builder.add_table_column(col, select_list[i].slot_idx)
+        plan.row_builder.set_table_output(
+            target, expr_cols=[(col, select_list[i].slot_idx) for i, col in enumerate(evaluated_cols)]
+        )
         plan = cls._add_cell_materialization_node(plan)
         plan = cls._add_save_node(plan)
 
@@ -1038,14 +1042,6 @@ class Planner:
             order_by_clause=order_by_clause,
             sample_clause=sample_clause,
         )
-        # If the from_clause has a single table, we can use it as the context table for the RowBuilder.
-        # Otherwise there is no context table, but that's ok, because the context table is only needed for
-        # table mutations, which can't happen during a join.
-        context_tbl = (
-            from_clause.tbls[0].tbl_version.get()
-            if len(from_clause.tbls) == 1 and isinstance(from_clause.tbls[0], catalog.TableVersionPath)
-            else None
-        )
         # Component views with unstored iterator columns need their (stored, live-versioned) iterator args retargeted
         # to the instances this query uses. Resolve each view against the from-clause path it is reached through, so
         # a base table appearing at different versions in different join branches binds correctly per branch.
@@ -1055,7 +1051,7 @@ class Planner:
                 args = h.get().iterator_args_expr()
                 if args is not None:
                     iter_args[h.id] = args.retarget_path(p)
-        row_builder = exprs.RowBuilder(analyzer.all_exprs, [], [], context_tbl, iter_args=iter_args)
+        row_builder = exprs.RowBuilder(analyzer.all_exprs, [], [], iter_args=iter_args)
 
         analyzer.finalize(row_builder)
         # select_list: we need to materialize everything that's been collected

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1170,15 +1170,38 @@ class TestTable:
         t1.insert({'id': i, 'n': i * 10} for i in range(3))
         t2 = pxt.create_table(p('strs'), {'id': pxt.Int, 's': pxt.String})
         t2.insert({'id': i, 's': f'str_{i}'} for i in range(3))
-        query = t1.join(t2, on=t1.id == t2.id).select(t1.n, t2.s)
+        src_query = t1.join(t2, on=t1.id == t2.id).select(t1.n, t2.s)
 
-        t3 = pxt.create_table(p('from_join'), source=query)
+        t3 = pxt.create_table(p('from_join'), source=src_query)
         assert list(t3.columns()) == ['n', 's']
         expected = [{'n': 0, 's': 'str_0'}, {'n': 10, 's': 'str_1'}, {'n': 20, 's': 'str_2'}]
         assert list(t3.select(t3.n, t3.s).order_by(t3.n).collect()) == expected
 
-        t3.insert(query)
+        t3.insert(src_query)
         assert list(t3.select(t3.n, t3.s).order_by(t3.n).collect()) == [row for row in expected for _ in range(2)]
+
+    def test_component_view_query_as_source(self, db_root: DatabaseRoot) -> None:
+        """A component view's rowid columns do not perfectly line up with those of the target table."""
+        p = db_root.make_catalog_path
+        t = pxt.create_table(p('cv_base'), {'id': pxt.Int, 'n': pxt.Int})
+        t.insert([{'id': 0, 'n': 3}])
+        v = pxt.create_view(p('cv'), t, iterator=DummyIterator(limit=t.n))
+        assert v.count() == 3
+        query = v.select(v.out1, v.out2, v.n)
+
+        t2 = pxt.create_table(p('from_cv'), source=query)
+        assert list(t2.columns()) == ['out1', 'out2', 'n']
+        expected = [
+            {'out1': 'str0', 'out2': 0, 'n': 3},
+            {'out1': 'str1', 'out2': 1, 'n': 3},
+            {'out1': 'str2', 'out2': 2, 'n': 3},
+        ]
+        assert list(t2.select(t2.out1, t2.out2, t2.n).order_by(t2.out2).collect()) == expected
+
+        t2.insert(query)
+        assert list(t2.select(t2.out1, t2.out2, t2.n).order_by(t2.out2).collect()) == [
+            row for row in expected for _ in range(2)
+        ]
 
     def _setup_pydantic_scalars(
         self, p: Callable[[str], str]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1164,6 +1164,22 @@ class TestTable:
         t2.insert(t)
         assert len(t2.collect()) == 2 * len(t.collect())
 
+    def test_join_query_as_source(self, db_root: DatabaseRoot) -> None:
+        p = db_root.make_catalog_path
+        t1 = pxt.create_table(p('ints'), {'id': pxt.Int, 'n': pxt.Int})
+        t1.insert({'id': i, 'n': i * 10} for i in range(3))
+        t2 = pxt.create_table(p('strs'), {'id': pxt.Int, 's': pxt.String})
+        t2.insert({'id': i, 's': f'str_{i}'} for i in range(3))
+        query = t1.join(t2, on=t1.id == t2.id).select(t1.n, t2.s)
+
+        t3 = pxt.create_table(p('from_join'), source=query)
+        assert list(t3.columns()) == ['n', 's']
+        expected = [{'n': 0, 's': 'str_0'}, {'n': 10, 's': 'str_1'}, {'n': 20, 's': 'str_2'}]
+        assert list(t3.select(t3.n, t3.s).order_by(t3.n).collect()) == expected
+
+        t3.insert(query)
+        assert list(t3.select(t3.n, t3.s).order_by(t3.n).collect()) == [row for row in expected for _ in range(2)]
+
     def _setup_pydantic_scalars(
         self, p: Callable[[str], str]
     ) -> tuple[


### PR DESCRIPTION
Clarify the meaning of `RowBuilder.tbl` as the write target, and perform a light refactoring and fixes around it. Two bugs fixed:
1. Create or insert into a table from a join query: `tbl` is set to the target write table, not guessed from the source query (which involves two tables)
2. Create or insert into a table from a component view query: this was broken for the same reason -- `tbl` was treated as both query source and write target.

Filed [PXT-1392](https://pixeltable.atlassian.net/browse/PXT-1392) to track the proper refactoring of `RowBuilder`.

[PXT-1392]: https://pixeltable.atlassian.net/browse/PXT-1392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ