### PR TITLE
[PXT-1408] Give service/schema example scaffolds a primary key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
-    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)
@@ -215,7 +215,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
+    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.doc_id, Docs.title, Docs.title_upper]
 )
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
+    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)
@@ -214,7 +215,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
+    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
 )
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
-    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)
@@ -237,7 +237,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
+    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.doc_id, Docs.title, Docs.title_upper]
 )
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
+    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)
@@ -236,7 +237,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
+    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ def excerpt(text: str, n: int = 12) -> str:
 
 
 class Docs(TableModel, name='docs'):
-    doc_id: pxt.Int                             # an annotation: a value you insert
+    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)      # an assignment: computed on insert and on update

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ def excerpt(text: str, n: int = 12) -> str:
 
 
 class Docs(TableModel, name='docs'):
-    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)      # an assignment: computed on insert and on update
@@ -62,7 +62,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(                        # POST /docs inserts and returns the computed columns
-    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title_upper, Docs.summary]
+    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.doc_id, Docs.title_upper, Docs.summary]
 )
 ingest.add_compute_route(Docs, path='/titles', inputs=[Docs.title], outputs=[Docs.title_upper])
 ```
@@ -77,8 +77,8 @@ back rather than hardcoding it:
 URL=$(pxt service list --json | jq -r '.[0].endpoint')
 curl -X POST "$URL/docs" \
   -H 'Content-Type: application/json' \
-  -d '{"doc_id": 1, "title": "Hello", "body": "world"}'
-# {"title_upper":"HELLO","summary":"Hello"}
+  -d '{"title": "Hello", "body": "world"}'
+# {"doc_id":"...","title_upper":"HELLO","summary":"Hello"}
 ```
 
 The same file runs on Pixeltable Cloud. Create an API key in the [Cloud dashboard](https://docs.pixeltable.com/howto/deployment/cloud#get-an-api-key), set `PIXELTABLE_API_KEY`, name the database in `pixeltable.toml`, then target it by URI. `pxt db update` creates or updates the hosted database; it does not insert rows. `pxt service run` is local only and cannot target Cloud.

--- a/docs/release/howto/deployment/cloud.mdx
+++ b/docs/release/howto/deployment/cloud.mdx
@@ -61,6 +61,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
+    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)
@@ -68,7 +69,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
+    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
 )
 ```
 

--- a/docs/release/howto/deployment/cloud.mdx
+++ b/docs/release/howto/deployment/cloud.mdx
@@ -61,7 +61,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
-    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)
@@ -69,7 +69,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title, Docs.title_upper]
+    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.doc_id, Docs.title, Docs.title_upper]
 )
 ```
 

--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -52,7 +52,7 @@ Python 3.11+ on Linux, macOS, or Windows. Tables, computed columns, and endpoint
 
 
     class Docs(TableModel, name='docs'):
-        doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
+        doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
         title: pxt.String
         body: pxt.String | None
         title_upper = pxtf.string.upper(title)      # an assignment: computed on insert
@@ -61,12 +61,12 @@ Python 3.11+ on Linux, macOS, or Windows. Tables, computed columns, and endpoint
 
     ingest = FastAPIRouter(name='ingest')
     ingest.add_insert_route(
-        Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title_upper, Docs.summary]
+        Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.doc_id, Docs.title_upper, Docs.summary]
     )
     ingest.add_compute_route(Docs, path='/titles', inputs=[Docs.title], outputs=[Docs.title_upper])
     ```
 
-    `title: pxt.String` is a value you insert. `title_upper = ...` is computed on insert and on update. Row lookup (`pxt get`) and the errors view need a primary key, so `doc_id` uses `pxt.Column(..., primary_key=True)`. The same file can hold `pxt.Image`, `pxt.Video`, `pxt.Audio`, or `pxt.Document`: [media pipelines](/use-cases/media-processing), [RAG](/use-cases/multimodal-backend).
+    `title: pxt.String` is a value you insert. `title_upper = ...` is computed on insert and on update. `doc_id` is a `uuid7()` primary key: filled on insert, required for `pxt get` and the errors view. The same file can hold `pxt.Image`, `pxt.Video`, `pxt.Audio`, or `pxt.Document`: [media pipelines](/use-cases/media-processing), [RAG](/use-cases/multimodal-backend).
   </Step>
   <Step title="Create tables, then start the endpoints">
     ```bash
