### PR TITLE
Docs Updates: Name first-run commands so a pip 0.7.6 reader types pxt schema update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Hand the agent [get-started.md](https://www.pixeltable.com/get-started.md). That
 npx skills add pixeltable/pixeltable-skill
 ```
 
-The skill writes a `TableModel` in `app.py`. If the agent writes `create_table` in application code, `schema.py`, or `pxt serve`, the installed skill is stale: reinstall `npx skills add pixeltable/pixeltable-skill`.
+The skill writes a `TableModel` in `app.py`. If the agent writes `create_table` in application code, names the file `schema.py`, or writes the removed command `pxt serve`, the installed skill is stale: reinstall `npx skills add pixeltable/pixeltable-skill`.
 
 Notebooks and tests still use `pxt.create_table()`. An app puts tables in `app.py` and creates them with `pxt schema update`.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ pxt schema update app.py pxt://org:mydb
 pxt service update app.py pxt://org:mydb
 ```
 
+A `@pxt.udf` in that same `app.py` is in the image `pxt db update` builds.
+
 ## Chat agent or video search
 
 [`uvx pixeltable-new`](https://github.com/pixeltable/pixeltable-new) copies one app from the [starter kit](https://github.com/pixeltable/pixeltable-starter-kit). The default copy is a chat app; pass `agent` as the last argument to `pxt schema update`. `--video` copies video search; pass `videointel`.
@@ -113,7 +115,7 @@ Hand the agent [get-started.md](https://www.pixeltable.com/get-started.md). That
 npx skills add pixeltable/pixeltable-skill
 ```
 
-Skill **2.8.0+** writes a `TableModel` in `app.py`. If your agent emits `create_table` in application code, the installed skill is stale: reinstall it.
+The skill writes a `TableModel` in `app.py`. If the agent writes `create_table` in application code, `schema.py`, or `pxt serve`, the installed skill is stale: reinstall `npx skills add pixeltable/pixeltable-skill`.
 
 Notebooks and tests still use `pxt.create_table()`. An app puts tables in `app.py` and creates them with `pxt schema update`.
 

--- a/docs/release/docs.json
+++ b/docs/release/docs.json
@@ -5,7 +5,7 @@
   "description": "The only open source Python library providing declarative data infrastructure for building multimodal AI applications, enabling incremental storage, transformation, indexing, retrieval, and orchestration of data.",
   "markdown": {
     "instructions": [
-      "Application code declares a TableModel in app.py, then runs `pxt schema update app.py <target>` to create the tables and `pxt service update` to serve routes. Do not call pxt.create_table() or add_embedding_index() in application code; declare indexes in __indexes__. Notebooks, tests, and the REPL do use pxt.create_table().",
+      "Application code puts a TableModel in app.py, then runs `pxt schema update app.py my_app` to create the tables and `pxt service update app.py my_app` to start HTTP. The last argument can be a Cloud URL such as `pxt://org:db`. Do not call pxt.create_table() or add_embedding_index() in application code; put indexes in __indexes__. Notebooks, tests, and the REPL do use pxt.create_table().",
       "Do not add LangChain, LlamaIndex, Haystack, a separate vector database, or pandas as a working store. Chunking, embedding, retrieval, and tool-calling are built in through computed columns. Use a computed column instead of a per-row loop that calls a model.",
       "Install with `pip install -U 'pixeltable[serve]'` on Python 3.11+. `pxt init` is a prerequisite for `pxt schema update`.",
       "Pixeltable Cloud is in Limited Beta. Direct interested users to contact@pixeltable.com."

--- a/docs/release/overview/how-it-works.mdx
+++ b/docs/release/overview/how-it-works.mdx
@@ -41,7 +41,7 @@ Set `base=Docs` to make a view of `Docs`. The view can use columns from that bas
 
 `pxt schema example` writes a long sample. `--brief` writes only a small set of classes. Create tables with `pxt schema update app.py my_app`. Extra tables in that namespace stay until you run `pxt schema prune`, which deletes them.
 
-A `@pxt.udf` defined in `app.py` is recorded by file path. A script run as `__main__` is refused. Renaming `app.py` leaves columns that call it unable to compute. On Cloud, `pxt db update` puts the project in the image so workers can resolve that path ([Deploy to Pixeltable Cloud](/howto/deployment/cloud)).
+`pxt schema update` imports `app.py` as a module, so a `@pxt.udf` there is recorded by file path. A UDF defined in a script you run with `python app.py` is refused. Renaming `app.py` leaves columns that call it unable to compute. On Cloud, `pxt db update` puts the project in the image so workers can resolve that path ([Deploy to Pixeltable Cloud](/howto/deployment/cloud)).
 
 ## Services
 

--- a/docs/release/overview/how-it-works.mdx
+++ b/docs/release/overview/how-it-works.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'How it works'
 sidebarTitle: 'How it works'
-description: 'pxt schema creates tables. pxt service starts the endpoints. diff shows what would change.'
+description: 'pxt schema update creates tables. pxt service update starts the endpoints. diff shows what would change.'
 ---
 
-[Quickstart](/overview/quick-start) is the first run. This page explains what `pxt schema` and `pxt service` do, and what the last argument names.
+[Quickstart](/overview/quick-start) is the first run. This page explains what `pxt schema update` and `pxt service update` do, and what the last argument names.
 
 One Python file declares tables and, if you want endpoints, routes. `pxt schema update` creates the tables. `pxt service update` starts the endpoints on an assigned port. The last argument is a catalog such as `my_app`, or a `pxt://org:db` URI for Cloud. It does not create a folder beside `app.py`.
 
@@ -26,7 +26,7 @@ Your repo holds `app.py` and usually `pixeltable.toml`. After `pxt schema update
 
 | Command | What it does |
 |---|---|
-| `diff` | Prints pending changes without applying them |
+| `diff` | Prints pending changes; does not run `update` |
 | `update` | Creates or migrates tables or services so they match `app.py` |
 | `prune` | Deletes tables or services that are no longer in the file |
 | `example` | Write a working file to start from |
@@ -35,13 +35,13 @@ Full flags: [CLI](/platform/cli).
 
 ## Schema
 
-An annotation (`title: pxt.String`) is a stored column: you insert that value. A bare type is required; use `pxt.String | None` when the value may be missing. An assignment (`title_upper = ...`) is a computed column. It runs on insert and on update. Use `pxt.Column(...)` when you need a primary key, `stored=False`, or a media option an annotation cannot express.
+An annotation (`title: pxt.String`) is a stored column: you insert that value. A bare type is required; use `pxt.String | None` when the value may be missing. Cast a JSON path such as `transcript.text` with `.astype(pxt.String | None)` when the value can be missing. `.astype(pxt.String)` aborts the insert if the value is None. An assignment (`title_upper = ...`) is a computed column. It runs on insert and on update. Use `pxt.Column(...)` when you need a primary key, `stored=False`, or a media option an annotation cannot express.
 
-Set `base=Docs` to make a view of `Docs`. The view can use columns from that base. Add an iterator when each input row should become many output rows, such as frames or chunks. Indexes belong on the model (`__indexes__` with `EmbeddingIndex` or `BtreeIndex`). B-tree indexes are not created automatically. Do not call `add_embedding_index()` after `pxt schema update`.
+Set `base=Docs` to make a view of `Docs`. The view can use columns from that base. Add an iterator when each input row should become many output rows, such as frames or chunks. A view (`base=`) cannot use `group_by`, aggregates, `order_by`, `limit`, or `join`. `.group_by()` on that view is allowed at query time ([Views](/platform/views)). Indexes belong on the model (`__indexes__` with `EmbeddingIndex` or `BtreeIndex`). B-tree indexes are not created automatically. Do not call `add_embedding_index()` after `pxt schema update`.
 
 `pxt schema example` writes a long sample. `--brief` writes only a small set of classes. Create tables with `pxt schema update app.py my_app`. Extra tables in that namespace stay until you run `pxt schema prune`, which deletes them.
 
-A `@pxt.udf` defined in the file is recorded by file path. Renaming the file leaves columns that call it unable to compute.
+A `@pxt.udf` defined in `app.py` is recorded by file path. A script run as `__main__` is refused. Renaming `app.py` leaves columns that call it unable to compute. On Cloud, `pxt db update` puts the project in the image so workers can resolve that path ([Deploy to Pixeltable Cloud](/howto/deployment/cloud)).
 
 ## Services
 

--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -140,7 +140,7 @@ Tables live under `~/.pixeltable` (`pgdata`, `media`, `file_cache`). That path i
 </Tabs>
 
 <Note>
-This quickstart uses a `TableModel` in `app.py` and creates the tables with `pxt schema update`. Notebooks and tests can still call `pxt.create_table()`, `add_computed_column()`, and `add_embedding_index()`. The skill writes that `TableModel`. If the agent writes `create_table` in app code, `schema.py`, or `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
+This quickstart uses a `TableModel` in `app.py` and creates the tables with `pxt schema update`. Notebooks and tests can still call `pxt.create_table()`, `add_computed_column()`, and `add_embedding_index()`. The skill writes that `TableModel`. If the agent writes `create_table` in app code, names the file `schema.py`, or writes the removed command `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
 </Note>
 
 ## Next

--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -98,7 +98,7 @@ Python 3.11+ on Linux, macOS, or Windows. Tables, computed columns, and endpoint
 |---|---|
 | `pxt init` | Mark this directory as a project root |
 | `pxt service example --out app.py` | Write a working file: models plus routes |
-| `pxt schema example --out schema.py` | Schema only. `--brief` writes a small set of classes; without it, every DSL construct |
+| `pxt schema example --out app.py` | Schema only. `--brief` writes a small set of classes; without it, every DSL construct |
 | `pxt schema update FILE my_app` | Create and migrate the tables `FILE` declares under last argument `my_app` |
 | `pxt service update FILE my_app` | Start the services `FILE` declares against those tables |
 | `pxt service list` | What is running, and the URL |
@@ -140,7 +140,7 @@ Tables live under `~/.pixeltable` (`pgdata`, `media`, `file_cache`). That path i
 </Tabs>
 
 <Note>
-This quickstart uses a `TableModel` in `app.py` and creates the tables with `pxt schema update`. Notebooks and tests can still call `pxt.create_table()`, `add_computed_column()`, and `add_embedding_index()`. Skill **2.8.0+** writes that `TableModel`. If the agent writes `create_table` in app code, `schema.py`, or `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
+This quickstart uses a `TableModel` in `app.py` and creates the tables with `pxt schema update`. Notebooks and tests can still call `pxt.create_table()`, `add_computed_column()`, and `add_embedding_index()`. The skill writes that `TableModel`. If the agent writes `create_table` in app code, `schema.py`, or `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
 </Note>
 
 ## Next

--- a/docs/release/platform/cli.mdx
+++ b/docs/release/platform/cli.mdx
@@ -99,10 +99,10 @@ pxt pwd                            # print it
 pxt init                             # mark the current directory as a project root
 
 # declarative schemas
-pxt schema check  schema.py          # validate the file on its own, with no target
-pxt schema diff   schema.py my_app   # what 'update' would change (exit 2 = drift)
-pxt schema update schema.py my_app   # create and migrate the declared tables
-pxt schema prune  schema.py my_app -f # drop the undeclared ones
+pxt schema check  app.py          # validate the file on its own, with no target
+pxt schema diff   app.py my_app   # what 'update' would change (exit 2 = drift)
+pxt schema update app.py my_app   # create and migrate the declared tables
+pxt schema prune  app.py my_app -f # drop the undeclared ones
 
 # interactive
 pxt shell
@@ -410,7 +410,7 @@ Imports resolve from the root down. This is where a single-file recipe and a lar
 A recorded path is how a later process -- the daemon, a serving worker, a hosted pod -- finds the udf again, so a command given a file outside any project root is refused. `pxt schema check` and `pxt service check` validate a file on its own -- it imports without touching the catalog, it declares what the verb needs, and the udfs its columns call are named by paths another process can resolve:
 
 ```bash
-pxt schema check schema.py           # exit 0 valid, 1 invalid
+pxt schema check app.py           # exit 0 valid, 1 invalid
 pxt service check app.py --json
 ```
 
@@ -433,7 +433,7 @@ The commands above act on one object at a time. `pxt schema` works differently: 
 A schema file defines one or more models on a `pxt.model_base()`. Each model becomes one table, named by `name=`. `pxt schema example` writes a file covering every construct the schema DSL supports, so you never have to start from a blank page and never have to look a construct up:
 
 ```bash
-pxt schema example --out schema.py
+pxt schema example --out app.py
 ```
 
 `pxt schema example --brief` writes the minimal version instead:
@@ -457,11 +457,11 @@ An annotation (`name: type`) declares a stored column; an assignment (`name = ex
 
 The daemon imports the file, so it must be readable there. Its own directory is added to `sys.path`, so it can import modules sitting next to it.
 
-### Reviewing and applying
+### Reviewing and updating
 
 ```bash
-pxt schema diff   schema.py my_app     # review
-pxt schema update schema.py my_app     # apply
+pxt schema diff   app.py my_app     # review
+pxt schema update app.py my_app     # create or migrate tables
 ```
 
 `diff` prints one line per table, then one per operation:
@@ -484,29 +484,29 @@ Plan: 0 create, 1 update, 1 unchanged, 1 extra  |  1 destructive
 | `-` | The column/index will be dropped |
 | `!` | The table cannot be migrated in place, or is not declared by the schema |
 
-### Applying
+### `pxt schema update`
 
 `update` creates missing tables and migrates existing ones, adding and dropping columns and indexes. It takes the same flags as the other mutations, plus one of its own:
 
 | Flag | Description |
 |---|---|
-| `-n`, `--dry-run` | Print the plan; apply nothing. Exit `2` if changes are pending |
+| `-n`, `--dry-run` | Print the plan; do not run `update`. Exit `2` if changes are pending |
 | `--allow-destructive` | Permit operations that drop a column or index |
 | `-f`, `--force` | Skip the `[y/N]` prompt shown before destructive operations |
 
 ```bash
-pxt schema update schema.py my_app                          # safe changes
-pxt schema update schema.py my_app -n                       # the plan, applying nothing
-pxt schema update schema.py my_app --allow-destructive -f   # including drops
+pxt schema update app.py my_app                          # safe changes
+pxt schema update app.py my_app -n                       # the plan; does not run `update`
+pxt schema update app.py my_app --allow-destructive -f   # including drops
 ```
 
-If the plan contains a destructive operation and `--allow-destructive` is absent, nothing at all is applied and `update` exits `3`.
+If the plan contains a destructive operation and `--allow-destructive` is absent, `update` does not change the catalog and exits `3`.
 
 <Warning>
 Dropping a column or an index destroys its data. Run `pxt schema diff` (or `update -n`) first: the plan marks every operation `safe`, `DESTRUCTIVE`, or `UNSUPPORTED`.
 </Warning>
 
-Some differences cannot be applied in place: a table declared where a view exists, a changed iterator, or a column whose type or properties changed. Those are reported as `UNSUPPORTED`, nothing is applied, and `update` exits `1`. Adjust the schema file or the table by hand.
+Some differences cannot be migrated in place: a table declared where a view exists, a changed iterator, or a column whose type or properties changed. Those are reported as `UNSUPPORTED`, `update` changes nothing, and it exits `1`. Adjust the application file or the table by hand.
 
 ### Exit codes
 
@@ -522,7 +522,7 @@ The schema commands report their outcome in the exit status, so a caller never h
 A drift check in CI is therefore one command:
 
 ```bash
-pxt schema diff schema.py pxt://acme:main/prod    # 0 = in sync, 2 = drift, 1 = error
+pxt schema diff app.py pxt://acme:main/prod    # 0 = in sync, 2 = drift, 1 = error
 ```
 
 ### Machine-readable plans
@@ -570,8 +570,8 @@ Every path returns the plan, including the ones that refuse before reaching the 
 | `-f`, `--force` | Skip the `[y/N]` prompt |
 
 ```bash
-pxt schema prune schema.py my_app -n     # list what would be dropped
-pxt schema prune schema.py my_app -f     # drop it
+pxt schema prune app.py my_app -n     # list what would be dropped
+pxt schema prune app.py my_app -f     # drop it
 ```
 
 Only tables under `TARGET` are considered, so nothing elsewhere in the catalog is affected, and declared tables are never dropped. A view is dropped before its base. Prune never force-drops: a table that something outside the pruned set depends on is left in place and the drop fails, naming what depends on it.
@@ -632,7 +632,7 @@ pxt schema update app.py my_dir     # create the tables the models declare
 pxt service update app.py my_dir    # serve this file's services against them
 ```
 
-`TARGET` is the catalog the models bind against, so one file can be applied to a development
+`TARGET` is the catalog the models bind against, so the same file can run against a development
 directory and a production one.
 
 ### Serving your own application
@@ -713,7 +713,7 @@ Like the `schema` verbs, `diff` reports drift in its exit status: `0` in agreeme
 |---|---|---|
 | `--json` | all | Emit machine-readable JSON |
 | `-f`, `--force` | `update`, `prune` | Skip the `[y/N]` prompt |
-| `-n`, `--dry-run` | `update`, `prune` | Print the intended change; don't apply it |
+| `-n`, `--dry-run` | `update`, `prune` | Print the intended change; do not run `update` or `prune` |
 | `--allow-destructive` | `update` | Permit changes that stop serving a route callers may be using |
 | `--host`, `--port` | `run` | Bind address and port (default `127.0.0.1:8000`) |
 | `--otel` | `run`, `update`, `diff` | Emit OpenTelemetry traces; see [Tracing](#tracing) |
@@ -761,7 +761,7 @@ pxt service run app.py my_dir --port 9000
 
 ### Restarts
 
-A service binds its models once, when its process starts, so a changed declaration is applied by replacing
+A service binds its models once, when its process starts, so a changed declaration takes effect when `pxt service update` replaces
 the process. `diff` reports which services that would interrupt, and `update` says so before it does it.
 Adding a route is additive; changing or removing one stops serving a contract a caller may be using, so it
 needs `--allow-destructive`.
@@ -827,7 +827,7 @@ pxt db update pxt://myorg:mydb --allow-destructive
 
 | Flag | Description |
 |---|---|
-| `-n`, `--dry-run` | Print the plan without applying it |
+| `-n`, `--dry-run` | Print the plan; do not run `update` |
 | `-f`, `--force` | Skip the confirmation |
 | `--allow-destructive` | Permit taking capacity away or deleting a secret |
 

--- a/docs/release/resources/ai-skills.mdx
+++ b/docs/release/resources/ai-skills.mdx
@@ -17,7 +17,7 @@ npx skills add pixeltable/pixeltable-skill
 Source: [pixeltable/pixeltable-skill](https://github.com/pixeltable/pixeltable-skill).
 
 <Note>
-Skill **2.8.0+** is the version that writes `app.py`. If the agent writes `create_table` in app code, `schema.py`, or `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
+If the agent writes `create_table` in app code, `schema.py`, or `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
 </Note>
 
 ## What it teaches

--- a/docs/release/resources/ai-skills.mdx
+++ b/docs/release/resources/ai-skills.mdx
@@ -17,7 +17,7 @@ npx skills add pixeltable/pixeltable-skill
 Source: [pixeltable/pixeltable-skill](https://github.com/pixeltable/pixeltable-skill).
 
 <Note>
-If the agent writes `create_table` in app code, `schema.py`, or `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
+If the agent writes `create_table` in app code, names the file `schema.py`, or writes the removed command `pxt serve`, the installed skill is stale: this page wins. Reinstall: `npx skills add pixeltable/pixeltable-skill`.
 </Note>
 
 ## What it teaches


### PR DESCRIPTION
## Summary
- First-run copy now names `pxt schema update` / `pxt service update` with a last argument (`my_app` or `pxt://org:db`), so Mintlify cannot strip `<target>` and agents do not type a bare `pxt schema`.
- How it Works states three verified 0.7.6 facts: `.astype(pxt.String | None)`, a view (`base=`) cannot `group_by`, and `pxt db update` puts project UDFs in the image.
- Quickstart and CLI examples use `app.py`. The Skill 2.8.0+ pin is gone. User-facing CLI sentences name the command instead of "apply." `TARGET` stays the CLI metavar.