### PR TITLE
Name live TableModel APIs in help() and unbound errors

### DIFF
--- a/pixeltable/catalog/model/base.py
+++ b/pixeltable/catalog/model/base.py
@@ -79,6 +79,11 @@ def _creation_order(registered_models: dict[str, TableModelMeta]) -> list[tuple[
 
 
 def model_base(cls_name: str = 'TableModel') -> type[TableModelMeta]:
+    """Returns the base class for table models in an application file.
+
+    Subclass the result in `app.py` and run `pxt schema update`. In a REPL, call
+    `TableModel.create_all(dir)` or `TableModel.bind_all(dir)`.
+    """
     # mypy fundamentally does not understand metaclasses.
     cls = TableModelMeta(cls_name, (), {}, name='')
     registered_models: dict[str, TableModelMeta] = {}

--- a/pixeltable/catalog/model/definition.py
+++ b/pixeltable/catalog/model/definition.py
@@ -137,7 +137,23 @@ class Column:
 
 @dataclasses.dataclass(frozen=True)
 class EmbeddingIndex:
-    """An embedding index specification used in a TableModel or ViewModel definition."""
+    """An embedding index specification used in a TableModel or ViewModel definition.
+
+    Put it on `__indexes__`. Do not call `add_embedding_index()` after `pxt schema update`.
+
+    Example:
+
+        >>> from pixeltable.functions.huggingface import clip
+        >>> TableModel = pxt.model_base()
+        >>> class Media(TableModel, name='media'):
+        ...     img: pxt.Image
+        ...     __indexes__ = [
+        ...         pxt.EmbeddingIndex(
+        ...             img,
+        ...             embedding=clip.using(model_id='openai/clip-vit-base-patch32'),
+        ...         )
+        ...     ]
+    """
 
     column: Any
     embedding: func.Function | None = None
@@ -208,7 +224,17 @@ class EmbeddingIndex:
 
 @dataclasses.dataclass(frozen=True)
 class BtreeIndex:
-    """A B-tree index specification used in a TableModel or ViewModel definition."""
+    """A B-tree index specification used in a TableModel or ViewModel definition.
+
+    Put it on `__indexes__`. Do not call `add_btree_index()` after `pxt schema update`.
+
+    Example:
+
+        >>> TableModel = pxt.model_base()
+        >>> class Items(TableModel, name='items'):
+        ...     sku: pxt.String
+        ...     __indexes__ = [pxt.BtreeIndex(sku)]
+    """
 
     column: Any
 
@@ -218,6 +244,11 @@ class BtreeIndex:
 
 # An index specification defined as a class attribute in a TableModel or ViewModel definition.
 IndexDefinition = EmbeddingIndex | BtreeIndex
+
+
+def _model_base_name(model_cls: type) -> str:
+    # __prepare__ requires a direct subclass of the class that model_base() returned
+    return model_cls.__bases__[0].__name__
 
 
 class TableSpec(TypedDict):
@@ -860,7 +891,7 @@ class TableModelMeta(type):
                 raise excs.RequestError(
                     excs.ErrorCode.UNSUPPORTED_OPERATION,
                     f'{item}(): `{cls.__name__}`, which is not bound to a table, holds no rows; '
-                    f'create the table with `{cls.__name__}.create()` or `pxt.create_all()` first.',
+                    f'create the table with `{_model_base_name(cls)}.create_all(dir)` or `pxt schema update` first.',
                 )
             try:
                 return getattr(cls.table, item)
@@ -951,9 +982,10 @@ class TableModelMeta(type):
     def table(cls) -> Table:
         """The underlying [`Table`][pixeltable.Table] this model is bound to."""
         if not cls.is_bound:
+            base = _model_base_name(cls)
             raise excs.RequestError(
                 excs.ErrorCode.NOT_BOUND,
                 f'`{cls.__name__}` is not yet bound to an actual table. You must first call '
-                f'`{cls.__name__}.bind()`, `{cls.__name__}.create()`, `pxt.bind_all()`, or `pxt.create_all()`.',
+                f'`{base}.create_all(dir)` or `{base}.bind_all(dir)`, or run `pxt schema update`.',
             )
         return cls._resolve_tbl(cls._catalog_dir, if_not_exists='error')

--- a/pixeltable/catalog/model/query.py
+++ b/pixeltable/catalog/model/query.py
@@ -11,7 +11,7 @@ from pixeltable._query_base import QueryBase
 from pixeltable.exprs import ColumnRefByName
 from pixeltable.query_clauses import FromClause
 
-from .definition import MODEL_BY_DEFINED_TBL_ID, TableModelMeta
+from .definition import MODEL_BY_DEFINED_TBL_ID, TableModelMeta, _model_base_name
 
 
 class ModelQuery(QueryBase):
@@ -167,7 +167,7 @@ class ModelQuery(QueryBase):
             raise excs.RequestError(
                 excs.ErrorCode.UNSUPPORTED_OPERATION,
                 f'{item}(): this query is defined over model `{self.model_cls.__name__}`, which is not bound '
-                f'to a table; create the table with `{self.model_cls.__name__}.create()`, or call this on a '
-                f'query over a bound model.',
+                f'to a table; create the table with `{_model_base_name(self.model_cls)}.create_all(dir)` or '
+                f'`pxt schema update`, or call this on a query over a bound model.',
             )
         raise AttributeError(item)

--- a/tests/test_table_model.py
+++ b/tests/test_table_model.py
@@ -2324,8 +2324,16 @@ class TestTableModel:
                 Id: pxt.Float | None
 
         # a Table method that a query cannot provide raises AttributeError while the model is unbound
-        with pytest.raises(AttributeError, match=r'is not yet bound to an actual table'):
+        with pytest.raises(AttributeError, match=r'is not yet bound to an actual table') as info:
             ValidTableModel.get_metadata()
+        unbound_msg = str(info.value)
+        assert 'TableModel.create_all' in unbound_msg
+        assert 'TableModel.bind_all' in unbound_msg
+        assert 'pxt schema update' in unbound_msg
+        assert 'pxt.create_all' not in unbound_msg
+        assert 'pxt.bind_all' not in unbound_msg
+        assert '.create()' not in unbound_msg
+        assert '.bind()' not in unbound_msg
 
         # every method that reads or writes rows refuses on an unbound model, naming it and how to create it
         for method, args in (
@@ -2341,9 +2349,16 @@ class TestTableModel:
         ):
             with pxt_raises(
                 excs.ErrorCode.UNSUPPORTED_OPERATION,
-                match=rf'{method}\(\): `ValidTableModel`, which is not bound to a table, holds no rows',
-            ):
+                match=(
+                    rf'{method}\(\): `ValidTableModel`, which is not bound to a table, holds no rows; '
+                    r'create the table with `TableModel.create_all\(dir\)` or `pxt schema update` first\.'
+                ),
+            ) as info:
                 getattr(ValidTableModel, method)(*args)
+            row_msg = info.value.message
+            assert 'pxt.create_all' not in row_msg
+            assert 'pxt.bind_all' not in row_msg
+            assert '.create()' not in row_msg
 
         # describe() needs no table: it renders what the model declares, in full
         ValidTableModel.describe()
@@ -2358,8 +2373,13 @@ class TestTableModel:
 
         # the same refusal from a declared query, rather than from the model
         declared = ValidTableModel.where(ValidTableModel.id > 0)  # type: ignore[arg-type]
-        with pxt_raises(excs.ErrorCode.UNSUPPORTED_OPERATION, match=r'`ValidTableModel`, which is not bound'):
+        with pxt_raises(excs.ErrorCode.UNSUPPORTED_OPERATION, match=r'`ValidTableModel`, which is not bound') as info:
             declared.collect()
+        query_msg = info.value.message
+        assert 'TableModel.create_all' in query_msg
+        assert 'pxt schema update' in query_msg
+        assert 'pxt.create_all' not in query_msg
+        assert '.create()' not in query_msg
 
         # similarity() on a column the model declares no embedding index on has nothing to resolve against
         with pxt_raises(excs.ErrorCode.INDEX_NOT_FOUND, match=r"No embedding index found for column 'id'"):


### PR DESCRIPTION
## Summary
- `help(EmbeddingIndex)` / `help(BtreeIndex)` / `help(model_base)` now show `__indexes__` and `pxt schema update` for an application file, and `TableModel.create_all(dir)` / `bind_all(dir)` for a REPL.
- Unbound-model errors no longer name `pxt.create_all()`, `pxt.bind_all()`, or `{Model}.create()` / `{Model}.bind()`, which are not public APIs.
- Leaves `Table.add_embedding_index` and `ColumnRef.similarity` on the functional table API. Skill changes are a follow-up.

Fixes PXT-1390 (library half).

## Test plan
- [x] `pytest tests/test_table_model.py::TestTableModel::test_table_model_errors`
- [ ] Confirm `help(pxt.EmbeddingIndex)` / `help(pxt.BtreeIndex)` / `help(pxt.model_base)` render the new examples
- [ ] Confirm an unbound `Photos.collect()` names `TableModel.create_all(dir)` and `pxt schema update`, and does not mention `pxt.create_all`


Made with [Cursor](https://cursor.com)