@@ -85,7 +85,7 @@ Python 3.11+ on Linux, macOS, or Windows. Tables, computed columns, and endpoint
     # my_app/ingest  http://127.0.0.1:<port>  pid 12345  app.py
     curl -X POST http://127.0.0.1:<port>/docs \
       -H 'Content-Type: application/json' \
-      -d '{"doc_id": 1, "title": "Hello", "body": "world"}'
+      -d '{"title": "Hello", "body": "world"}'
     ```
   </Step>
 </Steps>

--- a/docs/release/overview/quick-start.mdx
+++ b/docs/release/overview/quick-start.mdx
@@ -52,7 +52,7 @@ Python 3.11+ on Linux, macOS, or Windows. Tables, computed columns, and endpoint
 
 
     class Docs(TableModel, name='docs'):
-        doc_id: pxt.Int                             # an annotation: a value you insert
+        doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
         title: pxt.String
         body: pxt.String | None
         title_upper = pxtf.string.upper(title)      # an assignment: computed on insert
@@ -66,7 +66,7 @@ Python 3.11+ on Linux, macOS, or Windows. Tables, computed columns, and endpoint
     ingest.add_compute_route(Docs, path='/titles', inputs=[Docs.title], outputs=[Docs.title_upper])
     ```
 
-    `title: pxt.String` is a value you insert. `title_upper = ...` is computed on insert and on update. The same file can hold `pxt.Image`, `pxt.Video`, `pxt.Audio`, or `pxt.Document`: [media pipelines](/use-cases/media-processing), [RAG](/use-cases/multimodal-backend).
+    `title: pxt.String` is a value you insert. `title_upper = ...` is computed on insert and on update. Row lookup (`pxt get`) and the errors view need a primary key, so `doc_id` uses `pxt.Column(..., primary_key=True)`. The same file can hold `pxt.Image`, `pxt.Video`, `pxt.Audio`, or `pxt.Document`: [media pipelines](/use-cases/media-processing), [RAG](/use-cases/multimodal-backend).
   </Step>
   <Step title="Create tables, then start the endpoints">
     ```bash

--- a/docs/release/skill.md
+++ b/docs/release/skill.md
@@ -53,7 +53,7 @@ def excerpt(text: str, n: int = 12) -> str:
 
 
 class Docs(TableModel, name='docs'):
-    doc_id: pxt.Int                          # an annotation: a value you insert
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)   # an assignment: computed on insert
@@ -62,7 +62,7 @@ class Docs(TableModel, name='docs'):
 
 ingest = FastAPIRouter(name='ingest')
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title_upper, Docs.summary]
+    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.doc_id, Docs.title_upper, Docs.summary]
 )
 ingest.add_compute_route(Docs, path='/titles', inputs=[Docs.title], outputs=[Docs.title_upper])
 ```

--- a/pixeltable_cli/client/commands/get.py
+++ b/pixeltable_cli/client/commands/get.py
@@ -14,10 +14,10 @@ Examples:
   pxt get my_dir/my_table 42 --json
 
 Notes:
