### PR TITLE
Reject insert/compute routes whose inputs omit a required column

### DIFF
--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -2380,6 +2380,18 @@ class FastAPIRouter(fastapi.APIRouter):
             input_item_str='column',
             output_item_str='column',
         )
+        if route_type in ('insert', 'compute'):
+            # insert()/compute() reject a row that omits a required column, and the request model carries only
+            # input_col_names, so a caller cannot supply the rest
+            missing = [
+                name for name, col_type in input_schema.items() if not col_type.nullable and name not in input_col_names
+            ]
+            if len(missing) > 0:
+                raise pxt.RequestError(
+                    pxt.ErrorCode.MISSING_REQUIRED,
+                    f'{error_prefix}: required column(s) ({", ".join(missing)}) of '
+                    f'{defined_path.tbl_name()!r} are not among the inputs; every request would fail',
+                )
         return self.DmlArgsValidationResult(pk_col_names, input_col_names, output_col_names, cols_by_name)
 
     def _validate_args(

--- a/tests/serving/test_fastapi.py
+++ b/tests/serving/test_fastapi.py
@@ -1737,6 +1737,41 @@ class TestFastAPI:
             assert resp.status_code == 500, resp.text
             assert expected in resp.text, resp.text
 
+    def test_dml_routes_require_required_cols(self, db_root: DatabaseRoot) -> None:
+        """insert/compute routes reject an `inputs` list that omits a required column."""
+        p = db_root.make_catalog_path
+        skip_test_if_not_installed('fastapi')
+        from pixeltable.serving import FastAPIRouter
+
+        pxt.create_dir(p('test_serve'))
+        t = pxt.create_table(
+            p('test_serve/required_inputs'),
+            {'title': pxt.String, 'prod_id': pxt.String, 'note': pxt.String | None, 'thumb': pxt.Image},
+            primary_key='prod_id',
+        )
+        t.add_computed_column(title_upper=t.title.upper())
+
+        for route_type in ('insert', 'compute'):
+            router = FastAPIRouter()
+            with pxt_raises(pxt.ErrorCode.MISSING_REQUIRED, match=r'\(prod_id, thumb\) of .*required_inputs'):
+                add_dml_route(route_type, router, t, path='/x', inputs=['title'], outputs=['title_upper'])
+
+            # a nullable column may be left out, and a required media column may be covered by uploadfile_inputs
+            router = FastAPIRouter()
+            add_dml_route(
+                route_type,
+                router,
+                t,
+                path='/x',
+                inputs=['title', 'prod_id'],
+                uploadfile_inputs=['thumb'],
+                outputs=['title_upper'],
+            )
+
+        # update routes are unaffected: a partial column list is the point
+        router = FastAPIRouter()
+        router.add_update_route(t, path='/u', inputs=['title'], outputs=['title_upper'])
+
     def test_decorator_routes_allow_unservable_outputs(self, db_root: DatabaseRoot) -> None:
         """Decorator-form routes let user code handle outputs that add_*_route forms reject."""
         p = db_root.make_catalog_path


### PR DESCRIPTION
## The bug

`add_insert_route()` and `add_compute_route()` accept an `inputs` list that leaves out a non-nullable, non-computed column. The route registers without complaint and then fails **every** request.

Reproduced on `main`:

```python
t = pxt.create_table('d.products', {'title': pxt.String, 'prod_id': pxt.String, 'price': pxt.Float})
t.add_computed_column(title_upper=t.title.upper())

router.add_compute_route(t, path='/preview', inputs=['title'], outputs=['title_upper'])  # accepted
```

```text
POST /preview {"title": "headphones"}
-> 422 {"error_code":"MISSING_REQUIRED","message":"Missing required column(s) (prod_id, price) ..."}

POST /preview {"title": "headphones", "prod_id": "P1", "price": 10.0}
-> 422 {"error_code":"MISSING_REQUIRED","message":"Missing required column(s) (prod_id, price) in row {'title': 'headphones'}"}
```

The second call is the part that leaves no way out: the generated request model carries only the declared inputs, so Pydantic prunes `prod_id` and `price` before the row reaches `compute()`. The client cannot fix this from its side, and the failure only shows up at request time.

`add_insert_route()` behaves identically; both go through `_validate_dml_args()`.

## The fix

Check at declaration time that every required column of the input schema appears in `inputs` or `uploadfile_inputs`, and raise `MISSING_REQUIRED` naming the columns if not.

- Nullable columns may still be omitted.
- A required media column may be covered by `uploadfile_inputs` instead of `inputs`.
- Update routes are untouched: a partial column list is what they are for.

## Testing

`tests/serving/test_fastapi.py::test_dml_routes_require_required_cols` covers the rejection, both allowances, and the update-route exemption. Full `tests/serving/` suite passes (157 tests); ruff format, ruff check and mypy are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)