### PR TITLE
[PXT-1407] Presign media that hosted compute and query routes make on the fly

### DIFF
--- a/pixeltable/serving/_fastapi.py
+++ b/pixeltable/serving/_fastapi.py
@@ -45,6 +45,7 @@ from pixeltable.config import Config
 from pixeltable.env import Env
 from pixeltable.exec.globals import INLINED_OBJECT_MD_KEY
 from pixeltable.runtime import close_threadpool_runtimes
+from pixeltable.service.proxy_protocol import PxtStorePartSink
 from pixeltable.serving import SqlExport
 from pixeltable.serving.globals import SqlExporter
 from pixeltable.utils import image as image_utils
@@ -372,12 +373,38 @@ class PxtEndpoint:
     def route_type(self) -> Literal['insert', 'update', 'delete', 'compute', 'query']:
         return self.route.spec.route_type
 
-    def __call__(self, request: Request, **kwargs: Any) -> Any:
-        sample_url = str(request.url_for(_MEDIA_ROUTE_NAME, path='_'))
-        media_url_base = sample_url[:-1]
+    def _url_for_media(self, request: Request) -> Callable[[str], str]:
+        """The function that turns a local media file of a response into a url the client can fetch.
 
-        def url_for_media(rel_path: str) -> str:
-            return f'{media_url_base}{urllib.parse.quote(rel_path, safe="/")}'
+        A local service serves the file itself, from its /media route. A service in a hosted pod has no route a
+        client can reach, so it stages the file in the database's home bucket and signs a url for the object.
+        """
+        hosted = Env.get().hosted_db()
+        if hosted is None:
+            sample_url = str(request.url_for(_MEDIA_ROUTE_NAME, path='_'))
+            media_url_base = sample_url[:-1]
+
+            def serve_locally(rel_path: str) -> str:
+                return f'{media_url_base}{urllib.parse.quote(rel_path, safe="/")}'
+
+            return serve_locally
+
+        org, db = hosted
+        home_dir = self.router._home_dir
+        # one sink per request, so its uploads share one store client; its keys fall under uploads/, which the
+        # bucket expires
+        sink = PxtStorePartSink(org, db)
+
+        def stage_in_home_bucket(rel_path: str) -> str:
+            key = sink.add_media_file(str(home_dir / rel_path))
+            sink.flush()
+            # signed for an hour, so a client has time to fetch the media after reading the response
+            return ObjectOps.presigned_url(f'pxtfs://{org}:{db}/home/{key}', expiration_seconds=3600)
+
+        return stage_in_home_bucket
+
+    def __call__(self, request: Request, **kwargs: Any) -> Any:
+        url_for_media = self._url_for_media(request)
 
         # write out uploads while the request is still alive
         tmp_paths: list[Path] = []

--- a/tests/pixeltable_cli/apps/media.py
+++ b/tests/pixeltable_cli/apps/media.py
@@ -44,6 +44,15 @@ clips.add_insert_route(
     outputs=[Clips.clip_id, Clips.poster],
 )
 
+
+# a query that makes its media on the fly: the scaled poster is not a column, so no row stores it
+@pxt.query
+def poster_thumb(clip_id: int) -> pxt.Query:
+    return Clips.where(Clips.clip_id == clip_id).select(thumb=Clips.poster.resize(size=(32, 32)))  # type: ignore[arg-type]
+
+
+clips.add_query_route(path='/poster-thumb', query=poster_thumb, one_row=True)
+
 # one image per clip, returned as the image itself rather than as JSON: a file response carries a single
 # media value, so it cannot come from a view that yields a row per frame
 clips.add_compute_route(

--- a/tests/pixeltable_cli/test_service.py
+++ b/tests/pixeltable_cli/test_service.py
@@ -163,6 +163,17 @@ def _post(endpoint: str, path: str, **body: Any) -> httpx.Response:
     return resp
 
 
+def _fetch_media(url: str, db_root: DatabaseRoot) -> bytes:
+    """The bytes behind a media url of a response: a hosted service signs a home bucket url, a local one serves the
+    file itself."""
+    if db_root.id == 'cloud':
+        return fetch_presigned(url, expires_s=3600, host_suffix='.r2.cloudflarestorage.com')
+    assert '/media/' in url, url
+    resp = httpx.get(url, timeout=_REQUEST_TIMEOUT)
+    assert resp.status_code == 200, resp.text
+    return resp.content
+
+
 def _await_job(job_url: str, timeout: float = 120.0) -> Any:
     """Poll a background job until it stops being pending, and return what it produced."""
     deadline = time.time() + timeout
@@ -518,15 +529,11 @@ class TestService:
         body = resp.json()
         assert body['clip_id'] == 1, body
         assert pxt.get_table(f'{target}/frames').count() > 0
-        # the persisted poster comes back as a URL: presigned from the home bucket for a hosted table, served by
-        # the service for a local one
-        if db_root.id == 'cloud':
-            assert_image_bytes(fetch_presigned(body['poster'], expires_s=3600, host_suffix='.r2.cloudflarestorage.com'))
-        else:
-            assert '/media/' in body['poster'], body
-            poster = httpx.get(body['poster'], timeout=_REQUEST_TIMEOUT)
-            assert poster.status_code == 200, poster.text
-            assert_image_bytes(poster.content)
+        # the persisted poster comes back as a url
+        assert_image_bytes(_fetch_media(body['poster'], db_root))
+        # so does media a query makes on the fly, which no row stores
+        thumb_url = _post(running['clips']['endpoint'], '/poster-thumb', clip_id=1).json()['thumb']
+        assert_image_bytes(_fetch_media(thumb_url, db_root), size=(32, 32))
 
         # a URL the pod can fetch, in place of a local path it cannot read
         video_url = sample_file_server.url(video, db_root)
@@ -536,13 +543,10 @@ class TestService:
         assert resp.headers['content-type'].startswith('image/'), resp.headers
         assert_image_bytes(resp.content)
 
-        # a route over the iterator view answers with a row per frame, media rendered as urls
+        # a route over the iterator view answers with a row per frame, media rendered as urls; nothing is stored
         rows = _post(running['frames']['endpoint'], '/frames', clip_id=3, video=video_url).json()
         assert len(rows) > 1, rows
-        assert all(row['thumb'].startswith('http') for row in rows), rows[0]
-        thumb = httpx.get(rows[0]['thumb'], timeout=_REQUEST_TIMEOUT)
-        assert thumb.status_code == 200, thumb.text
-        assert_image_bytes(thumb.content)
+        assert_image_bytes(_fetch_media(rows[0]['thumb'], db_root), size=(32, 32))
 
         # a background route answers with a job to poll, and the two uploads arrive in one request
         audio = get_audio_files()[0]


### PR DESCRIPTION
Compute routes on a hosted database returned /media URLs of the service itself, which a client cannot reach. The same happened to query routes whose select list transforms media inline. Insert routes were fine because the save node moves their media into the home bucket and the service presigns the resulting URI. Compute and inline query media are never stored, so they stayed as local files on the pod.

A service in a hosted pod now stages such a file in the database's home bucket under the uploads prefix, which the bucket expires after a day, and returns a presigned URL with the same one hour expiry the stored media already gets. Local services are unchanged and keep serving the file from /media.

The media test app gains a query route that scales the poster in the query, and the service test now fetches the persisted poster, the query thumb, and the compute frame thumb the same way: presigned on the cloud axis, /media locally. On the cloud axis that run passed against a chrisdev database built from this branch.