-  PK values are coerced to int or float when they parse as numbers; otherwise they stay
-  as strings. There is no way to force a string PK that looks like a number; if your PK
-  column is typed as string but the value is '42', the server will reject the type mismatch.
-  Use 'pxt describe <table>' to see the primary_key columns and their order.
+  PK values are coerced to int, float, or UUID when they parse as those types; otherwise
+  they stay as strings. There is no way to force a string PK that looks like a number; if
+  your PK column is typed as string but the value is '42', the server will reject the type
+  mismatch. Use 'pxt describe <table>' to see the primary_key columns and their order.
   Unstored computed columns are skipped by default; pass them explicitly via --cols to
   include them.
   The table must have a primary key defined."""

--- a/pixeltable_cli/client/commands/schema.py
+++ b/pixeltable_cli/client/commands/schema.py
@@ -26,7 +26,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
-    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     title: pxt.String                         # a stored column
     body: pxt.String | None                   # a stored column that may be null
     title_upper = pxtf.string.upper(title)    # a computed column: an assignment, not an annotation
@@ -65,8 +65,8 @@ def excerpt(text: str, n: int = 80) -> str:
 class Docs(TableModel, name='docs'):
     """One model becomes one table, named by name=."""
 
-    # pxt.Column declares a primary key; an annotation alone cannot
-    doc_id = pxt.Column(type=pxt.Int, primary_key=True)
+    # uuid7() fills the key on insert; primary_key needs pxt.Column (an annotation cannot set it)
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     # an annotation defines a stored column
     title: pxt.String
     body: pxt.String | None
@@ -95,7 +95,7 @@ class Docs(TableModel, name='docs'):
 class Recordings(TableModel, name='recordings'):
     """The other media types, and the column properties an annotation cannot express."""
 
-    recording_id = pxt.Column(type=pxt.Int, primary_key=True)
+    recording_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     cover: pxt.Image | None
     narration: pxt.Audio | None
     clip: pxt.Video | None

--- a/pixeltable_cli/client/commands/schema.py
+++ b/pixeltable_cli/client/commands/schema.py
@@ -26,6 +26,7 @@ TableModel = pxt.model_base()
 
 
 class Docs(TableModel, name='docs'):
+    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
     title: pxt.String                         # a stored column
     body: pxt.String | None                   # a stored column that may be null
     title_upper = pxtf.string.upper(title)    # a computed column: an assignment, not an annotation
@@ -64,8 +65,9 @@ def excerpt(text: str, n: int = 80) -> str:
 class Docs(TableModel, name='docs'):
     """One model becomes one table, named by name=."""
 
+    # pxt.Column declares a primary key; an annotation alone cannot
+    doc_id = pxt.Column(type=pxt.Int, primary_key=True)
     # an annotation defines a stored column
-    doc_id: pxt.Int
     title: pxt.String
     body: pxt.String | None
     published: pxt.Timestamp | None
@@ -93,7 +95,7 @@ class Docs(TableModel, name='docs'):
 class Recordings(TableModel, name='recordings'):
     """The other media types, and the column properties an annotation cannot express."""
 
-    recording_id: pxt.Int
+    recording_id = pxt.Column(type=pxt.Int, primary_key=True)
     cover: pxt.Image | None
     narration: pxt.Audio | None
     clip: pxt.Video | None

--- a/pixeltable_cli/client/commands/service.py
+++ b/pixeltable_cli/client/commands/service.py
@@ -48,7 +48,7 @@ def excerpt(text: str, n: int = 12) -> str:
 
 
 class Docs(TableModel, name='docs'):
-    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
+    doc_id = pxt.Column(value=pxtf.uuid.uuid7(), primary_key=True)
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)  # a computed column: an assignment, not an annotation
@@ -58,9 +58,9 @@ class Docs(TableModel, name='docs'):
 # the router names the service; without name= it takes the name of the variable holding it
 ingest = FastAPIRouter(name='ingest')
 
-# POST /docs inserts a row and returns the computed column
+# POST /docs inserts a row and returns the generated id plus computed columns
 ingest.add_insert_route(
-    Docs, path='/docs', inputs=[Docs.doc_id, Docs.title, Docs.body], outputs=[Docs.title_upper, Docs.summary]
+    Docs, path='/docs', inputs=[Docs.title, Docs.body], outputs=[Docs.doc_id, Docs.title_upper, Docs.summary]
 )
 
 # POST /titles computes without storing a row

--- a/pixeltable_cli/client/commands/service.py
+++ b/pixeltable_cli/client/commands/service.py
@@ -48,7 +48,7 @@ def excerpt(text: str, n: int = 12) -> str:
 
 
 class Docs(TableModel, name='docs'):
-    doc_id: pxt.Int
+    doc_id = pxt.Column(type=pxt.Int, primary_key=True)  # row lookup and the errors view need a primary key
     title: pxt.String
     body: pxt.String | None
     title_upper = pxtf.string.upper(title)  # a computed column: an assignment, not an annotation

--- a/pixeltable_cli/server/routes.py
+++ b/pixeltable_cli/server/routes.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import typing
 import urllib.parse
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -636,9 +637,10 @@ _COUNT_POOL_WORKERS = 16
 
 
 def _coerce_pk(s: str) -> Any:
-    """Numeric-looking PK strings become int or float; everything else stays a string.
+    """Restore a typed PK value from an untyped HTTP string.
 
-    PK values arrive untyped over HTTP, so we restore their natural type here.
+    Numeric-looking tokens become int or float. UUID tokens become ``uuid.UUID``.
+    Everything else stays a string.
     """
     try:
         return int(s)
