### PR TITLE
[PXT-1385] Honor on_error='ignore' for object-store put failures

### DIFF
--- a/pixeltable/exec/object_store_save_node.py
+++ b/pixeltable/exec/object_store_save_node.py
@@ -185,7 +185,6 @@ class ObjectStoreSaveNode(ExecNode):
             new_file_url, exc = f.result()
             if exc is not None and not ignore_errors:
                 raise exc
-            assert new_file_url is not None
 
             if exc is None:
                 num_objects += 1
@@ -196,6 +195,7 @@ class ObjectStoreSaveNode(ExecNode):
                 if exc is not None:
                     self.row_builder.set_exc(row, info.slot_idx, exc)
                 else:
+                    assert new_file_url is not None
                     row.file_urls[info.slot_idx] = new_file_url
 
                 state = self.in_flight_rows[id(row)]

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -369,6 +369,33 @@ class TestDestination:
         # Ensure that local file is copied to a specified destination
         assert ObjectOps.count(t._id, dest=dest1_uri) == len(r)
 
+    @pytest.mark.db_roots('local', reason='monkeypatches ObjectOps.put_file_resolved in-process')
+    def test_dest_put_failure_on_error_ignore(self, uses_db: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Persist failure with on_error='ignore' must record a cell error, not AssertionError (PXT-1385)."""
+        dest_uri = self.resolve_destination_uri(StorageTarget.LOCAL_STORE) + '/bucket1'
+        t = pxt.create_table('test_dest_put_fail', schema={'img': pxt.Image | None})
+        # Empty table: add_computed_column does not put yet.
+        t.add_computed_column(img_rot=t.img.rotate(90), destination=dest_uri)
+
+        def fail_put(_store: object, _src_path: Path, _dest: object, _relocate_or_delete: bool) -> str:
+            raise OSError('injected put failure')
+
+        monkeypatch.setattr(ObjectOps, 'put_file_resolved', staticmethod(fail_put))
+
+        rows = [{'img': 'tests/data/imagenette2-160/ILSVRC2012_val_00000557.JPEG'}]
+        with pytest.raises(OSError, match='injected put failure'):
+            t.insert(rows)
+
+        status = t.insert(rows, on_error='ignore')
+        assert status.num_rows == 1
+        assert status.num_excs >= 1
+        assert 'test_dest_put_fail.img_rot' in status.cols_with_excs
+        assert t.where(t.img_rot.errortype != None).count() == 1
+        err = t.select(msg=t.img_rot.errormsg, url=t.img_rot.fileurl).collect()[0]
+        assert 'injected put failure' in err['msg']
+        assert err['url'] is None
+        assert ObjectOps.count(t._id, dest=dest_uri) == 0
+
     @pytest.mark.very_expensive
     def test_dest_all(self, db_root: DatabaseRoot) -> None:
         """Test destination with all available storage targets"""


### PR DESCRIPTION
## Summary
- ObjectStoreSaveNode asserted `new_file_url is not None` before handling put exceptions, so `on_error='ignore'` crashed with `AssertionError` instead of recording a cell error (PXT-1385).
- Move the assert to the success path at the use site, matching `CachePrefetchNode`.
- Add a regression test that injects put failure for abort vs ignore.

## Test plan
- [x] `pytest tests/test_destination.py::TestDestination::test_dest_put_failure_on_error_ignore`
- [ ] CI slimtest / destination tests


Made with [Cursor](https://cursor.com)