### PR TITLE
Upload `bytes` and `ndarray`s out of band during insertion [PXT-1314, PXT-1318, PXT-1319, PXT-1320]

### DIFF
--- a/pixeltable/service/db.py
+++ b/pixeltable/service/db.py
@@ -353,7 +353,9 @@ def _build_image(db_path: catalog.Path, archive_key: str, fingerprint: ProjectFi
     if current.last_build_state == 'FAILED':
         raise excs.ExternalServiceError(
             excs.ErrorCode.PROVIDER_ERROR,
-            f'The image build for {db_path.uri_str} failed: {current.last_build_error or "no reason was reported"}',
+            # covers the whole runtime update, not just the image build: the reported error also comes from
+            # the rollout onto the built image
+            f'The runtime update for {db_path.uri_str} failed: {current.last_build_error or "no reason was reported"}',
             provider='pixeltable_cloud',
         )
 

--- a/pixeltable/service/db.py
+++ b/pixeltable/service/db.py
@@ -353,7 +353,7 @@ def _build_image(db_path: catalog.Path, archive_key: str, fingerprint: ProjectFi
     if current.last_build_state == 'FAILED':
         raise excs.ExternalServiceError(
             excs.ErrorCode.PROVIDER_ERROR,
-            f'The runtime update for {db_path.uri_str} failed: {current.last_build_error or "no reason was reported"}',
+            f'The image build for {db_path.uri_str} failed: {current.last_build_error or "no reason was reported"}',
             provider='pixeltable_cloud',
         )
 

--- a/pixeltable/service/db.py
+++ b/pixeltable/service/db.py
@@ -353,8 +353,6 @@ def _build_image(db_path: catalog.Path, archive_key: str, fingerprint: ProjectFi
     if current.last_build_state == 'FAILED':
         raise excs.ExternalServiceError(
             excs.ErrorCode.PROVIDER_ERROR,
-            # covers the whole runtime update, not just the image build: the reported error also comes from
-            # the rollout onto the built image
             f'The runtime update for {db_path.uri_str} failed: {current.last_build_error or "no reason was reported"}',
             provider='pixeltable_cloud',
         )

--- a/pixeltable/service/proxy_dispatch.py
+++ b/pixeltable/service/proxy_dispatch.py
@@ -139,7 +139,7 @@ def handle(request_json: str, request_parts: list[bytes], *, include_error_detai
 
 
 def _prefetch_remote_parts(request: ProxyRequest) -> None:
-    """Localize the request's out-of-band media parts (object store keys) into TempStore before dispatch.
+    """Localize the request's out-of-band binary parts (object store keys) into TempStore before dispatch.
     Updates request._remote_parts with the temp paths of the localized files.
 
     Should be called outside of a db transaction so that object-store I/O never holds a db connection.
@@ -151,9 +151,7 @@ def _prefetch_remote_parts(request: ProxyRequest) -> None:
         # only client uploads may be localized; anything else (e.g. 'pixeltable/data/...' store objects)
         # must not be readable through this daemon
         if not remote_key.startswith('uploads/'):
-            raise excs.RequestError(
-                excs.ErrorCode.INVALID_ARGUMENT, f'Invalid uploaded media object key: {remote_key!r}'
-            )
+            raise excs.RequestError(excs.ErrorCode.INVALID_ARGUMENT, f'Invalid uploaded object key: {remote_key!r}')
     org = os.environ.get('PXTCLOUD_ORG')
     db = os.environ.get('PXTCLOUD_DB')
     if not (org and db):
@@ -175,7 +173,7 @@ def _prefetch_remote_parts(request: ProxyRequest) -> None:
             # gone (expired via the uploads/ lifecycle rule) or was never fully uploaded
             raise excs.NotFoundError(
                 excs.ErrorCode.STORAGE_NOT_FOUND,
-                f'Uploaded media object {remote_key!r} not found (upload expired or incomplete); retry the operation',
+                f'Uploaded object {remote_key!r} not found (upload expired or incomplete); retry the operation',
             ) from e
 
     # concurrent downloads are safe: boto3 clients are thread-safe

--- a/pixeltable/service/proxy_protocol.py
+++ b/pixeltable/service/proxy_protocol.py
@@ -116,7 +116,8 @@ class PxtStorePartSink(PartSink[int | str]):
     Each part's key is minted during serialization, but the transfer itself is deferred to flush() so that a
     request's uploads run concurrently rather than one per part.
 
-    Scalars (tags 'bytes'/'ndarray') take the same path once they reach _MIN_OUT_OF_BAND_SIZE.
+    Scalars (tags 'bytes'/'ndarray') take the same path if the exceed _MIN_OUT_OF_BAND_SIZE; otherwise they
+    are inlined.
     """
 
     _MAX_UPLOAD_THREADS = 16

--- a/pixeltable/service/proxy_protocol.py
+++ b/pixeltable/service/proxy_protocol.py
@@ -44,7 +44,7 @@ from pixeltable.utils.object_stores import FileDestination, ObjectOps, ObjectSto
 if TYPE_CHECKING:
     from pixeltable._query import Query
 
-PROTOCOL_VERSION = 3
+PROTOCOL_VERSION = 4
 
 # Reserved key marking a type-tagged value: {_TAG: <type-name>, 'v': <payload>}.
 _TAG = '$pxt'
@@ -77,6 +77,14 @@ class PartSink(abc.ABC, Generic[T]):
     def add_media_file(self, path: str) -> T:
         """Add a file-backed media value; returns a part index (inline) or an object key (out of band)."""
 
+    @abc.abstractmethod
+    def add_scalar_bytes(self, data: bytes, extension: str) -> T:
+        """Add a non-media binary value (a Binary cell, an array); returns a reference to the value.
+
+        Sending a small value out of band costs more in round trips than it saves in request size, so a sink
+        may inline one even where it sends every media value out of band.
+        """
+
     def flush(self) -> None:
         """Complete any work the sink deferred while serializing."""
 
@@ -93,9 +101,12 @@ class InlinePartSink(PartSink[int]):
         with open(path, 'rb') as f:
             return self.add_inline(f.read())
 
+    def add_scalar_bytes(self, data: bytes, extension: str) -> int:
+        return self.add_inline(data)
+
 
 class PxtStorePartSink(PartSink[int | str]):
-    """PartSink that uploads media parts to the hosted db's home bucket. The parts will be deposited in the
+    """PartSink that uploads binary parts to the hosted db's home bucket. The parts will be deposited in the
     uploads/ folder of the db's home bucket, in a per-request subfolder uploads/<request-uuid>.
 
     The RPC then carries only the object keys; the daemon localizes the objects before dispatch; see
@@ -103,17 +114,19 @@ class PxtStorePartSink(PartSink[int | str]):
     they must never become stored cell values.
 
     Each part's key is minted during serialization, but the transfer itself is deferred to flush() so that a
-    request's uploads run concurrently rather than one per media value.
+    request's uploads run concurrently rather than one per part.
 
-    Scalars (tags 'bytes'/'ndarray') always stay inline.
+    Scalars (tags 'bytes'/'ndarray') take the same path once they reach _MIN_OUT_OF_BAND_SIZE.
     """
 
     _MAX_UPLOAD_THREADS = 16
+    # Below this, an upload plus a download costs more than the bytes do in the request itself.
+    _MIN_OUT_OF_BAND_SIZE = 512
 
     _org: str
     _db: str
     _key_prefix: str  # 'uploads/<request-uuid>/'
-    _num_media_parts: int
+    _num_parts: int
     _store: ObjectStoreBase | None  # built on the first flush, so scalar requests skip the overhead of construction
     _pending: list[tuple[pathlib.Path, str, bool]]  # (local path, object key, remove the path after uploading it)
 
@@ -122,7 +135,7 @@ class PxtStorePartSink(PartSink[int | str]):
         self._org = org
         self._db = db
         self._key_prefix = f'uploads/{uuid4().hex}/'
-        self._num_media_parts = 0
+        self._num_parts = 0
         self._store = None
         self._pending = []
 
@@ -142,15 +155,20 @@ class PxtStorePartSink(PartSink[int | str]):
     def add_media_file(self, path: str) -> str:
         return self._add_pending(pathlib.Path(path), remove_after_upload=False)
 
+    def add_scalar_bytes(self, data: bytes, extension: str) -> int | str:
+        if len(data) < self._MIN_OUT_OF_BAND_SIZE:
+            return self.add_inline(data)
+        return self.add_media_bytes(data, extension)
+
     def _add_pending(self, path: pathlib.Path, *, remove_after_upload: bool) -> str:
         """Mint this part's object key and queue its upload for flush()."""
-        key = f'{self._key_prefix}{self._num_media_parts}{path.suffix}'
-        self._num_media_parts += 1
+        key = f'{self._key_prefix}{self._num_parts}{path.suffix}'
+        self._num_parts += 1
         self._pending.append((path, key, remove_after_upload))
         return key
 
     def flush(self) -> None:
-        """Upload the queued media parts concurrently.
+        """Upload the queued parts concurrently.
 
         Repeated references to one path are not coalesced into a single object: the daemon moves each
         localized file into the media store (ObjectOps.put_file_resolved), which would consume a shared one.
@@ -317,15 +335,11 @@ def _serialize(obj: Any, sink: PartSink) -> Any:
         return str(obj)  # filesystem paths travel as strings
     if isinstance(obj, bytes):
         # a Binary cell, or an array column's stored byte form as returned by compute()
-        # TODO: We should be coalescing these into out-of-band uploads via add_media_bytes(), not inlining them
-        #     in HTTP requests [PXT-1314]
-        return {_TAG: 'bytes', 'v': sink.add_inline(obj)}
+        return {_TAG: 'bytes', 'v': sink.add_scalar_bytes(obj, '.bin')}
     if isinstance(obj, np.ndarray):
-        # TODO: We should be coalescing these into out-of-band uploads via add_media_bytes(), not inlining them
-        #     in HTTP requests [PXT-1314]
         buf = io.BytesIO()
         np.save(buf, obj, allow_pickle=False)  # .npy carries dtype and shape
-        return {_TAG: 'ndarray', 'v': sink.add_inline(buf.getvalue())}
+        return {_TAG: 'ndarray', 'v': sink.add_scalar_bytes(buf.getvalue(), '.npy')}
     if isinstance(obj, PIL.Image.Image):
         # an in-memory image; file-backed media travels as a path
         buf = io.BytesIO()
@@ -435,9 +449,16 @@ def _deserialize(
         if tag == 'tuple':
             return tuple(_deserialize(x, binary_parts, uploaded_names, remote_parts) for x in v)
         if tag == 'bytes':
+            # a str v is an object key of an out-of-band part, resolved to a pre-downloaded local path
+            if isinstance(v, str):
+                with open(_remote_part_path(v, remote_parts), 'rb') as f:
+                    return f.read()
             return binary_parts[v]
         if tag == 'ndarray':
-            return np.load(io.BytesIO(binary_parts[v]), allow_pickle=False)
+            buf: str | io.BytesIO = (
+                _remote_part_path(v, remote_parts) if isinstance(v, str) else io.BytesIO(binary_parts[v])
+            )
+            return np.load(buf, allow_pickle=False)
         if tag == 'image':
             # a str v is an object key of an out-of-band media part, resolved to a pre-downloaded local path
             img = PIL.Image.open(
@@ -450,9 +471,8 @@ def _deserialize(
                 # an object key of an out-of-band media part; return its pre-downloaded local path
                 dest_str = _remote_part_path(v, remote_parts)
             else:
-                # write the sent bytes to an opaque temp path (extension preserved for media-type detection)
-                # TODO: We still need this because bytes/ndarrays are still inlined into HTTP requests; once that's
-                #     fixed, this code branch can be removed (v will always be a str) [PXT-1314]
+                # write the sent bytes to an opaque temp path (extension preserved for media-type detection);
+                # an inlining sink serves the local daemon and every response, so this branch stays
                 dest = TempStore.create_path(extension=pathlib.Path(obj['name']).suffix)
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 with open(dest, 'wb') as f:
@@ -536,23 +556,27 @@ def _deserialize(
 
 
 def _remote_part_path(key: str, remote_parts: dict[str, str] | None) -> str:
-    """Resolve an out-of-band media part's object key to its pre-downloaded local path."""
+    """Resolve an out-of-band part's object key to its pre-downloaded local path."""
     if remote_parts is None:
         raise excs.RequestError(
             excs.ErrorCode.INVALID_CONFIGURATION,
-            f'Cannot localize uploaded media object {key!r}: this receiver has no access to uploaded objects',
+            f'Cannot localize uploaded object {key!r}: this receiver has no access to uploaded objects',
         )
     if key not in remote_parts:
         raise excs.RequestError(
             excs.ErrorCode.STORAGE_NOT_FOUND,
-            f'Cannot localize uploaded media object {key!r}: object was not prefetched on this receiver',
+            f'Cannot localize uploaded object {key!r}: object was not prefetched on this receiver',
         )
     return remote_parts[key]
 
 
+# the tags whose 'v' is an object key when the value went out of band, and a part index when it did not
+_BINARY_TAGS = ('file', 'image', 'bytes', 'ndarray')
+
+
 def collect_remote_keys(args: Any) -> list[str]:
-    """Return the object keys of all out-of-band media parts ('file'/'image' tags whose 'v' is a str) in
-    serialized args, deduplicated in encounter order."""
+    """Return the object keys of all out-of-band binary parts in serialized args, deduplicated in encounter
+    order."""
     keys: dict[str, None] = {}
 
     def walk(obj: Any) -> None:
@@ -560,7 +584,7 @@ def collect_remote_keys(args: Any) -> list[str]:
             for item in obj:
                 walk(item)
         elif isinstance(obj, dict):
-            if obj.get(_TAG) in ('file', 'image') and isinstance(obj.get('v'), str):
+            if obj.get(_TAG) in _BINARY_TAGS and isinstance(obj.get('v'), str):
                 keys[obj['v']] = None
             else:
                 for value in obj.values():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,6 +306,7 @@ ignore_missing_imports = true
 name = 'pxt://pixeltable:pxttest'
 include = ['.git/**', 'pixeltable/_version.py']
 system_dependencies = ["libiconv", "ffmpeg==6.1.1=gpl*"]
+memory_mb = 2048
 uv_options = "--no-dev"
 
 [tool.pyright]

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -151,7 +151,6 @@ class TestJson:
 
         assert original == reimported
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails due to inaccessible .fileurl [PXT-1323]')
     def test_round_trip_media(self, db_root: DatabaseRoot, tmp_path: pathlib.Path) -> None:
         """Export JSONL with media columns, re-import, and verify file URLs survive the round-trip."""
         p = db_root.make_catalog_path

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -555,7 +555,6 @@ class TestIndex:
         with pxt_raises(pxt.ErrorCode.INDEX_ALREADY_EXISTS, match='identical embedding index'):
             t.add_embedding_index('category', string_embed=local_embed)
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails due to inaccessible .fileurl [PXT-1323]')
     def test_update_img(
         self, img_tbl: pxt.Table, test_tbl: pxt.Table, db_root: DatabaseRoot, reload_tester: ReloadTester
     ) -> None:
@@ -611,7 +610,7 @@ class TestIndex:
             img_t.batch_update([repl_row], cascade=True)
         print(img_t.select(img_t.pkey, img_t.img).collect())
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails due to inaccessible .fileurl [PXT-1323]')
+    @pytest.mark.db_roots('local', 'proxy', reason='Extremely slow on cloud')
     def test_embedding_access(
         self, img_tbl: pxt.Table, db_root: DatabaseRoot, local_embed: pxt.Function, is_data_versioned: bool
     ) -> None:
@@ -644,7 +643,7 @@ class TestIndex:
         img_t.drop_column('ebd_copy')
         img_t.drop_embedding_index(column=img_t.category)
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails due to inaccessible .fileurl [PXT-1323]')
+    @pytest.mark.db_roots('local', 'proxy', reason='Extremely slow on cloud')
     def test_embedding_basic(
         self,
         img_tbl: pxt.Table,

--- a/tests/test_inlined_objects.py
+++ b/tests/test_inlined_objects.py
@@ -43,7 +43,6 @@ class TestInlinedObjects:
         assert all(row['data'] is not None for row in res)
         assert all(row['i'] % 2 == 0 for row in res)
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails, possibly due to bytes/ndarray being inlined [PXT-1318]')
     def test_insert_arrays(self, db_root: DatabaseRoot) -> None:
         """Test storing arrays of various sizes and dtypes."""
         p = db_root.make_catalog_path

--- a/tests/test_inlined_objects.py
+++ b/tests/test_inlined_objects.py
@@ -66,7 +66,7 @@ class TestInlinedObjects:
         )
         rows: list[dict[str, Any]] = [
             {'id': i, 'ar1': next(vals), 'ar2': next(vals), 'ar3': next(vals), 'ar4': next(vals), 'ar5': next(vals)}
-            for i in range(60)
+            for i in range(5)
         ]
         total_bytes = sum(
             row['ar1'].nbytes + row['ar2'].nbytes + row['ar3'].nbytes + row['ar4'].nbytes + row['ar5'].nbytes

--- a/tests/test_inlined_objects.py
+++ b/tests/test_inlined_objects.py
@@ -66,7 +66,7 @@ class TestInlinedObjects:
         )
         rows: list[dict[str, Any]] = [
             {'id': i, 'ar1': next(vals), 'ar2': next(vals), 'ar3': next(vals), 'ar4': next(vals), 'ar5': next(vals)}
-            for i in range(5)
+            for i in range(5 if db_root.id == 'cloud' else 60)
         ]
         total_bytes = sum(
             row['ar1'].nbytes + row['ar2'].nbytes + row['ar3'].nbytes + row['ar4'].nbytes + row['ar5'].nbytes
@@ -122,7 +122,6 @@ class TestInlinedObjects:
         if db_root.id == 'local':
             assert LocalStore(Env.get().media_dir).count(tbl_id) == 0
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails, possibly due to bytes/ndarray being inlined [PXT-1318]')
     def test_insert_inlined_objects(self, db_root: DatabaseRoot) -> None:
         """Test storing lists and dicts with arrays of various sizes and dtypes."""
         p = db_root.make_catalog_path
@@ -150,7 +149,7 @@ class TestInlinedObjects:
         imgs = inf_image_iterator()
         rng = np.random.default_rng(0)
         rows: list[dict[str, Any]] = []
-        for i in range(10):
+        for i in range(2 if db_root.id == 'cloud' else 10):
             img1 = next(imgs)
             img2 = next(imgs)
             img3 = next(imgs)
@@ -199,7 +198,6 @@ class TestInlinedObjects:
         if db_root.id == 'local':
             assert LocalStore(Env.get().media_dir).count(tbl_id) == 0
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails, possibly due to bytes/ndarray being inlined [PXT-1318]')
     def test_nonstandard_json_construction(self, db_root: DatabaseRoot) -> None:
         p = db_root.make_catalog_path
         skip_test_if_not_installed('imagehash')
@@ -237,7 +235,7 @@ class TestInlinedObjects:
                 'img3': next(imgs),
                 'img4': next(imgs),
             }
-            for i in range(100)
+            for i in range(2 if db_root.id == 'cloud' else 100)
         ]
         validate_update_status(t.insert(rows), expected_rows=len(rows))
 

--- a/tests/test_proxy_daemon.py
+++ b/tests/test_proxy_daemon.py
@@ -1,3 +1,4 @@
+import io
 import json
 import math
 import pathlib
@@ -18,8 +19,8 @@ from pixeltable.utils.object_stores import FileDestination, ObjectOps
 from .utils import pxt_raises
 
 
-class _RemoteMediaSink(proxy_protocol.PartSink[str]):
-    """PartSink that stores media parts in a dict of object store-style object keys,
+class _RemotePartSink(proxy_protocol.PartSink[int | str]):
+    """PartSink that stores out-of-band parts in a dict of object store-style object keys,
     mirroring PxtStorePartSink's contract."""
 
     def __init__(self) -> None:
@@ -34,6 +35,11 @@ class _RemoteMediaSink(proxy_protocol.PartSink[str]):
     def add_media_file(self, path: str) -> str:
         with open(path, 'rb') as f:
             return self.add_media_bytes(f.read(), pathlib.Path(path).suffix)
+
+    def add_scalar_bytes(self, data: bytes, extension: str) -> int | str:
+        if len(data) < proxy_protocol.PxtStorePartSink._MIN_OUT_OF_BAND_SIZE:
+            return self.add_inline(data)
+        return self.add_media_bytes(data, extension)
 
 
 class TestProxyDaemon:
@@ -51,11 +57,11 @@ class TestProxyDaemon:
 
     def test_media_sink_round_trip(self, tmp_path: pathlib.Path) -> None:
         args = self._media_args(tmp_path)
-        sink = _RemoteMediaSink()
+        sink = _RemotePartSink()
         wire = proxy_protocol.serialize_args(args, sink)
         row = wire['rows'][0]
 
-        # media parts go out of band as object keys (names/formats preserved); scalar binary parts stay inline
+        # media parts go out of band as object keys (names/formats preserved); small scalars stay inline
         assert row['img_file'] == {'$pxt': 'file', 'name': 'cat.png', 'v': 'uploads/req/0.png'}
         assert row['img'] == {'$pxt': 'image', 'format': 'PNG', 'v': 'uploads/req/1.png'}
         assert row['data'] == {'$pxt': 'bytes', 'v': 0}
@@ -96,6 +102,80 @@ class TestProxyDaemon:
         assert sink.binary_parts[0] == (tmp_path / 'cat.png').read_bytes()
         assert sink.binary_parts[2] == b'abc'
         assert proxy_protocol.collect_remote_keys(wire) == []
+
+    def test_scalar_out_of_band_threshold(self, tmp_path: pathlib.Path) -> None:
+        """bytes and ndarrays follow the media path once they are big enough to be worth an upload."""
+        threshold = proxy_protocol.PxtStorePartSink._MIN_OUT_OF_BAND_SIZE
+        big_blob = b'x' * threshold
+        big_arr = np.arange(threshold, dtype=np.int64)  # 8 bytes per element, so well over the threshold
+        args = {
+            'rows': [
+                {
+                    'small_blob': b'y' * (threshold - 1),
+                    'big_blob': big_blob,
+                    'small_arr': np.zeros(1, dtype=np.int8),
+                    'big_arr': big_arr,
+                }
+            ]
+        }
+        sink = _RemotePartSink()
+        wire = proxy_protocol.serialize_args(args, sink)
+        row = wire['rows'][0]
+
+        # a value under the threshold is still inline; the extension names the payload's own format
+        assert row['small_blob'] == {'$pxt': 'bytes', 'v': 0}
+        assert row['small_arr'] == {'$pxt': 'ndarray', 'v': 1}
+        assert row['big_blob'] == {'$pxt': 'bytes', 'v': 'uploads/req/0.bin'}
+        assert row['big_arr'] == {'$pxt': 'ndarray', 'v': 'uploads/req/1.npy'}
+        assert len(sink.binary_parts) == 2
+        assert proxy_protocol.collect_remote_keys(wire) == ['uploads/req/0.bin', 'uploads/req/1.npy']
+
+        # the daemon resolves each key to the file it pre-downloaded, and the values come back unchanged
+        remote_parts: dict[str, str] = {}
+        for key, data in sink.objects.items():
+            local = tmp_path / key.replace('/', '_')
+            local.write_bytes(data)
+            remote_parts[key] = str(local)
+        out_row = proxy_protocol._deserialize(wire, sink.binary_parts, {}, remote_parts)['rows'][0]
+        assert out_row['small_blob'] == b'y' * (threshold - 1)
+        assert out_row['big_blob'] == big_blob
+        assert np.array_equal(out_row['small_arr'], np.zeros(1, dtype=np.int8))
+        assert np.array_equal(out_row['big_arr'], big_arr)
+        assert out_row['big_arr'].dtype == big_arr.dtype
+
+        # an out-of-band scalar cannot be read by a receiver with no access to the uploads
+        with pxt_raises(pxt.ErrorCode.INVALID_CONFIGURATION, match='has no access to uploaded objects'):
+            proxy_protocol._deserialize(wire, sink.binary_parts, None, None)
+
+    def test_scalars_reach_a_handler_from_the_object_store(
+        self, init_env: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End to end on the daemon side: prefetch localizes an uploaded scalar, dispatch decodes it."""
+        arr = np.arange(64, dtype=np.float32)
+        npy = io.BytesIO()
+        np.save(npy, arr, allow_pickle=False)
+        objects = {'req/0.bin': b'z' * 1024, 'req/1.npy': npy.getvalue()}
+        self._install_fake_upload_store(monkeypatch, objects, [])
+        seen: list[Any] = []
+
+        def echo_handler(request: proxy_protocol.ProxyRequest) -> None:
+            seen.append(proxy_protocol.deserialize_request(request))
+
+        monkeypatch.setitem(proxy_dispatch._HANDLERS, ('CatalogBase', 'echo_test'), echo_handler)
+        request = proxy_protocol.ProxyRequest(
+            class_name='CatalogBase',
+            method='echo_test',
+            args={
+                'blob': {'$pxt': 'bytes', 'v': 'uploads/req/0.bin'},
+                'arr': {'$pxt': 'ndarray', 'v': 'uploads/req/1.npy'},
+            },
+        )
+        head, _ = proxy_protocol.decode_body(proxy_dispatch.handle(request.model_dump_json(), []))
+        assert json.loads(head).get('error') is None
+        assert seen[0]['blob'] == objects['req/0.bin']
+        assert np.array_equal(seen[0]['arr'], arr)
+        # handle() removed the files it localized for the request
+        assert not any(pathlib.Path(p).exists() for p in request._remote_parts.values())
 
     def test_response_round_trip(self) -> None:
         """The generic response path preserves every value it is given."""
@@ -149,11 +229,22 @@ class TestProxyDaemon:
             'rows': [{'img': {'$pxt': 'image', 'format': 'PNG', 'v': 'uploads/r/2.png'}, 'dup': dict(file_tag)}],
             # keys inside nested containers are found
             'nested': {'$pxt': 'tuple', 'v': [{'$pxt': 'file', 'name': 'c', 'v': 'uploads/r/3'}]},
-            # int-indexed (inline) media and non-media str tags are not remote keys
+            # scalars that outgrew the inline threshold carry keys of their own
+            'blob': {'$pxt': 'bytes', 'v': 'uploads/r/4.bin'},
+            'arr': {'$pxt': 'ndarray', 'v': 'uploads/r/5.npy'},
+            # int-indexed (inline) parts and str tags that are not parts at all are not remote keys
             'inline': {'$pxt': 'file', 'name': 'd', 'v': 0},
-            'not_media': {'$pxt': 'mediapath', 'v': 'uploads/r/9.png'},
+            'inline_blob': {'$pxt': 'bytes', 'v': 1},
+            'not_a_part': {'$pxt': 'mediapath', 'v': 'uploads/r/9.png'},
         }
-        expected = ['uploads/r/0.png', 'uploads/r/1.png', 'uploads/r/2.png', 'uploads/r/3']
+        expected = [
+            'uploads/r/0.png',
+            'uploads/r/1.png',
+            'uploads/r/2.png',
+            'uploads/r/3',
+            'uploads/r/4.bin',
+            'uploads/r/5.npy',
+        ]
         assert proxy_protocol.collect_remote_keys(args) == expected
 
     def test_prepare_once_on_stale_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -302,7 +393,7 @@ class TestProxyDaemon:
 
         # keys outside uploads/ (e.g. persisted store objects) are rejected before any download
         with pxt_raises(
-            pxt.ErrorCode.INVALID_ARGUMENT, match=r"Invalid uploaded media object key: 'pixeltable/data/foo\.png'"
+            pxt.ErrorCode.INVALID_ARGUMENT, match=r"Invalid uploaded object key: 'pixeltable/data/foo\.png'"
         ):
             proxy_dispatch._prefetch_remote_parts(self._remote_file_request('pixeltable/data/foo.png'))
 

--- a/tests/test_proxy_daemon.py
+++ b/tests/test_proxy_daemon.py
@@ -103,50 +103,6 @@ class TestProxyDaemon:
         assert sink.binary_parts[2] == b'abc'
         assert proxy_protocol.collect_remote_keys(wire) == []
 
-    def test_scalar_out_of_band_threshold(self, tmp_path: pathlib.Path) -> None:
-        """bytes and ndarrays follow the media path once they are big enough to be worth an upload."""
-        threshold = proxy_protocol.PxtStorePartSink._MIN_OUT_OF_BAND_SIZE
-        big_blob = b'x' * threshold
-        big_arr = np.arange(threshold, dtype=np.int64)  # 8 bytes per element, so well over the threshold
-        args = {
-            'rows': [
-                {
-                    'small_blob': b'y' * (threshold - 1),
-                    'big_blob': big_blob,
-                    'small_arr': np.zeros(1, dtype=np.int8),
-                    'big_arr': big_arr,
-                }
-            ]
-        }
-        sink = _RemotePartSink()
-        wire = proxy_protocol.serialize_args(args, sink)
-        row = wire['rows'][0]
-
-        # a value under the threshold is still inline; the extension names the payload's own format
-        assert row['small_blob'] == {'$pxt': 'bytes', 'v': 0}
-        assert row['small_arr'] == {'$pxt': 'ndarray', 'v': 1}
-        assert row['big_blob'] == {'$pxt': 'bytes', 'v': 'uploads/req/0.bin'}
-        assert row['big_arr'] == {'$pxt': 'ndarray', 'v': 'uploads/req/1.npy'}
-        assert len(sink.binary_parts) == 2
-        assert proxy_protocol.collect_remote_keys(wire) == ['uploads/req/0.bin', 'uploads/req/1.npy']
-
-        # the daemon resolves each key to the file it pre-downloaded, and the values come back unchanged
-        remote_parts: dict[str, str] = {}
-        for key, data in sink.objects.items():
-            local = tmp_path / key.replace('/', '_')
-            local.write_bytes(data)
-            remote_parts[key] = str(local)
-        out_row = proxy_protocol._deserialize(wire, sink.binary_parts, {}, remote_parts)['rows'][0]
-        assert out_row['small_blob'] == b'y' * (threshold - 1)
-        assert out_row['big_blob'] == big_blob
-        assert np.array_equal(out_row['small_arr'], np.zeros(1, dtype=np.int8))
-        assert np.array_equal(out_row['big_arr'], big_arr)
-        assert out_row['big_arr'].dtype == big_arr.dtype
-
-        # an out-of-band scalar cannot be read by a receiver with no access to the uploads
-        with pxt_raises(pxt.ErrorCode.INVALID_CONFIGURATION, match='has no access to uploaded objects'):
-            proxy_protocol._deserialize(wire, sink.binary_parts, None, None)
-
     def test_scalars_reach_a_handler_from_the_object_store(
         self, init_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -159,10 +159,9 @@ class TestQuery:
         with pxt_raises(pxt.ErrorCode.INVALID_STATE, match=r'where\(\) clause already specified'):
             _ = t.select(t.c2).where(t.c2 <= 10).where(t.c2 <= 20).count()
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails due to server timeout [PXT-1319]')
     def test_join(self, db_root: DatabaseRoot) -> None:
         p = db_root.make_catalog_path
-        num_rows = 1000
+        num_rows = 100 if db_root.id == 'cloud' else 1000
         t1, t2, t3 = self.create_join_tbls(num_rows, p)
         # inner join
         query = t1.join(t2, on=t1.id, how='inner').select(t1.i, t2.f, out=t1.i + t2.f).order_by(t2.f)
@@ -187,19 +186,19 @@ class TestQuery:
         # left outer join
         query = t1.join(t3, on=t1.id, how='left').select(t1.i, t3.f, out=t1.i + t3.f).order_by(t1.i)
         pd_df = query.collect().to_pandas()
-        assert len(pd_df) == 1000
-        assert len(pd_df[~pd_df.f.isnull()]) == 100  # correct number of nulls
-        assert (pd_df[~pd_df.f.isnull()].out == 1000.0).all()  # correct sum
+        assert len(pd_df) == num_rows
+        assert len(pd_df[~pd_df.f.isnull()]) == num_rows // 10  # correct number of nulls
+        assert (pd_df[~pd_df.f.isnull()].out == float(num_rows)).all()  # correct sum
 
         # full outer join:
         # - t1 ids are 0..999, t3 ids are 0,10,...,9990
         # - 100 ids match, 900 are t1-only, and 900 are t3-only
         query = t1.join(t3, on=t1.id == t3.id, how='full_outer').select(left_i=t1.i, right_f=t3.f)
         pd_df = query.collect().to_pandas()
-        assert len(pd_df) == 1900
-        assert len(pd_df[pd_df.left_i.isnull()]) == 900  # t3-only rows
-        assert len(pd_df[pd_df.right_f.isnull()]) == 900  # t1-only rows
-        assert len(pd_df[pd_df.left_i.notnull() & pd_df.right_f.notnull()]) == 100  # matched rows
+        assert len(pd_df) == num_rows * 19 // 10
+        assert len(pd_df[pd_df.left_i.isnull()]) == num_rows * 9 // 10  # t3-only rows
+        assert len(pd_df[pd_df.right_f.isnull()]) == num_rows * 9 // 10  # t1-only rows
+        assert len(pd_df[pd_df.left_i.notnull() & pd_df.right_f.notnull()]) == num_rows // 10  # matched rows
 
         # TODO: implement right outer join
         # # right outer join
@@ -214,7 +213,8 @@ class TestQuery:
         # assert (pd_df[~pd_df.f.isnull()].out == 1000.0).all()  # correct sum
 
         # cross join
-        small_t1, small_t2, _ = self.create_join_tbls(100, p)
+        num_cj_rows = num_rows // 10
+        small_t1, small_t2, _ = self.create_join_tbls(num_cj_rows, p)
         query = small_t1.join(small_t2, how='cross').select(small_t1.i, small_t2.f, out=small_t1.i + small_t2.f)
         res = query.collect()
         # TODO: verify result
@@ -222,7 +222,7 @@ class TestQuery:
         # inner join with aggregation and explicit join predicate
         query = t1.join(t2, on=t1.id == t2.id).select(pxt.functions.sum(t1.i + t2.id))
         res = query.collect()[0, 0]
-        assert res == sum(range(1000)) * 2
+        assert res == sum(range(num_rows)) * 2
 
         # inner join with grouping aggregation
         query = t1.join(t2, on=t2.id).group_by(t2.id % 10).select(grp=t2.id % 10, val=pxt.functions.sum(t1.i + t2.id))
@@ -1258,7 +1258,7 @@ class TestQuery:
         assert all('a' in row and 'b' in row for row in rows)
 
     @pytest.mark.benchmark(group='select_inexpensive')
-    @pytest.mark.db_roots('local', 'proxy', reason='Fails due to server timeout [PXT-1319]')
+    @pytest.mark.db_roots('local', reason='Benchmark test is intended for local only')
     def test_select_inexpensive(self, db_root: DatabaseRoot, benchmark: Any) -> None:
         p = db_root.make_catalog_path
         t = pxt.create_table(p('test_inexpensive'), {'c1': pxt.Int | None, 'c2': pxt.String | None})

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2422,7 +2422,6 @@ class TestTable:
             assert container.streams.video[0].codec_context.name == 'h264'
 
     @rerun_on_network_error()
-    @pytest.mark.db_roots('local', 'proxy', reason='Cloud service hangs on first insert [PXT-1320]')
     def test_create_video_table(self, db_root: DatabaseRoot) -> None:
         if Env.get().is_using_cockroachdb:
             # TODO(PXT-921): fix this on CockroachDB
@@ -2474,7 +2473,7 @@ class TestTable:
 
         # drop() clears stored images and the cache
         tbl.insert(payload=1, video=get_video_files()[0])
-        with pxt_raises(pxt.ErrorCode.CONSTRAINT_VIOLATION, match="the following depend on it: 'test_view'"):
+        with pxt_raises(pxt.ErrorCode.CONSTRAINT_VIOLATION, match=r"the following depend on it: '.*test_view'"):
             pxt.drop_table(p('test_tbl'))
         pxt.drop_table(p('test_view'))
         pxt.drop_table(p('test_tbl'))

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -3312,7 +3312,6 @@ class TestTable:
     def img_fn_with_exc(img: PIL.Image.Image) -> PIL.Image.Image:
         raise RuntimeError
 
-    @pytest.mark.db_roots('local', 'proxy', reason='Cloud service hangs on first insert [PXT-1320]')
     def test_computed_img_cols(self, db_root: DatabaseRoot) -> None:
         p = db_root.make_catalog_path
         schema: dict[str, Any] = {'img': pxt.Image | None}


### PR DESCRIPTION
- Upload `bytes` and `ndarray`s out of band via the same pathway (home bucket intermediary) used for media objects. (Data of less than 512 bytes is still inlined.)
- Reduce the footprint of certain tests in `'cloud'` configuration
- Set `memory_mb = 2048` on the cloud DB configuration in `pyproject.toml`