@@ -646,6 +648,10 @@ def _coerce_pk(s: str) -> Any:
         pass
     try:
         return float(s)
+    except ValueError:
+        pass
+    try:
+        return uuid.UUID(s)
     except ValueError:
         return s
 

--- a/tests/pixeltable_cli/test_schema.py
+++ b/tests/pixeltable_cli/test_schema.py
@@ -594,7 +594,8 @@ class TestSchema:
         r = cli('schema', 'update', str(schema_file), target)
         assert r.stdout.count('created') == 2
         docs = pxt.get_table(f'{target}/docs')
-        docs.insert([{'title': 'hello', 'body': 'world'}, {'title': '', 'body': 'untitled'}])
+        assert docs.get_metadata()['primary_key'] == ['doc_id']
+        docs.insert([{'doc_id': 1, 'title': 'hello', 'body': 'world'}, {'doc_id': 2, 'title': '', 'body': 'untitled'}])
         titled = pxt.get_table(f'{target}/titled')
         assert titled.select(titled.headline).collect()['headline'] == ['HELLO!']
         assert_in_agreement(cli, str(schema_file), target)
@@ -604,6 +605,7 @@ class TestSchema:
         r = cli('schema', 'example', '--brief', '--out', str(out_file))
         assert f'wrote {out_file}' in r.stdout
         assert out_file.read_text() == schema_file.read_text()
+        assert 'primary_key=True' in schema_file.read_text()
         cli('schema', 'example', '--out', str(out_file))
         assert out_file.read_text() == cli('schema', 'example').stdout
 
@@ -611,7 +613,15 @@ class TestSchema:
         full = out_file.read_text()
         assert all(
             construct in full
-            for construct in ('pxt.Column(', 'pxt.EmbeddingIndex(', 'iterator=', 'base=', 'pxt.Document', '@pxt.udf')
+            for construct in (
+                'primary_key=True',
+                'pxt.Column(',
+                'pxt.EmbeddingIndex(',
+                'iterator=',
+                'base=',
+                'pxt.Document',
+                '@pxt.udf',
+            )
         )
         # it has to be a file the daemon can import and plan, media types and embedding index included
         full_target = p('full_example')

--- a/tests/pixeltable_cli/test_schema.py
+++ b/tests/pixeltable_cli/test_schema.py
@@ -595,7 +595,7 @@ class TestSchema:
         assert r.stdout.count('created') == 2
         docs = pxt.get_table(f'{target}/docs')
         assert docs.get_metadata()['primary_key'] == ['doc_id']
-        docs.insert([{'doc_id': 1, 'title': 'hello', 'body': 'world'}, {'doc_id': 2, 'title': '', 'body': 'untitled'}])
+        docs.insert([{'title': 'hello', 'body': 'world'}, {'title': '', 'body': 'untitled'}])
         titled = pxt.get_table(f'{target}/titled')
         assert titled.select(titled.headline).collect()['headline'] == ['HELLO!']
         assert_in_agreement(cli, str(schema_file), target)
@@ -605,7 +605,6 @@ class TestSchema:
         r = cli('schema', 'example', '--brief', '--out', str(out_file))
         assert f'wrote {out_file}' in r.stdout
         assert out_file.read_text() == schema_file.read_text()
-        assert 'primary_key=True' in schema_file.read_text()
         cli('schema', 'example', '--out', str(out_file))
         assert out_file.read_text() == cli('schema', 'example').stdout
 
@@ -614,6 +613,7 @@ class TestSchema:
         assert all(
             construct in full
             for construct in (
+                'uuid7()',
                 'primary_key=True',
                 'pxt.Column(',
                 'pxt.EmbeddingIndex(',
@@ -635,10 +635,9 @@ class TestSchema:
         docs = pxt.get_table(f'{full_target}/docs')
         docs.insert(
             [
-                {'doc_id': 1, 'title': 'bread', 'body': 'Sourdough needs a long, slow fermentation.'},
-                {'doc_id': 2, 'title': 'sharks', 'body': 'Great white sharks hunt seals along the coast.'},
+                {'title': 'bread', 'body': 'Sourdough needs a long, slow fermentation.'},
+                {'title': 'sharks', 'body': 'Great white sharks hunt seals along the coast.'},
                 {
-                    'doc_id': 3,
                     'title': 'sharks',
                     'body': 'A simple and effective breathing exercise to reduce stress is box breathing',
                 },
@@ -646,7 +645,8 @@ class TestSchema:
         )
         # verify embeddings by running a similarity search
         sim = docs.body.similarity(string='sharks hunting seals near the shore')
-        assert docs.order_by(sim, asc=False).select(docs.doc_id).limit(1).collect()['doc_id'] == [2]
+        top = docs.order_by(sim, asc=False).select(docs.body).limit(1).collect()['body'][0]
+        assert top.startswith('Great white sharks')
 
         # the file is reachable from wherever an agent lands: the verb list, and every verb's help
         assert 'example' in cli('schema', check=False).stdout

--- a/tests/pixeltable_cli/test_service.py
+++ b/tests/pixeltable_cli/test_service.py
@@ -969,11 +969,9 @@ class TestService:
         deploy(cli, str(app_file), target)
         endpoint = assert_serving(cli, str(app_file), target, 'ingest')['ingest']['endpoint']
         # summary comes from the udf the file defines, computed in the service's own process
-        assert _post(endpoint, '/docs', doc_id=1, title='a long enough title', body=None).json() == {
-            'title_upper': 'A LONG ENOUGH TITLE',
-            'summary': 'a long enoug...',
-        }
-        # PXT-1408: scaffold declares a primary key so row lookup works on a fresh project
-        assert 'primary_key=True' in app_file.read_text()
-        out = cli('get', f'{target}/docs', '1', '--json').json
+        resp = _post(endpoint, '/docs', title='a long enough title', body=None).json()
+        assert resp['title_upper'] == 'A LONG ENOUGH TITLE'
+        assert resp['summary'] == 'a long enoug...'
+        assert resp['doc_id'] is not None
+        out = cli('get', f'{target}/docs', str(resp['doc_id']), '--json').json
         assert out['row']['title'] == 'a long enough title'

--- a/tests/pixeltable_cli/test_service.py
+++ b/tests/pixeltable_cli/test_service.py
@@ -973,3 +973,7 @@ class TestService:
             'title_upper': 'A LONG ENOUGH TITLE',
             'summary': 'a long enoug...',
         }
+        # PXT-1408: scaffold declares a primary key so row lookup works on a fresh project
+        assert 'primary_key=True' in app_file.read_text()
+        out = cli('get', f'{target}/docs', '1', '--json').json
+        assert out['row']['title'] == 'a long enough title'


### PR DESCRIPTION
## Summary
- `pxt service example` and `pxt schema example` now declare `doc_id = pxt.Column(type=pxt.Int, primary_key=True)` so `pxt get` / errors view work on a fresh project ([PXT-1408](https://pixeltable.atlassian.net/browse/PXT-1408)).
- Sync README, Quickstart, Cloud, AGENTS.md, and CLAUDE.md.
- Extend example tests to assert the PK and that `pxt get` succeeds after insert.

Related (not fixed here): PXT-1382, PXT-1051, PXT-1393, PXT-1402.

## Test plan
- [x] `pytest tests/pixeltable_cli/test_service.py::TestService::test_example`
- [x] `pytest tests/pixeltable_cli/test_schema.py::TestSchema::test_example`
- [ ] Fresh: `pxt service example --out app.py` → schema/service update → `pxt get <target>/docs 1`


Made with [Cursor](https://cursor.com)

[PXT-1408]: https://pixeltable.atlassian.net/browse/PXT-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